### PR TITLE
Add voucher OCR entry feature

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,8 @@
         "nodemailer": "^7.0.3",
         "passport": "^0.7.0",
         "passport-local": "^1.0.0",
-        "xlsx": "^0.18.5"
+        "xlsx": "^0.18.5",
+        "tesseract.js": "^4.0.2"
       },
       "devDependencies": {
         "nodemon": "^3.1.10"

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "nodemailer": "^7.0.3",
     "passport": "^0.7.0",
     "passport-local": "^1.0.0",
-    "xlsx": "^0.18.5"
+    "xlsx": "^0.18.5",
+    "tesseract.js": "^4.0.2"
   },
   "description": "",
   "devDependencies": {

--- a/public/main.css
+++ b/public/main.css
@@ -60,7 +60,7 @@ body {
 /* 테이블 헤더 */
 th {
   font-size: calc(12px + 0.2vw);
-  white-space: pre-wrap;
+  white-space: nowrap;
   word-break: keep-all;
 }
 th.sortable {
@@ -71,5 +71,27 @@ th.sortable {
   font-size: 0.8em;
 }
 .sort-select {
-  min-width: 70px;
+  width: auto;
+  min-width: 0;
+}
+
+/* 배너 2x2 그리드 */
+/* 관리자들이 올린 배너 이미지를 2x2 정사각형으로 배치 */
+.banner-grid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  grid-auto-rows: 1fr; /* 모든 셀 높이를 동일하게 */
+  gap: 0.5rem;
+}
+.banner-grid img {
+  width: 100%;
+  aspect-ratio: 1 / 1; /* 4등분을 위해 정사각 비율 유지 */
+  object-fit: cover;
+}
+
+/* 표 너비 자동 맞춤 */
+.auto-width {
+  /* Bootstrap의 width:100% 를 덮어쓰고 내용에 맞게 넓이를 조정 */
+  width: auto !important;
+  table-layout: auto !important;
 }

--- a/routes/ocr.js
+++ b/routes/ocr.js
@@ -1,0 +1,37 @@
+const express = require('express');
+const router = express.Router();
+const multer = require('multer');
+const fs = require('fs');
+const path = require('path');
+const { createWorker } = require('tesseract.js');
+
+// 임시 업로드 폴더 보장
+const uploadsDir = path.join(__dirname, '../uploads');
+if (!fs.existsSync(uploadsDir)) fs.mkdirSync(uploadsDir);
+const upload = multer({ dest: uploadsDir });
+
+// OCR 입력 폼
+router.get('/', (req, res) => {
+  res.render('ocr.ejs', { text: null });
+});
+
+// 이미지에서 텍스트 추출
+router.post('/', upload.single('image'), async (req, res) => {
+  if (!req.file) return res.status(400).send('이미지를 업로드해주세요.');
+  const worker = createWorker();
+  try {
+    await worker.load();
+    await worker.loadLanguage('kor+eng');
+    await worker.initialize('kor+eng');
+    const { data: { text } } = await worker.recognize(req.file.path);
+    await worker.terminate();
+    fs.unlink(req.file.path, () => {});
+    res.render('ocr.ejs', { text });
+  } catch (err) {
+    console.error('OCR error:', err);
+    fs.unlink(req.file.path, () => {});
+    res.status(500).send('텍스트 추출 실패');
+  }
+});
+
+module.exports = router;

--- a/routes/voucher.js
+++ b/routes/voucher.js
@@ -1,0 +1,71 @@
+const express = require('express');
+const router = express.Router();
+const multer = require('multer');
+const fs = require('fs');
+const path = require('path');
+const { createWorker } = require('tesseract.js');
+const connectDB = require('../database');
+let db;
+connectDB.then(client => { db = client.db('forum'); });
+
+const uploadsDir = path.join(__dirname, '../uploads');
+if (!fs.existsSync(uploadsDir)) fs.mkdirSync(uploadsDir);
+const upload = multer({ dest: uploadsDir });
+
+// 전표 목록을 조회한다. 저장된 필드 중 "매출금액"의 합계를 계산하여 화면에 전달한다.
+router.get('/', async (req, res) => {
+  const list = db ? await db.collection('vouchers').find().toArray() : [];
+  // 새로운 필드명에 맞춰 총액을 계산한다.
+  const total = list.reduce((acc, v) => acc + (v['매출금액'] || 0), 0);
+  res.render('voucher.ejs', { list, total });
+});
+
+router.post('/upload', upload.single('image'), async (req, res) => {
+  if (!req.file) return res.status(400).send('전표 이미지를 업로드해주세요.');
+  const worker = createWorker();
+  try {
+    await worker.load();
+    await worker.loadLanguage('kor+eng');
+    await worker.initialize('kor+eng');
+    const { data: { text } } = await worker.recognize(req.file.path);
+    await worker.terminate();
+    fs.unlink(req.file.path, () => {});
+    const fields = await parseVoucher(text);
+    if (fields && db) await db.collection('vouchers').insertOne(fields);
+    res.redirect('/voucher');
+  } catch (err) {
+    console.error('Voucher OCR error:', err);
+    fs.unlink(req.file.path, () => {});
+    res.status(500).send('전표 처리 실패');
+  }
+});
+
+async function parseVoucher(text) {
+  try {
+    const apiKey = process.env.OPENAI_API_KEY;
+    if (!apiKey) return null;
+    // 새롭게 정의된 필드를 GPT에게 요청한다.
+    const prompt = `다음 전표 내용에서 전표 매출일, 공급 세액, 세함가, 상품명, 품명, 출고수량, 매출단가, 매출금액을 JSON으로 반환해 주세요.\n${text}`;
+    const response = await fetch('https://api.openai.com/v1/chat/completions', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': `Bearer ${apiKey}`
+      },
+      body: JSON.stringify({
+        model: 'gpt-3.5-turbo',
+        messages: [{ role: 'user', content: prompt }],
+        max_tokens: 200
+      })
+    });
+    if (!response.ok) throw new Error('OpenAI error');
+    const json = await response.json();
+    const content = json.choices?.[0]?.message?.content || '{}';
+    return JSON.parse(content);
+  } catch (err) {
+    console.error('GPT parsing error:', err);
+    return null;
+  }
+}
+
+module.exports = router;

--- a/server.js
+++ b/server.js
@@ -298,6 +298,8 @@ app.use('/search', require('./routes/search.js'));
 app.use('/stock', require('./routes/stock.js'));
 app.use('/coupang', require('./routes/coupang.js'));
 app.use('/coupang/add', require('./routes/coupangAdd.js'));
+app.use('/voucher', require('./routes/voucher.js'));
+app.use('/ocr', require('./routes/ocr.js'));
 app.use('/help', require('./routes/help.js'));
 app.use('/', require('./routes/auth.js'));
 

--- a/views/admin/index.ejs
+++ b/views/admin/index.ejs
@@ -30,7 +30,7 @@
               <% } else { %>
                 <p class="text-muted">현재 이미지가 없습니다.</p>
               <% } %>
-              <form action="/admin/banner/<%= i %>" method="post" enctype="multipart/form-data" class="banner-form d-flex gap-2 mb-2">
+              <form action="/admin/banner/<%= i %>" method="post" enctype="multipart/form-data" class="banner-form d-flex flex-nowrap gap-2 mb-2">
                 <input type="file" name="banner" accept="image/*" class="form-control" id="bannerInput<%= i %>">
                 <button type="submit" class="btn btn-primary">업로드</button>
               </form>

--- a/views/coupang.ejs
+++ b/views/coupang.ejs
@@ -60,9 +60,10 @@
     <% } %>
 
     <div class="table-responsive">
-      <table class="table table-bordered table-hover bg-white align-middle">
+      <table class="table table-bordered table-hover bg-white align-middle auto-width">
         <thead class="table-light text-center">
           <% if (필드 && 필드.length > 0) { %>
+            <!-- 정렬용 셀렉트 박스 -->
             <tr id="sortRow">
               <th>정렬</th>
               <% 필드.forEach((key, idx) => { %>

--- a/views/dashboard.ejs
+++ b/views/dashboard.ejs
@@ -12,11 +12,10 @@
 
   <div class="container my-4">
     <% if (banners && banners.length > 0) { %>
-      <div class="row row-cols-1 row-cols-md-2 row-cols-lg-4 g-3 mb-4">
+      <!-- 대시보드 배너도 같은 2x2 형식 -->
+      <div class="banner-grid mb-4">
         <% banners.forEach(img => { %>
-          <div class="col text-center">
-            <img src="<%= img %>" class="img-fluid rounded shadow" alt="banner">
-          </div>
+          <img src="<%= img %>" alt="banner">
         <% }) %>
       </div>
     <% } %>

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -16,11 +16,10 @@
     <h1 class="mb-4 fw-bold text-center">🩲 내의미 재고관리 시스템</h1>
 
     <% if (banners && banners.length > 0) { %>
-      <div class="row row-cols-1 row-cols-md-2 row-cols-lg-4 g-3 mb-4">
+      <!-- 메인 배너는 4등분 그리드로 표시 -->
+      <div class="banner-grid mb-4">
         <% banners.forEach(img => { %>
-          <div class="col text-center">
-            <img src="<%= img %>" class="img-fluid rounded shadow" alt="banner">
-          </div>
+          <img src="<%= img %>" alt="banner">
         <% }) %>
       </div>
     <% } %>

--- a/views/nav.ejs
+++ b/views/nav.ejs
@@ -28,6 +28,9 @@
             <a class="nav-link text-dark" href="/coupang/add">💰 매출/광고비</a>
           </li>
           <li class="nav-item">
+            <a class="nav-link text-dark" href="/voucher">📝 전표입력</a>
+          </li>
+          <li class="nav-item">
             <a class="nav-link text-dark" href="/write">✍ 글작성</a>
           </li>
           <li class="nav-item">
@@ -36,6 +39,9 @@
         <% } %>
         <li class="nav-item">
           <a class="nav-link text-dark" href="/help">❓ 사용방법</a>
+        </li>
+        <li class="nav-item">
+          <a class="nav-link text-dark" href="/ocr">🖼️ OCR</a>
         </li>
       </ul>
 

--- a/views/ocr.ejs
+++ b/views/ocr.ejs
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+  <meta charset="UTF-8">
+  <title>OCR 변환</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.6/dist/css/bootstrap.min.css" rel="stylesheet">
+  <link rel="stylesheet" href="/main.css">
+</head>
+<body class="bg-light">
+  <%- include('nav.ejs') %>
+
+  <div class="container my-5">
+    <h2 class="mb-4 fw-bold">🖼️ 이미지 텍스트 추출</h2>
+    <form action="/ocr" method="POST" enctype="multipart/form-data" class="d-flex flex-wrap gap-2 mb-4">
+      <input type="file" name="image" accept="image/*" class="form-control" required>
+      <button type="submit" class="btn btn-primary">추출</button>
+    </form>
+    <% if (text) { %>
+      <h5 class="mb-3">추출된 텍스트</h5>
+      <pre class="p-3 bg-white border rounded"><%= text %></pre>
+    <% } %>
+  </div>
+
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.6/dist/js/bootstrap.bundle.min.js"></script>
+</body>
+</html>

--- a/views/stock.ejs
+++ b/views/stock.ejs
@@ -47,16 +47,17 @@
 
     <!-- 테이블 -->
     <div class="table-responsive">
-      <table class="table table-bordered table-hover bg-white align-middle">
+      <table class="table table-bordered table-hover bg-white align-middle auto-width">
         <thead class="table-light text-center">
           <% if (필드 && 필드.length > 0) { %>
+            <!-- 정렬용 셀렉트 박스 -->
             <tr id="sortRow">
               <% 필드.forEach((key, idx) => { %>
                 <th>
                   <select class="form-select form-select-sm sort-select" data-index="<%= idx %>">
                     <option value="">-</option>
-                    <option value="asc">▲</option>
-                    <option value="desc">▼</option>
+                    <option value="asc">오름차순▲</option>
+                    <option value="desc">내림차순▼</option>
                   </select>
                 </th>
               <% }) %>

--- a/views/voucher.ejs
+++ b/views/voucher.ejs
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+  <meta charset="UTF-8">
+  <title>전표 입력</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.6/dist/css/bootstrap.min.css" rel="stylesheet">
+  <link rel="stylesheet" href="/main.css">
+</head>
+<body class="bg-light">
+  <%- include('nav.ejs') %>
+  <div class="container my-5">
+    <h2 class="mb-4 fw-bold">📝 전표 입력</h2>
+    <form action="/voucher/upload" method="POST" enctype="multipart/form-data" class="d-flex flex-wrap gap-2 mb-4">
+      <input type="file" name="image" accept="image/*" class="form-control" required>
+      <button type="submit" class="btn btn-primary">업로드</button>
+    </form>
+    <% if (list && list.length > 0) { %>
+      <p class="text-muted">총 <strong><%= list.length %></strong>건, 합계: <strong><%= total.toLocaleString('ko-KR') %></strong>원</p>
+      <div class="table-responsive">
+        <table class="table table-bordered table-hover bg-white align-middle auto-width">
+          <thead class="table-light text-center">
+            <tr>
+              <th>전표 매출일</th>
+              <th>공급 세액</th>
+              <th>세함가</th>
+              <th>상품명</th>
+              <th>품명</th>
+              <th>출고수량</th>
+              <th>매출단가</th>
+              <th>매출금액</th>
+            </tr>
+          </thead>
+          <tbody>
+            <% list.forEach(row => { %>
+              <tr>
+                <td><%= row['전표 매출일'] %></td>
+                <td class="text-end"><%= Number(row['공급 세액'] || 0).toLocaleString('ko-KR') %></td>
+                <td class="text-end"><%= Number(row['세함가'] || 0).toLocaleString('ko-KR') %></td>
+                <td><%= row['상품명'] %></td>
+                <td><%= row['품명'] %></td>
+                <td class="text-end"><%= row['출고수량'] %></td>
+                <td class="text-end"><%= Number(row['매출단가'] || 0).toLocaleString('ko-KR') %></td>
+                <td class="text-end"><%= Number(row['매출금액'] || 0).toLocaleString('ko-KR') %></td>
+              </tr>
+            <% }) %>
+          </tbody>
+        </table>
+      </div>
+    <% } else { %>
+      <p class="text-muted">전표 데이터가 없습니다.</p>
+    <% } %>
+  </div>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.6/dist/js/bootstrap.bundle.min.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- implement new `/voucher` route to read invoice images
- parse voucher info with Tesseract and OpenAI API
- list uploaded vouchers and totals
- expose voucher page through the navbar
- update voucher fields to recognize 매출금액 and other data

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68427a4696188329bb1795739dbd4bb7