### PR TITLE
Refine edit page design

### DIFF
--- a/routes/admin.js
+++ b/routes/admin.js
@@ -13,7 +13,7 @@ router.get('/', checkAdmin, async (req, res) => {
   const banners = [];
   for (let i = 1; i <= 4; i++) {
     const doc = await db.collection('homepage').findOne({ key: 'banner' + i });
-    banners.push(doc?.img || '');
+    banners.push({ text: doc?.text || '', img: doc?.img || '' });
   }
   res.render('admin/index.ejs', {
     banners,
@@ -23,13 +23,22 @@ router.get('/', checkAdmin, async (req, res) => {
 
 // 배너 이미지 업로드
 router.post('/banner/:idx', checkAdmin, upload.single('banner'), async (req, res) => {
-  const imgLocation = req.file ? req.file.location : '';
   const idx = req.params.idx;
-  await db.collection('homepage').updateOne(
-    { key: 'banner' + idx },
-    { $set: { img: imgLocation, updatedAt: new Date() } },
-    { upsert: true }
-  );
+  if (idx === '1' || idx === '2') {
+    const text = req.body.text || '';
+    await db.collection('homepage').updateOne(
+      { key: 'banner' + idx },
+      { $set: { text, updatedAt: new Date() }, $unset: { img: '' } },
+      { upsert: true }
+    );
+  } else {
+    const imgLocation = req.file ? req.file.location : '';
+    await db.collection('homepage').updateOne(
+      { key: 'banner' + idx },
+      { $set: { img: imgLocation, updatedAt: new Date() }, $unset: { text: '' } },
+      { upsert: true }
+    );
+  }
   res.redirect('/admin');
 });
 

--- a/routes/coupang.js
+++ b/routes/coupang.js
@@ -24,7 +24,8 @@ const 한글 = {
   'Option name': '옵션명',
   'Orderable quantity (real-time)': '재고량',
   'Sales amount on the last 30 days': '30일 판매금액',
-  'Sales in the last 30 days': '30일 판매량'
+  'Sales in the last 30 days': '30일 판매량',
+  'Shortage quantity': '부족재고량'
 };
 const DEFAULT_COLUMNS = [
   'Option ID',
@@ -32,14 +33,30 @@ const DEFAULT_COLUMNS = [
   'Option name',
   'Orderable quantity (real-time)',
   'Sales amount on the last 30 days',
-  'Sales in the last 30 days'
+  'Sales in the last 30 days',
+  'Shortage quantity'
 ];
+
+const IMPORT_COLUMNS = DEFAULT_COLUMNS.filter(col => col !== 'Shortage quantity');
 
 const NUMERIC_COLUMNS = [
   'Orderable quantity (real-time)',
   'Sales amount on the last 30 days',
-  'Sales in the last 30 days'
+  'Sales in the last 30 days',
+  'Shortage quantity'
 ];
+
+function addShortage(items) {
+  return items.map(item => {
+    const sales30 = Number(item['Sales in the last 30 days'] || 0);
+    const inventory = Number(item['Orderable quantity (real-time)'] || 0);
+    const daily = sales30 / 30;
+    const safety = daily * 7;
+    const shortage = inventory < safety ? Math.ceil(safety - inventory) : 0;
+    item['Shortage quantity'] = shortage;
+    return item;
+  });
+}
 
 // 공통 필드 추출
 function getAllFields(resultArray) {
@@ -51,13 +68,14 @@ router.get('/', async (req, res) => {
   const keyword = '';
   try {
     const result = await db.collection('coupang').find().sort({ 'Product name': 1 }).toArray();
+    const resultWithShortage = addShortage(result);
     let selected = req.query.fields;
     if (selected && !Array.isArray(selected)) selected = selected.split(',');
     const fields = (selected && selected.length > 0)
       ? DEFAULT_COLUMNS.filter(col => selected.includes(col))
       : DEFAULT_COLUMNS;
     res.render('coupang.ejs', {
-      결과: result,
+      결과: resultWithShortage,
       필드: fields,
       전체필드: DEFAULT_COLUMNS,
       성공메시지: null,
@@ -84,14 +102,14 @@ router.post('/upload', upload.single('excelFile'), async (req, res) => {
 
     // 매핑
     const indexMap = {};
-    DEFAULT_COLUMNS.forEach(key => {
+    IMPORT_COLUMNS.forEach(key => {
       const idx = headerRow.findIndex(col => col && col.trim() === key);
       if (idx !== -1) indexMap[key] = idx;
     });
 
     const data = dataRows.map(row => {
       const obj = {};
-      for (const col of DEFAULT_COLUMNS) {
+      for (const col of IMPORT_COLUMNS) {
         let val = row[indexMap[col]] ?? '';
         if (NUMERIC_COLUMNS.includes(col)) {
           const num = Number(String(val).replace(/,/g, ''));
@@ -115,8 +133,9 @@ router.post('/upload', upload.single('excelFile'), async (req, res) => {
     fs.unlink(filePath, () => {});
 
     const resultArray = await db.collection('coupang').find().sort({ 'Product name': 1 }).toArray();
+    const resultWithShortage = addShortage(resultArray);
     res.render('coupang.ejs', {
-      결과: resultArray,
+      결과: resultWithShortage,
       필드: DEFAULT_COLUMNS,
       전체필드: DEFAULT_COLUMNS,
       성공메시지: '✅ 업로드 완료',
@@ -141,13 +160,14 @@ router.get('/search', async (req, res) => {
         { 'Option ID': regex }
       ]
     }).toArray();
+    const resultWithShortage = addShortage(result);
     let selected = req.query.fields;
     if (selected && !Array.isArray(selected)) selected = selected.split(',');
     const fields = (selected && selected.length > 0)
       ? DEFAULT_COLUMNS.filter(col => selected.includes(col))
       : DEFAULT_COLUMNS;
     res.render('coupang.ejs', {
-      결과: result,
+      결과: resultWithShortage,
       필드: fields,
       전체필드: DEFAULT_COLUMNS,
       성공메시지: null,

--- a/server.js
+++ b/server.js
@@ -78,15 +78,23 @@ app.use(async (req, res, next) => {
     const logoConfig = await db.collection('homepage').findOne({ key: 'logo' });
     res.locals.logo = logoConfig?.img || '';
     const banners = [];
+    const notices = [];
     for (let i = 1; i <= 4; i++) {
       const doc = await db.collection('homepage').findOne({ key: 'banner' + i });
-      if (doc?.img) banners.push(doc.img);
+      if (!doc) continue;
+      if (i <= 2) {
+        if (doc.text) notices.push(doc.text);
+      } else {
+        if (doc.img) banners.push(doc.img);
+      }
     }
     res.locals.banners = banners;
+    res.locals.notices = notices;
   } catch (err) {
     console.error(err);
     res.locals.logo = '';
     res.locals.banners = [];
+    res.locals.notices = [];
   }
   next();
 });
@@ -119,11 +127,11 @@ const path = require('path');
 
 app.get('/', async (req, res) => {
   // 로그인 여부와 상관없이 동일한 메인 페이지
-  res.render('index.ejs', { banners: res.locals.banners });
+  res.render('index.ejs', { banners: res.locals.banners, notices: res.locals.notices });
 });
 
 app.get('/dashboard', checkLogin, (req, res) => {
-  res.render('dashboard.ejs', { banners: res.locals.banners });
+  res.render('dashboard.ejs', { banners: res.locals.banners, notices: res.locals.notices });
 });
 
 app.get('/news', (요청, 응답) => {

--- a/views/admin/index.ejs
+++ b/views/admin/index.ejs
@@ -22,22 +22,35 @@
       <div class="col-md-9">
         <div id="bannerSection" class="admin-section">
           <h1 class="mb-3">배너 이미지 관리</h1>
-          <% for (let i = 1; i <= 4; i++) { const img = banners[i-1]; %>
+          <% for (let i = 1; i <= 4; i++) { const data = banners[i-1]; %>
             <div class="mb-4">
               <h5 class="mb-2">배너 <%= i %></h5>
-              <% if (img) { %>
-                <img src="<%= img %>" class="img-fluid mb-2" alt="banner <%= i %>">
-              <% } else { %>
-                <p class="text-muted">현재 이미지가 없습니다.</p>
-              <% } %>
-              <form action="/admin/banner/<%= i %>" method="post" enctype="multipart/form-data" class="banner-form d-flex flex-nowrap gap-2 mb-2">
-                <input type="file" name="banner" accept="image/*" class="form-control" id="bannerInput<%= i %>">
-                <button type="submit" class="btn btn-primary">업로드</button>
-              </form>
-              <% if (img) { %>
-                <form action="/admin/banner/<%= i %>/delete" method="post" onsubmit="return confirm('배너를 삭제하시겠습니까?')" class="d-inline">
-                  <button type="submit" class="btn btn-danger btn-sm">삭제</button>
+              <% if (i <= 2) { %>
+                <form action="/admin/banner/<%= i %>" method="post" class="banner-text-form d-flex flex-nowrap gap-2 mb-2">
+                  <input type="text" name="text" class="form-control" value="<%= data.text %>" placeholder="공지 내용을 입력하세요">
+                  <button type="submit" class="btn btn-primary">저장</button>
                 </form>
+                <% if (data.text) { %>
+                  <form action="/admin/banner/<%= i %>/delete" method="post" onsubmit="return confirm('삭제하시겠습니까?')" class="d-inline">
+                    <button type="submit" class="btn btn-danger btn-sm">삭제</button>
+                  </form>
+                <% } %>
+              <% } else { %>
+                <% const img = data.img; %>
+                <% if (img) { %>
+                  <img src="<%= img %>" class="img-fluid mb-2" alt="banner <%= i %>">
+                <% } else { %>
+                  <p class="text-muted">현재 이미지가 없습니다.</p>
+                <% } %>
+                <form action="/admin/banner/<%= i %>" method="post" enctype="multipart/form-data" class="banner-img-form d-flex flex-nowrap gap-2 mb-2">
+                  <input type="file" name="banner" accept="image/*" class="form-control" id="bannerInput<%= i %>">
+                  <button type="submit" class="btn btn-primary">업로드</button>
+                </form>
+                <% if (img) { %>
+                  <form action="/admin/banner/<%= i %>/delete" method="post" onsubmit="return confirm('배너를 삭제하시겠습니까?')" class="d-inline">
+                    <button type="submit" class="btn btn-danger btn-sm">삭제</button>
+                  </form>
+                <% } %>
               <% } %>
             </div>
           <% } %>
@@ -76,7 +89,7 @@
         });
       });
 
-      document.querySelectorAll('.banner-form').forEach(form => {
+      document.querySelectorAll('.banner-img-form').forEach(form => {
         form.addEventListener('submit', function (e) {
           const input = form.querySelector('input[type="file"]');
           if (!input.files || input.files.length === 0) {

--- a/views/dashboard.ejs
+++ b/views/dashboard.ejs
@@ -11,6 +11,14 @@
   <%- include('nav.ejs') %>
 
   <div class="container my-4">
+    <% if (notices && notices.length > 0) { %>
+      <div class="alert alert-info mb-4">
+        <% notices.forEach(text => { %>
+          <div><%= text %></div>
+        <% }) %>
+      </div>
+    <% } %>
+
     <% if (banners && banners.length > 0) { %>
       <!-- 대시보드 배너도 같은 2x2 형식 -->
       <div class="banner-grid mb-4">

--- a/views/edit.ejs
+++ b/views/edit.ejs
@@ -1,25 +1,34 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="ko">
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Document</title>
+  <title>글 수정</title>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.6/dist/css/bootstrap.min.css" rel="stylesheet">
   <link rel="stylesheet" href="/main.css">
 </head>
-<body class="grey-bg">
+<body class="bg-light">
 
   <%- include('nav.ejs') %>
 
+  <div class="container py-5">
+    <div class="mx-auto p-4 bg-white shadow-sm rounded" style="max-width: 600px;">
+      <h4 class="mb-4 text-center fw-bold">✏️ 글 수정</h4>
+      <form action="/edit?_method=PUT" method="POST">
+        <input type="hidden" name="id" value="<%= result._id %>">
+        <div class="mb-3">
+          <label for="title" class="form-label">제목</label>
+          <input type="text" class="form-control" id="title" name="title" value="<%= result.title %>" required>
+        </div>
+        <div class="mb-3">
+          <label for="content" class="form-label">내용</label>
+          <textarea class="form-control" id="content" name="content" rows="4" required><%= result.content %></textarea>
+        </div>
+        <button type="submit" class="btn btn-primary w-100">수정하기</button>
+      </form>
+    </div>
+  </div>
 
-  <form class="form-box" action="/edit?_method=PUT" method="POST">
-    <h4>수정하기</h4>
-    <input type="hidden" name="id" value="<%= result._id %>">
-    <input name="title" value="<%= result.title %>">
-    <input name="content" value="<%= result.content %>">
-    <button type="submit">수정</button>
- </form>
-
-
-
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.6/dist/js/bootstrap.bundle.min.js"></script>
 </body>
 </html>

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -14,6 +14,13 @@
 
   <div class="container py-5">
     <h1 class="mb-4 fw-bold text-center">🩲 내의미 재고관리 시스템</h1>
+    <% if (notices && notices.length > 0) { %>
+      <div class="alert alert-info mb-4">
+        <% notices.forEach(text => { %>
+          <div><%= text %></div>
+        <% }) %>
+      </div>
+    <% } %>
 
     <% if (banners && banners.length > 0) { %>
       <!-- 메인 배너는 4등분 그리드로 표시 -->


### PR DESCRIPTION
## Summary
- restyle the edit page for a cleaner look using Bootstrap
- add shortage stock calculation and display for Coupang inventory
- add admin fields for text notices instead of first two banner uploads

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6842c917f43c83299610b12ed131aaa4