### PR TITLE
Fix board navigation and update admin settings

### DIFF
--- a/routes/admin.js
+++ b/routes/admin.js
@@ -57,7 +57,7 @@ router.post('/logo/delete', checkAdmin, async (req, res) => {
 });
 
 // ===== 뷰 접근 권한 설정 =====
-const managedViews = ['/stock', '/coupang', '/list', '/write'];
+const managedViews = ['/stock', '/coupang', '/list', '/write', '/list/write'];
 
 router.get('/permissions', checkAdmin, async (req, res) => {
   const docs = await db.collection('permissions').find().toArray();

--- a/views/detail.ejs
+++ b/views/detail.ejs
@@ -17,8 +17,8 @@
         <h4 class="card-title fw-bold mb-3">
           <%= 게시물.title %>
           <% if (유저 && String(유저._id) === String(게시물.user)) { %>
-            <a href="/edit/<%= 게시물._id %>" class="ms-2 text-warning">✏️</a>
-            <span class="text-danger delete" data-id="<%= 게시물._id %>">🗑</span>
+            <a href="/edit/<%= 게시물._id %>" class="ms-2 text-warning text-decoration-none">수정</a>
+            <a href="#" class="text-danger delete text-decoration-none" data-id="<%= 게시물._id %>">삭제</a>
           <% } %>
         </h4>
         <p class="card-text mb-4"><%= 게시물.content %></p>

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -13,7 +13,12 @@
   <%- include('nav.ejs') %>
 
   <div class="container py-5">
-    <h1 class="mb-4 fw-bold text-center">🩲 내의미 재고관리 시스템</h1>
+    <div class="mb-4 text-center">
+      <% if (logo) { %>
+        <img src="<%= logo %>" alt="logo" class="brand-logo me-2 align-middle">
+      <% } %>
+      <span class="h1 fw-bold align-middle">내의미 재고관리 시스템</span>
+    </div>
 
     <% if (banners && banners.length > 0) { %>
       <!-- 메인 배너는 4등분 그리드로 표시 -->

--- a/views/list.ejs
+++ b/views/list.ejs
@@ -23,7 +23,7 @@
 
   <!-- 글쓰기 버튼 -->
   <div class="container mb-3 text-end">
-    <a href="/list/write" class="btn btn-primary">글 작성</a>
+    <a href="/write" class="btn btn-primary">글 작성</a>
   </div>
 
 
@@ -36,8 +36,8 @@
           <h5 class="card-title mb-2">
             <a href="/detail/<%= item._id %>" class="text-decoration-none"><%= item.title %></a>
             <% if (유저 && String(유저._id) === String(item.user)) { %>
-              <a href="/edit/<%= item._id %>" class="ms-2 text-warning">✏️</a>
-              <span class="text-danger delete" data-id="<%= item._id %>">🗑</span>
+              <a href="/edit/<%= item._id %>" class="ms-2 text-warning text-decoration-none">수정</a>
+              <a href="#" class="text-danger delete text-decoration-none" data-id="<%= item._id %>">삭제</a>
             <% } %>
           </h5>
           <p class="card-text text-muted mb-0"><%= item.content %></p>


### PR DESCRIPTION
## Summary
- fix new post button so it navigates properly
- replace edit/delete icons with text links on list and detail pages
- show brand logo with main title on home page
- include `/list/write` in admin permission settings

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684545d0de008329878d91969a0e93dc