### PR TITLE
Fix env loading issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,8 @@ This project requires several environment variables to run:
   credentials must allow bucket creation).
 
 Create a `.env` file in the project root and define these values before starting
-the server.
+the server. Make sure the file is saved as **UTF-8 without BOM** so that
+`dotenv` can read it correctly.
 
 
 ## Python scripts

--- a/server.js
+++ b/server.js
@@ -1,4 +1,9 @@
 require('dotenv').config();
+
+if (!process.env.DB_URL) {
+  console.error('Missing DB_URL environment variable. Ensure your .env file is saved in UTF-8 without BOM.');
+  process.exit(1);
+}
 const express = require('express')
 const app = express()
 const { MongoClient, ObjectId } = require('mongodb')


### PR DESCRIPTION
## Summary
- ensure `DB_URL` env var is defined
- document that `.env` must be saved in UTF‑8

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684795dba2ec8329ad2ae22838a80b32