### PR TITLE
Fix upload variable redeclaration

### DIFF
--- a/server.js
+++ b/server.js
@@ -112,9 +112,9 @@ app.use(async (req, res, next) => {
 /**
  * 엘셀 업로드 → Python 변환 → MongoDB 저장
  */
-const upload = multer({ dest: 'uploads/' });
+const localUpload = multer({ dest: 'uploads/' });
 
-app.post('/stock/upload', upload.single('file'), async (req, res) => {
+app.post('/stock/upload', localUpload.single('file'), async (req, res) => {
   try {
     if (!req.file) {
       return res.status(400).json({ error: 'file not found' });


### PR DESCRIPTION
## Summary
- avoid redeclaring `upload` in `server.js`
- keep S3 upload middleware working
- use new `localUpload` for Excel file handling

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684798870e748329b122f73e53cc0380