### PR TITLE
Add last uploader info to stock page

### DIFF
--- a/views/stock.ejs
+++ b/views/stock.ejs
@@ -25,11 +25,11 @@
 
   <div class="container my-5">
     <h2 class="mb-4 fw-bold">📦 재고 관리</h2>
-    <% if (결과 && 결과.length > 0 && 결과[0].createdAt) { %>
+    <% if (latestInfo && latestInfo.createdAt) { %>
       <div class="text-end text-muted small mb-3">
-        🕒 최근 업로드: 
-        <%= new Date(결과[0].createdAt).toLocaleString('ko-KR') %> 
-        (<%= 결과[0].uploadedBy || '알 수 없음' %>)
+        🕒 최근 업로드:
+        <%= new Date(latestInfo.createdAt).toLocaleString('ko-KR') %>
+        (<%= latestInfo.uploadedBy || '알 수 없음' %>)
       </div>
     <% } %>
     
@@ -54,6 +54,13 @@
         <button type="submit" class="btn btn-danger btn-reset">데이터 초기화</button>
       </form>
     </div>
+    <% if (latestInfo && latestInfo.createdAt) { %>
+      <div class="text-end text-muted small mb-3">
+        📝 마지막 업로드:
+        <%= new Date(latestInfo.createdAt).toLocaleString('ko-KR') %>
+        (<%= latestInfo.uploadedBy || '알 수 없음' %>)
+      </div>
+    <% } %>
 
     <!-- 검색 -->
     <form action="/stock/search" method="GET" class="input-group mb-4">


### PR DESCRIPTION
## Summary
- show latest upload timestamp and user when viewing stock
- update stock upload route to record last upload info
- display last upload info under the upload form

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684bba9334688329bbf7a736330105ed