### PR TITLE
Fix admin image management

### DIFF
--- a/routes/admin.js
+++ b/routes/admin.js
@@ -1,40 +1,86 @@
-const express = require("express");
+const express = require('express');
 const router = express.Router();
-const multer = require("multer");
-const path = require("path");
+const upload = require('../upload.js');
+const { checkAdmin } = require('../middlewares/auth');
 
 // ─────────────────────────────────────────
-// 1) Multer 설정
+// 관리자 메인 페이지
 // ─────────────────────────────────────────
-const storage = multer.diskStorage({
-  destination: (req, file, cb) => cb(null, "uploads/"),
-  filename: (req, file, cb) =>
-    cb(null, `banner_${Date.now()}${path.extname(file.originalname)}`),
-});
-const upload = multer({ storage });
-
-// ─────────────────────────────────────────
-// 2) 배너 업로드 라우트
-// ─────────────────────────────────────────
-router.post("/banner/:idx", upload.single("banner"), async (req, res) => {
+router.get('/', checkAdmin, async (req, res) => {
   try {
-    const db = req.app.locals.db; // 서버에서 저장한 DB 인스턴스 사용
-    const idx = req.params.idx;
-    const imgLocation = req.file ? req.file.path : "";
-
-    await db.collection("banners").updateOne(
-      { idx },
-      { $set: { img: imgLocation } },
-      { upsert: true }
-    );
-
-    res.redirect("/admin/banners");
+    const db = req.app.locals.db;
+    const logoDoc = await db.collection('homepage').findOne({ key: 'logo' });
+    const banners = [];
+    for (let i = 1; i <= 4; i++) {
+      const doc = await db.collection('homepage').findOne({ key: 'banner' + i });
+      banners.push(doc?.img || '');
+    }
+    res.render('admin/index.ejs', { banners, logo: logoDoc?.img || '' });
   } catch (err) {
-    console.error("❌ 배너 업로드 실패:", err);
-    res.status(500).send("서버 오류");
+    console.error('❌ 관리자 페이지 오류:', err);
+    res.status(500).send('서버 오류');
   }
 });
 
-// 필요에 따라 추가 라우트...
+// ─────────────────────────────────────────
+// 배너 업로드 및 삭제
+// ─────────────────────────────────────────
+router.post('/banner/:idx', checkAdmin, upload.single('banner'), async (req, res) => {
+  try {
+    const db = req.app.locals.db;
+    const idx = req.params.idx;
+    const imgLocation = req.file ? req.file.location || req.file.path : '';
+    await db.collection('homepage').updateOne(
+      { key: 'banner' + idx },
+      { $set: { img: imgLocation, updatedAt: new Date() } },
+      { upsert: true }
+    );
+    res.redirect('/admin');
+  } catch (err) {
+    console.error('❌ 배너 업로드 실패:', err);
+    res.status(500).send('서버 오류');
+  }
+});
+
+router.post('/banner/:idx/delete', checkAdmin, async (req, res) => {
+  try {
+    const db = req.app.locals.db;
+    await db.collection('homepage').deleteOne({ key: 'banner' + req.params.idx });
+    res.redirect('/admin');
+  } catch (err) {
+    console.error('❌ 배너 삭제 실패:', err);
+    res.status(500).send('서버 오류');
+  }
+});
+
+// ─────────────────────────────────────────
+// 로고 업로드 및 삭제
+// ─────────────────────────────────────────
+router.post('/logo', checkAdmin, upload.single('logo'), async (req, res) => {
+  try {
+    const db = req.app.locals.db;
+    const imgLocation = req.file ? req.file.location || req.file.path : '';
+    await db.collection('homepage').updateOne(
+      { key: 'logo' },
+      { $set: { img: imgLocation, updatedAt: new Date() } },
+      { upsert: true }
+    );
+    res.redirect('/admin');
+  } catch (err) {
+    console.error('❌ 로고 업로드 실패:', err);
+    res.status(500).send('서버 오류');
+  }
+});
+
+router.post('/logo/delete', checkAdmin, async (req, res) => {
+  try {
+    const db = req.app.locals.db;
+    await db.collection('homepage').deleteOne({ key: 'logo' });
+    res.redirect('/admin');
+  } catch (err) {
+    console.error('❌ 로고 삭제 실패:', err);
+    res.status(500).send('서버 오류');
+  }
+});
 
 module.exports = router;


### PR DESCRIPTION
## Summary
- fetch logo and banner data from MongoDB for every request
- show banners on dashboard
- restore admin routes for logo/banner upload and deletion

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6851319d5fbc8329966d3c48b6ac6dd1