### PR TITLE
Add example env file and mention in docs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,7 @@
+MONGO_URI=mongodb://127.0.0.1:27017
+DB_NAME=forum
+SESSION_SECRET=changeme
+S3_KEY=your-s3-key
+S3_SECRET=your-s3-secret
+S3_REGION=your-s3-region
+S3_BUCKET_NAME=your-bucket

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # --- Secrets / Credentials ---
 .env
 .env.*
+!.env.example
 *.pem
 *.key
 *.crt

--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 This project requires several environment variables to run:
 
 - `MONGO_URI` – MongoDB connection string
+- `DB_NAME` – MongoDB database name used by the application
+- `SESSION_SECRET` – Secret string used to sign session cookies
 - `S3_KEY` – AWS S3 access key
 - `S3_SECRET` – AWS S3 secret key
 - `S3_REGION` – AWS S3 region where the bucket resides
@@ -10,9 +12,7 @@ This project requires several environment variables to run:
   automatically create this bucket if it does not exist (your AWS credentials
   must allow bucket creation).
 
-Create a `.env` file in the project root and define these values before starting
-the server. Make sure the file is saved as **UTF-8 without BOM** so that
-`dotenv` can read it correctly.
+Copy `.env.example` to `.env` in the project root and define these values before starting the server. Make sure the file is saved as **UTF-8 without BOM** so that `dotenv` can read it correctly.
 
 ## Python scripts
 


### PR DESCRIPTION
## Summary
- add `.env.example` file with required environment variables
- allow `.env.example` in gitignore
- document copying this sample file in README

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685215bdaa10832989bf90a5e058bbaa