### PR TITLE
Fix stock delete-all button

### DIFF
--- a/public/js/stock.js
+++ b/public/js/stock.js
@@ -21,7 +21,10 @@ $(document).ready(function () {
   // 전체 삭제
   $("#btnDeleteAll").on("click", function () {
     if (confirm("정말 전체 삭제하시겠습니까?")) {
-      $.post("/stock/delete-all")
+      $.ajax({
+        url: "/api/stock",
+        type: "DELETE",
+      })
         .done(() => location.reload())
         .fail((xhr) => alert(xhr.responseText));
     }


### PR DESCRIPTION
## Summary
- delete all stock items with DELETE /api/stock
- remove obsolete POST /stock/delete-all

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: cannot find ESLint module)*

------
https://chatgpt.com/codex/tasks/task_e_685215b8f668832996fbb609dfe4f613