### PR TITLE
Fix session store fallback to match connectDB defaults

### DIFF
--- a/server.js
+++ b/server.js
@@ -53,8 +53,9 @@ async function initApp() {
       resave: false,
       saveUninitialized: false,
       store: MongoStore.create({
-        mongoUrl: process.env.MONGO_URI,
-        dbName: process.env.DB_NAME,
+        mongoUrl:
+          process.env.MONGO_URI || "mongodb://localhost:27017/testdb",
+        dbName: process.env.DB_NAME || "testdb",
         collectionName: "sessions",
         ttl: 60 * 60,
       }),


### PR DESCRIPTION
## Summary
- update `MongoStore.create` options to mirror `connectDB()` defaults

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68521eafe57c8329991bba437de4ffc1