### PR TITLE
Fix coupang/add routing order

### DIFF
--- a/routes/wep/index.js
+++ b/routes/wep/index.js
@@ -5,8 +5,8 @@ router.use("/stock", require("../stock"));
 router.use("/", require("../auth"));
 router.use("/admin", require("../admin"));
 router.use("/board", require("../board"));
-router.use("/coupang", require("../coupang"));
 router.use("/coupang/add", require("../coupangAdd"));
+router.use("/coupang", require("../coupang"));
 router.use("/help", require("../help"));
 router.use("/list", require("../list")); // ← 추가
 router.use("/post", require("../post"));


### PR DESCRIPTION
## Summary
- ensure `/coupang/add` router is registered before `/coupang`

## Testing
- `npm test` *(fails: `jest: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6852200459e4832982b52f4ee395de59