### PR TITLE
Add stock delete AJAX and tests

### DIFF
--- a/jest.setup.js
+++ b/jest.setup.js
@@ -3,9 +3,25 @@
 // 1) config/db.js 모킹
 // ─────────────────────────────────────────────
 jest.mock("./config/db", () => {
-  const mockClient = { db: () => ({}) };
-  const mockConnect = jest.fn().mockResolvedValue(mockClient);
-  mockConnect.then = (fn) => fn(mockClient); // connectDB.then(...) 호환
+  const mockCollection = {
+    findOne: jest.fn().mockResolvedValue(null),
+    find: jest.fn().mockReturnValue({
+      sort: jest.fn().mockReturnThis(),
+      skip: jest.fn().mockReturnThis(),
+      limit: jest.fn().mockReturnThis(),
+      toArray: jest.fn().mockResolvedValue([]),
+    }),
+    deleteMany: jest.fn().mockResolvedValue({ deletedCount: 0 }),
+    updateMany: jest.fn().mockResolvedValue({}),
+    countDocuments: jest.fn().mockResolvedValue(0),
+  };
+
+  const mockDb = {
+    collection: jest.fn(() => mockCollection),
+  };
+
+  const mockConnect = jest.fn().mockResolvedValue(mockDb);
+  mockConnect.then = (fn) => fn(mockDb); // connectDB.then(...) 호환
   return {
     connectDB: mockConnect,
     closeDB: jest.fn().mockResolvedValue(),

--- a/public/js/stock.js
+++ b/public/js/stock.js
@@ -37,7 +37,7 @@ $(document).ready(function () {
   // 전체 삭제
   $("#btnDeleteAll").on("click", function () {
     if (confirm("정말 전체 삭제하시겠습니까?")) {
-      $.post("/stock/delete-all")
+      $.ajax({ url: "/api/stock", type: "DELETE" })
         .done(() => location.reload())
         .fail((xhr) => alert(xhr.responseText));
     }

--- a/tests/stockApi.test.js
+++ b/tests/stockApi.test.js
@@ -1,0 +1,33 @@
+const request = require("supertest");
+const { initApp } = require("../server");
+const { closeDB, connectDB } = require("../config/db");
+
+jest.setTimeout(60000);
+
+let app;
+
+beforeAll(async () => {
+  process.env.NODE_ENV = "test";
+  process.env.MONGO_URI = "mongodb://127.0.0.1:27017/testdb";
+  process.env.DB_NAME = "testdb";
+  process.env.SESSION_SECRET = "testsecret";
+
+  app = await initApp();
+});
+
+afterAll(async () => {
+  await closeDB();
+});
+
+describe("DELETE /api/stock", () => {
+  it("should delete all stock data", async () => {
+    const res = await request(app).delete("/api/stock");
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toEqual({ message: "삭제 완료" });
+
+    const db = connectDB.mock.results[0].value;
+    const mockCollection = db.collection.mock.results[0].value;
+    expect(db.collection).toHaveBeenCalledWith("stock");
+    expect(mockCollection.deleteMany).toHaveBeenCalledWith({});
+  });
+});


### PR DESCRIPTION
## Summary
- mock MongoDB in tests with collection helper functions
- send DELETE request from the stock page to `/api/stock`
- add tests covering `DELETE /api/stock`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685223c61a4883298f389746f3488f27