### PR TITLE
Add stock upload API and tests

### DIFF
--- a/controllers/stockController.js
+++ b/controllers/stockController.js
@@ -131,3 +131,80 @@ exports.uploadExcel = asyncHandler(async (req, res) => {
     }
   }, 60000);
 });
+
+// Excel upload API (JSON response)
+exports.uploadExcelApi = asyncHandler(async (req, res) => {
+  console.log("✅ POST /api/stock/upload controller");
+
+  if (!req.file) {
+    console.log("❌ 파일이 업로드되지 않았습니다.");
+    return res.status(400).json({ status: "error", message: "파일이 없습니다." });
+  }
+
+  const filePath = path.resolve(req.file.path);
+  const dbName = process.env.DB_NAME || "forum";
+  const collectionName = "stock";
+  const PY_SCRIPT = path.join(__dirname, "../scripts/excel_to_mongo.py");
+
+  const python = spawn(
+    "python",
+    ["-u", PY_SCRIPT, filePath, dbName, collectionName],
+    {
+      shell: true,
+      env: {
+        ...process.env,
+        PYTHONIOENCODING: "utf-8",
+        MONGO_URI: process.env.MONGO_URI,
+      },
+    }
+  );
+
+  python.stdout.on("data", (data) =>
+    console.log(`📤 Python STDOUT: ${data.toString()}`)
+  );
+  python.stderr.on("data", (data) =>
+    console.error(`⚠️ Python STDERR: ${data.toString()}`)
+  );
+
+  python.on("error", (err) => {
+    console.error("🚨 Python 실행 실패:", err);
+    if (!res.headersSent) res.status(500).json({ status: "error", message: "Python 실행 실패" });
+  });
+
+  python.on("close", async (code) => {
+    console.log(`📦 Python 프로세스 종료 코드: ${code}`);
+    if (res.headersSent) return;
+
+    if (code === 0) {
+      try {
+        const db = req.app.locals.db;
+        if (db) {
+          await db.collection(collectionName).updateMany(
+            {},
+            {
+              $set: {
+                createdAt: new Date(),
+                uploadedBy: req.user ? req.user.username : "알 수 없음",
+              },
+            }
+          );
+        }
+        res.json({ status: "success" });
+      } catch (err) {
+        console.error("❌ 업로드 후 처리 실패:", err);
+        res.status(500).json({ status: "error", message: "업로드 후 처리 실패" });
+      }
+    } else {
+      res.status(500).json({ status: "error", message: "엑셀 처리 중 오류 발생" });
+    }
+  });
+
+  // 60초 타임아웃
+  setTimeout(() => {
+    if (!python.killed) {
+      python.kill("SIGTERM");
+      console.error("⏱️ Python 실행 시간 초과로 종료");
+      if (!res.headersSent) res.status(500).json({ status: "error", message: "Python 실행 시간 초과" });
+    }
+  }, 60000);
+});

--- a/routes/api/stockApi.js
+++ b/routes/api/stockApi.js
@@ -4,7 +4,7 @@ const router = express.Router();
 const stockCtrl = require("../../controllers/stockController");
 
 router.get("/", stockCtrl.getStockData);
-router.post("/upload", stockCtrl.upload, stockCtrl.uploadExcel);
+router.post("/upload", stockCtrl.upload, stockCtrl.uploadExcelApi);
 router.delete("/", async (req, res) => {
   const db = req.app.locals.db;
   await db.collection("stock").deleteMany({});

--- a/tests/fixtures/dummy.xlsx
+++ b/tests/fixtures/dummy.xlsx
@@ -1,0 +1,1 @@
+dummy excel content

--- a/tests/stockApi.test.js
+++ b/tests/stockApi.test.js
@@ -1,0 +1,61 @@
+jest.setTimeout(60000);
+
+// Mock DB connection
+const mockCollection = { updateMany: jest.fn().mockResolvedValue() };
+jest.mock("../config/db", () => {
+  const mockDb = { collection: jest.fn(() => mockCollection) };
+  const mockClient = { db: () => mockDb };
+  const mockConnect = jest.fn().mockResolvedValue(mockClient);
+  mockConnect.then = (fn) => fn(mockClient);
+  return { connectDB: mockConnect, closeDB: jest.fn().mockResolvedValue() };
+});
+
+// Use real multer for file parsing
+jest.mock("multer", () => jest.requireActual("multer"));
+
+// Mock child_process.spawn to avoid running Python
+jest.mock("child_process", () => {
+  const EventEmitter = require("events");
+  return {
+    spawn: jest.fn(() => {
+      const proc = new EventEmitter();
+      proc.stdout = new EventEmitter();
+      proc.stderr = new EventEmitter();
+      proc.kill = jest.fn();
+      proc.killed = false;
+      process.nextTick(() => proc.emit("close", 0));
+      return proc;
+    }),
+  };
+});
+
+const request = require("supertest");
+const path = require("path");
+const { initApp } = require("../server");
+const { closeDB } = require("../config/db");
+
+let app;
+
+beforeAll(async () => {
+  process.env.NODE_ENV = "test";
+  process.env.MONGO_URI = "mongodb://127.0.0.1:27017/testdb";
+  process.env.DB_NAME = "testdb";
+  process.env.SESSION_SECRET = "testsecret";
+
+  app = await initApp();
+});
+
+afterAll(async () => {
+  await closeDB();
+});
+
+describe("POST /api/stock/upload", () => {
+  it("should respond with success", async () => {
+    const res = await request(app)
+      .post("/api/stock/upload")
+      .attach("excelFile", path.join(__dirname, "fixtures", "dummy.xlsx"));
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toEqual({ status: "success" });
+  });
+});


### PR DESCRIPTION
## Summary
- add JSON-based uploadExcelApi controller
- wire new controller in routes/api/stockApi.js
- provide sample Excel file fixture
- add Jest test for `/api/stock/upload`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685223c50e6c83298e854abeeb0cf909