### PR TITLE
Fix db mocking in tests

### DIFF
--- a/tests/health.test.js
+++ b/tests/health.test.js
@@ -8,9 +8,9 @@ jest.setTimeout(60000);
 // config/db.js 모킹 (절대 경로로 한 번만)
 // ─────────────────────────────────────────────
 jest.mock("../config/db", () => {
-  const mockClient = { db: () => ({}) };
-  const mockConnect = jest.fn().mockResolvedValue(mockClient);
-  mockConnect.then = (fn) => fn(mockClient); // connectDB.then(...) 호환
+  const mockDb = { collection: jest.fn() };
+  const mockConnect = jest.fn().mockResolvedValue(mockDb);
+  mockConnect.then = (fn) => fn(mockDb); // connectDB.then(...) 호환
   return {
     connectDB: mockConnect,
     closeDB: jest.fn().mockResolvedValue(),

--- a/tests/stockApi.test.js
+++ b/tests/stockApi.test.js
@@ -4,9 +4,8 @@ jest.setTimeout(60000);
 const mockCollection = { updateMany: jest.fn().mockResolvedValue() };
 jest.mock("../config/db", () => {
   const mockDb = { collection: jest.fn(() => mockCollection) };
-  const mockClient = { db: () => mockDb };
-  const mockConnect = jest.fn().mockResolvedValue(mockClient);
-  mockConnect.then = (fn) => fn(mockClient);
+  const mockConnect = jest.fn().mockResolvedValue(mockDb);
+  mockConnect.then = (fn) => fn(mockDb);
   return { connectDB: mockConnect, closeDB: jest.fn().mockResolvedValue() };
 });
 


### PR DESCRIPTION
## Summary
- correct mocked DB return value so express can access collection()

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852278eef008329a8bbbb5a1b3572fd