### PR TITLE
Update stock page layout and defaults

### DIFF
--- a/public/js/stock.js
+++ b/public/js/stock.js
@@ -5,6 +5,9 @@ $(document).ready(function () {
     paging: true,
     searching: false,
     info: false,
+    pageLength: 50,
+    lengthChange: false,
+    columnDefs: [{ targets: '_all', className: 'text-center' }],
     ajax: {
       url: "/api/stock",
       dataSrc: "data",
@@ -34,14 +37,6 @@ $(document).ready(function () {
     table.ajax.url("/api/stock").load();
   });
 
-  // 전체 삭제
-  $("#btnDeleteAll").on("click", function () {
-    if (confirm("정말 전체 삭제하시겠습니까?")) {
-      $.post("/stock/delete-all")
-        .done(() => location.reload())
-        .fail((xhr) => alert(xhr.responseText));
-    }
-  });
 
   // 엑셀 업로드
   $("#uploadForm").on("submit", function (e) {
@@ -64,10 +59,4 @@ $(document).ready(function () {
     });
   });
 
-  // ─────────────────────────────────────────
-  // ARIA 경고 제거: 모달이 열릴 때 aria-hidden 삭제
-  // ─────────────────────────────────────────
-  $('#uploadModal').on('shown.bs.modal', function () {
-    $(this).removeAttr('aria-hidden');
-  });
 });

--- a/views/stock.ejs
+++ b/views/stock.ejs
@@ -6,6 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.6/dist/css/bootstrap.min.css" rel="stylesheet">
   <link rel="stylesheet" href="/main.css">
+  <link rel="stylesheet" href="https://cdn.datatables.net/1.13.6/css/dataTables.bootstrap5.min.css">
 </head>
 <body class="bg-light">
   <%- include('nav.ejs') %>
@@ -13,27 +14,32 @@
   <div class="container my-5">
     <h2 class="fw-bold mb-4">📦 재고 관리</h2>
 
-    <!-- 검색·버튼 -->
-    <div class="row g-2 mb-3">
-      <div class="col-sm-6 col-md-4">
+    <!-- 업로드/삭제 -->
+    <div class="action-form mb-4">
+      <form id="uploadForm" class="d-flex gap-2 flex-nowrap" enctype="multipart/form-data">
+        <input type="file" name="excelFile" accept=".xlsx,.xls" class="form-control" required>
+        <button type="submit" class="btn btn-success btn-upload">엑셀 업로드</button>
+      </form>
+      <form action="/stock/delete-all" method="POST" onsubmit="return confirm('정말 모든 데이터를 삭제하시겠습니까?')">
+        <button type="submit" class="btn btn-danger btn-reset">데이터 초기화</button>
+      </form>
+    </div>
+
+    <!-- 검색 -->
+    <div class="row row-cols-auto g-2 mb-4">
+      <div class="col flex-grow-1">
         <input id="keyword" class="form-control" placeholder="상품명 또는 상품코드" />
       </div>
-      <div class="col-auto d-grid">
+      <div class="col">
         <button id="btnSearch" class="btn btn-outline-primary">검색</button>
       </div>
-      <div class="col-auto d-grid">
+      <div class="col">
         <button id="btnRefresh" class="btn btn-secondary">새로고침</button>
-      </div>
-      <div class="col-auto d-grid">
-        <button class="btn btn-success" data-bs-toggle="modal" data-bs-target="#uploadModal">엑셀 업로드</button>
-      </div>
-      <div class="col-auto d-grid">
-        <button id="btnDeleteAll" class="btn btn-danger">전체 삭제</button>
       </div>
     </div>
 
     <!-- 테이블 -->
-    <table id="stockTable" class="table table-bordered table-hover w-100 align-middle">
+    <table id="stockTable" class="table table-bordered table-hover bg-white align-middle text-center w-100">
       <thead class="table-light">
         <tr>
           <th>품번</th>
@@ -47,24 +53,6 @@
       <tbody></tbody>
     </table>
 
-    <!-- 업로드 모달 -->
-    <div class="modal fade" id="uploadModal" tabindex="-1" aria-labelledby="uploadModalLabel">
-      <div class="modal-dialog">
-        <form id="uploadForm" class="modal-content">
-          <div class="modal-header">
-            <h5 class="modal-title" id="uploadModalLabel">엑셀 업로드</h5>
-            <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
-          </div>
-          <div class="modal-body">
-            <input type="file" name="excelFile" accept=".xlsx,.xls" class="form-control" required />
-          </div>
-          <div class="modal-footer">
-            <button type="submit" class="btn btn-success">업로드</button>
-          </div>
-        </form>
-      </div>
-    </div>
-    <!-- 업로드 모달 끝 -->
   </div>
 
   <script src="https://code.jquery.com/jquery-3.7.1.min.js"></script>


### PR DESCRIPTION
## Summary
- redesign stock page to match Coupang layouts
- center table text and use DataTables styling
- display 50 stock items per page

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68528a3b6a9c83298b01d604067d84d7