### PR TITLE
Add pagination & upload metadata to stock list

### DIFF
--- a/public/js/stock.js
+++ b/public/js/stock.js
@@ -2,39 +2,58 @@
 $(document).ready(function () {
   // DataTable 초기화
   const table = $("#stockTable").DataTable({
+    serverSide: true,
+    processing: true,
     paging: true,
     searching: false,
     info: false,
     pageLength: 50,
     lengthChange: false,
-    columnDefs: [{ targets: '_all', className: 'text-center' }],
+    columnDefs: [
+      { targets: '_all', className: 'text-center' },
+      {
+        targets: 0,
+        render: function (data, type, row, meta) {
+          return meta.row + meta.settings._iDisplayStart + 1;
+        }
+      },
+      {
+        targets: 8,
+        render: function (data) {
+          if (!data) return '';
+          const d = new Date(data);
+          return d.toLocaleString('ko-KR');
+        }
+      }
+    ],
     ajax: {
       url: "/api/stock",
+      type: "GET",
       dataSrc: "data",
     },
     columns: [
+      { data: null },
       { data: "item_code" },
       { data: "item_name" },
       { data: "color" },
       { data: "size" },
       { data: "qty" },
       { data: "allocation" },
+      { data: "uploadedBy" },
+      { data: "createdAt" },
     ],
   });
 
   // 검색 버튼
   $("#btnSearch").on("click", function () {
     const keyword = $("#keyword").val().trim();
-    const url = keyword
-      ? `/api/stock?keyword=${encodeURIComponent(keyword)}`
-      : "/api/stock";
-    table.ajax.url(url).load();
+    table.search(keyword).draw();
   });
 
   // 새로고침 버튼
   $("#btnRefresh").on("click", function () {
     $("#keyword").val("");
-    table.ajax.url("/api/stock").load();
+    table.search("").draw();
   });
 
 

--- a/views/stock.ejs
+++ b/views/stock.ejs
@@ -42,12 +42,15 @@
     <table id="stockTable" class="table table-bordered table-hover bg-white align-middle text-center w-100">
       <thead class="table-light">
         <tr>
+          <th>#</th>
           <th>품번</th>
           <th>품명</th>
           <th>색상</th>
           <th>사이즈</th>
           <th>수량</th>
           <th>할당</th>
+          <th>업로드 사용자</th>
+          <th>업로드 시각</th>
         </tr>
       </thead>
       <tbody></tbody>


### PR DESCRIPTION
## Summary
- implement server-side pagination for stock list
- show uploaded username and time for each row
- display row numbers in table

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853cf7936608329acb47fe27604107e