### PR TITLE
Fix /write route to load post form

### DIFF
--- a/routes/web/index.js
+++ b/routes/web/index.js
@@ -4,6 +4,7 @@ const path = require('path');
 const { checkAuth } = require('../../middlewares/auth');
 
 const router = express.Router();
+const postController = require('../../controllers/postController');
 const routesDir = __dirname;
 
 const protectedRoutes = new Set([
@@ -27,16 +28,19 @@ fs.readdirSync(routesDir)
     } else if (name === 'coupangAdd') {
       mountPaths = ['/coupang/add'];
     } else if (name === 'post') {
-      mountPaths = ['/' + name, '/list', '/write'];
+      mountPaths = ['/' + name, '/list'];
     }
 
-    mountPaths.forEach((mountPath) => {
-      if (protectedRoutes.has(name)) {
-        router.use(mountPath, checkAuth, routeModule);
-      } else {
-        router.use(mountPath, routeModule);
-      }
-    });
+  mountPaths.forEach((mountPath) => {
+    if (protectedRoutes.has(name)) {
+      router.use(mountPath, checkAuth, routeModule);
+    } else {
+      router.use(mountPath, routeModule);
+    }
   });
+});
+
+// 글쓰기 페이지 직접 연결
+router.get('/write', checkAuth, postController.renderWritePage);
 
 module.exports = router;


### PR DESCRIPTION
## Summary
- route '/write' incorrectly displayed post list instead of the write form
- adjust router mounting logic and add explicit handler for write page

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853d7f5ff708329bc85442bc6fd2800