### PR TITLE
Enable pagination on Coupang pages

### DIFF
--- a/views/coupang.ejs
+++ b/views/coupang.ejs
@@ -6,6 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.6/dist/css/bootstrap.min.css" rel="stylesheet">
   <link rel="stylesheet" href="/main.css">
+  <link rel="stylesheet" href="https://cdn.datatables.net/1.13.6/css/dataTables.bootstrap5.min.css">
 </head>
 <body class="bg-light">
 
@@ -15,7 +16,7 @@
   <div class="container my-5">
     <h2 class="mb-4 fw-bold">🛒 쿠팡재고</h2>
     <div class="alert alert-info mb-4">
-      <p class="mb-1">헤더를 클릭하거나 위의 셀렉트 박스로 원하는 컬럼을 정렬할 수 있습니다.</p>
+      <p class="mb-1">헤더를 클릭하면 오름차순/내림차순 정렬이 가능하며 50개씩 페이지 이동이 가능합니다.</p>
       <p class="mb-0">검색 후에는 옵션명과 30일 판매량을 그래프로 확인할 수 있습니다.</p>
     </div>
 
@@ -76,26 +77,13 @@
     <% } %>
 
     <div class="table-responsive">
-      <table class="table table-bordered table-hover bg-white align-middle auto-width">
+      <table id="coupangTable" class="table table-bordered table-hover bg-white align-middle text-center auto-width">
         <thead class="table-light text-center">
           <% if (필드 && 필드.length > 0) { %>
-            <!-- 정렬용 셀렉트 박스 -->
-            <tr id="sortRow">
-              <th>정렬</th>
-              <% 필드.forEach((key, idx) => { %>
-                <th>
-                  <select class="form-select form-select-sm sort-select" data-index="<%= idx %>">
-                    <option value="">-</option>
-                    <option value="asc">오름차순▲</option>
-                    <option value="desc">내림차순▼</option>
-                  </select>
-                </th>
-              <% }) %>
-            </tr>
             <tr>
               <th>번호</th>
-              <% 필드.forEach((key, idx) => { %>
-                <th class="sortable" data-index="<%= idx %>"><%= 한글[key] || key %> <span class="sort-indicator"></span></th>
+              <% 필드.forEach((key) => { %>
+                <th><%= 한글[key] || key %></th>
               <% }) %>
             </tr>
           <% } else { %>
@@ -137,39 +125,19 @@
     <% } %>
   </div>
 
+  <script src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
+  <script src="https://cdn.datatables.net/1.13.6/js/jquery.dataTables.min.js"></script>
+  <script src="https://cdn.datatables.net/1.13.6/js/dataTables.bootstrap5.min.js"></script>
   <script>
-    const getCellValue = (tr, idx) => tr.children[idx + 1].innerText.trim();
-    const comparer = (idx, asc) => (a, b) => {
-      const v1 = getCellValue(asc ? a : b, idx).replace(/,/g, '');
-      const v2 = getCellValue(asc ? b : a, idx).replace(/,/g, '');
-      const n1 = parseFloat(v1); const n2 = parseFloat(v2);
-      if (!isNaN(n1) && !isNaN(n2)) return n1 - n2;
-      return v1.localeCompare(v2);
-    };
-
-    document.querySelectorAll('th.sortable').forEach(th => th.addEventListener('click', function () {
-      const table = th.closest('table');
-      Array.from(table.querySelectorAll('tbody tr'))
-        .sort(comparer(parseInt(th.dataset.index), th.dataset.asc !== 'true'))
-        .forEach(tr => table.tBodies[0].appendChild(tr));
-      document.querySelectorAll('th.sortable').forEach(t => t.dataset.asc = '');
-      th.dataset.asc = th.dataset.asc === 'true' ? 'false' : 'true';
-      th.querySelector('.sort-indicator').textContent = th.dataset.asc === 'true' ? '▲' : '▼';
-    }));
-
-    document.querySelectorAll('.sort-select').forEach(sel => {
-      sel.addEventListener('change', () => {
-        if (!sel.value) return;
-        const table = sel.closest('table');
-        const idx = parseInt(sel.dataset.index);
-        Array.from(table.querySelectorAll('tbody tr'))
-          .sort(comparer(idx, sel.value === 'asc'))
-          .forEach(tr => table.tBodies[0].appendChild(tr));
-        document.querySelectorAll('th.sortable').forEach(t => t.dataset.asc = '');
-        const th = table.querySelector('th.sortable[data-index="' + idx + '"]');
-        th.dataset.asc = sel.value === 'asc' ? 'true' : 'false';
-        th.querySelector('.sort-indicator').textContent = sel.value === 'asc' ? '▲' : '▼';
-        document.querySelectorAll('.sort-select').forEach(other => { if (other !== sel) other.value = ''; });
+    $(function () {
+      $('#coupangTable').DataTable({
+        ordering: true,
+        order: [[0, 'asc']],
+        lengthChange: false,
+        paging: true,
+        pageLength: 50,
+        searching: false,
+        info: false,
       });
     });
   </script>

--- a/views/coupangAdd.ejs
+++ b/views/coupangAdd.ejs
@@ -6,6 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.6/dist/css/bootstrap.min.css" rel="stylesheet">
   <link rel="stylesheet" href="/main.css">
+  <link rel="stylesheet" href="https://cdn.datatables.net/1.13.6/css/dataTables.bootstrap5.min.css">
 </head>
 <body class="bg-light">
 
@@ -13,6 +14,10 @@
 
   <div class="container my-5">
     <h2 class="mb-4 fw-bold">🛒 쿠팡 매출/광고비</h2>
+
+    <div class="alert alert-info mb-4">
+      <p class="mb-0">헤더를 클릭하면 오름차순/내림차순 정렬이 가능하며 50개씩 페이지 이동이 가능합니다.</p>
+    </div>
 
     <% if (성공메시지) { %>
       <div class="alert alert-success alert-dismissible fade show" role="alert">
@@ -36,7 +41,7 @@
     <% } %>
 
     <div class="table-responsive">
-      <table class="table table-bordered table-hover bg-white align-middle">
+      <table id="coupangAddTable" class="table table-bordered table-hover bg-white align-middle text-center auto-width">
         <thead class="table-light text-center">
           <% if (필드 && 필드.length > 0) { %>
             <tr>
@@ -69,6 +74,22 @@
     </div>
   </div>
 
+  <script src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
+  <script src="https://cdn.datatables.net/1.13.6/js/jquery.dataTables.min.js"></script>
+  <script src="https://cdn.datatables.net/1.13.6/js/dataTables.bootstrap5.min.js"></script>
+  <script>
+    $(function () {
+      $('#coupangAddTable').DataTable({
+        ordering: true,
+        order: [[0, 'asc']],
+        lengthChange: false,
+        paging: true,
+        pageLength: 50,
+        searching: false,
+        info: false,
+      });
+    });
+  </script>
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.6/dist/js/bootstrap.bundle.min.js"></script>
 </body>
 </html>

--- a/views/stock.ejs
+++ b/views/stock.ejs
@@ -39,22 +39,24 @@
     </div>
 
     <!-- 테이블 -->
-    <table id="stockTable" class="table table-bordered table-hover bg-white align-middle text-center w-100">
-      <thead class="table-light">
-        <tr>
-          <th>#</th>
-          <th>품번</th>
-          <th>품명</th>
-          <th>색상</th>
-          <th>사이즈</th>
-          <th>수량</th>
-          <th>할당</th>
-          <th>업로드 사용자</th>
-          <th>업로드 시각</th>
-        </tr>
-      </thead>
-      <tbody></tbody>
-    </table>
+    <div class="table-responsive">
+      <table id="stockTable" class="table table-bordered table-hover bg-white align-middle text-center auto-width">
+        <thead class="table-light">
+          <tr>
+            <th>#</th>
+            <th>품번</th>
+            <th>품명</th>
+            <th>색상</th>
+            <th>사이즈</th>
+            <th>수량</th>
+            <th>할당</th>
+            <th>업로드 사용자</th>
+            <th>업로드 시각</th>
+          </tr>
+        </thead>
+        <tbody></tbody>
+      </table>
+    </div>
 
   </div>
 


### PR DESCRIPTION
## Summary
- update Coupang stock pages to show pagination like the stock table
- message in Coupang page now references paging
- header note and JS updated for Coupang add page as well

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853d48a40c48329950be728d02e889f