### PR TITLE
Add coupang API routes

### DIFF
--- a/routes/api/coupangApi.js
+++ b/routes/api/coupangApi.js
@@ -1,0 +1,71 @@
+const express = require("express");
+const router = express.Router();
+const multer = require("multer");
+const xlsx = require("xlsx");
+const fs = require("fs");
+const path = require("path");
+
+const uploadsDir = path.join(__dirname, "../../uploads");
+if (!fs.existsSync(uploadsDir)) fs.mkdirSync(uploadsDir);
+const upload = multer({ dest: uploadsDir });
+
+function parseExcel(filePath) {
+  const workbook = xlsx.readFile(filePath);
+  const sheet = workbook.Sheets[workbook.SheetNames[0]];
+  const rows = xlsx.utils.sheet_to_json(sheet, { header: 1 }).slice(2);
+  return rows
+    .map((row) => {
+      const obj = {};
+      obj["Option ID"] = String(row[2] ?? "").trim();
+      obj["Product name"] = row[4] ?? "";
+      obj["Option name"] = row[5] ?? "";
+      const inventory = Number(String(row[7]).replace(/,/g, "")) || 0;
+      obj["Orderable quantity (real-time)"] = inventory;
+      const salesAmount = Number(String(row[11]).replace(/,/g, "")) || 0;
+      obj["Sales amount on the last 30 days"] = salesAmount;
+      const salesCount = Number(String(row[13]).replace(/,/g, "")) || 0;
+      obj["Sales in the last 30 days"] = salesCount;
+      const daily = salesCount / 30;
+      const safety = daily * 7;
+      obj["Shortage quantity"] =
+        inventory < safety ? Math.ceil(safety - inventory) : 0;
+      return obj;
+    })
+    .filter((item) => item["Option ID"]);
+}
+
+router.post("/upload", upload.single("excelFile"), async (req, res) => {
+  const db = req.app.locals.db;
+  try {
+    if (!req.file)
+      return res.status(400).json({ status: "error", message: "파일이 없습니다." });
+    const filePath = req.file.path;
+    const data = parseExcel(filePath);
+    const bulkOps = data.map((item) => ({
+      updateOne: {
+        filter: { "Option ID": item["Option ID"] },
+        update: { $set: item },
+        upsert: true,
+      },
+    }));
+    if (bulkOps.length > 0) await db.collection("coupang").bulkWrite(bulkOps);
+    fs.unlink(filePath, () => {});
+    res.json({ status: "success" });
+  } catch (err) {
+    console.error("POST /api/coupang/upload 오류:", err);
+    res.status(500).json({ status: "error", message: "업로드 실패" });
+  }
+});
+
+router.delete("/", async (req, res) => {
+  const db = req.app.locals.db;
+  try {
+    await db.collection("coupang").deleteMany({});
+    res.json({ message: "삭제 완료" });
+  } catch (err) {
+    console.error("DELETE /api/coupang 오류:", err);
+    res.status(500).json({ status: "error", message: "삭제 실패" });
+  }
+});
+
+module.exports = router;

--- a/routes/api/index.js
+++ b/routes/api/index.js
@@ -10,6 +10,8 @@ const router = express.Router();
 
 // 재고(Stock) API
 router.use("/stock", require("./stockApi"));
+// 쿠팡 재고 API
+router.use("/coupang", require("./coupangApi"));
 
 // TODO: 다른 API 라우터 추가 시 아래와 같이 등록
 // router.use("/user", require("./userApi"));

--- a/tests/coupangApi.test.js
+++ b/tests/coupangApi.test.js
@@ -1,0 +1,62 @@
+jest.setTimeout(60000);
+
+const mockCollection = {
+  bulkWrite: jest.fn().mockResolvedValue(),
+  deleteMany: jest.fn().mockResolvedValue(),
+  find: jest.fn().mockReturnThis(),
+  sort: jest.fn().mockReturnThis(),
+  toArray: jest.fn().mockResolvedValue([]),
+};
+jest.mock("../config/db", () => {
+  const mockDb = { collection: jest.fn(() => mockCollection) };
+  const mockConnect = jest.fn().mockResolvedValue(mockDb);
+  mockConnect.then = (fn) => fn(mockDb);
+  return { connectDB: mockConnect, closeDB: jest.fn().mockResolvedValue() };
+});
+
+jest.mock("multer", () => jest.requireActual("multer"));
+
+const request = require("supertest");
+const path = require("path");
+const { initApp } = require("../server");
+const { closeDB } = require("../config/db");
+
+let app;
+
+beforeAll(async () => {
+  process.env.NODE_ENV = "test";
+  process.env.MONGO_URI = "mongodb://127.0.0.1:27017/testdb";
+  process.env.DB_NAME = "testdb";
+  process.env.SESSION_SECRET = "testsecret";
+
+  app = await initApp();
+});
+
+afterAll(async () => {
+  await closeDB();
+});
+
+describe("POST /api/coupang/upload", () => {
+  it("should respond with success", async () => {
+    const res = await request(app)
+      .post("/api/coupang/upload")
+      .attach("excelFile", path.join(__dirname, "fixtures", "dummy.xlsx"));
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toEqual({ status: "success" });
+  });
+});
+
+describe("DELETE /api/coupang", () => {
+  it("should delete all coupang data", async () => {
+    const res = await request(app).delete("/api/coupang");
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toEqual({ message: "삭제 완료" });
+
+    const db = app.locals.db;
+    const mockColl = db.collection.mock.results[0].value;
+    expect(db.collection).toHaveBeenCalledWith("coupang");
+    expect(mockColl.deleteMany).toHaveBeenCalledWith({});
+  });
+});


### PR DESCRIPTION
## Summary
- implement REST API for Coupang stock uploads
- register new router in the API index
- add tests for new `/api/coupang` endpoints

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853e59a596083298bba8b91fe0c8feb