### PR TITLE
Fix Excel upload warnings

### DIFF
--- a/lib/safeReadXlsx.js
+++ b/lib/safeReadXlsx.js
@@ -1,0 +1,27 @@
+const fs = require('fs');
+const xlsx = require('xlsx');
+
+/**
+ * Reads an XLSX file while suppressing noisy unzip warnings from the xlsx/cfb libraries.
+ * @param {string} filePath - Path to the XLSX file to read.
+ * @returns {object} Parsed workbook instance.
+ */
+function safeReadXlsx(filePath) {
+  const originalError = console.error;
+  console.error = function (...args) {
+    const msg = args[0];
+    if (typeof msg === 'string' &&
+        (/^Bad (uncompressed|compressed) size/.test(msg) || msg.startsWith('Bad CRC32 checksum'))) {
+      return;
+    }
+    originalError.apply(console, args);
+  };
+  try {
+    const data = fs.readFileSync(filePath);
+    return xlsx.read(data, { type: 'buffer' });
+  } finally {
+    console.error = originalError;
+  }
+}
+
+module.exports = safeReadXlsx;

--- a/routes/api/coupangApi.js
+++ b/routes/api/coupangApi.js
@@ -2,6 +2,7 @@ const express = require("express");
 const router = express.Router();
 const multer = require("multer");
 const xlsx = require("xlsx");
+const safeReadXlsx = require("../../lib/safeReadXlsx");
 const fs = require("fs");
 const path = require("path");
 
@@ -10,7 +11,7 @@ if (!fs.existsSync(uploadsDir)) fs.mkdirSync(uploadsDir);
 const upload = multer({ dest: uploadsDir });
 
 function parseExcel(filePath) {
-  const workbook = xlsx.readFile(filePath);
+  const workbook = safeReadXlsx(filePath);
   const sheet = workbook.Sheets[workbook.SheetNames[0]];
   const rows = xlsx.utils.sheet_to_json(sheet, { header: 1 }).slice(2);
   return rows

--- a/routes/web/coupang.js
+++ b/routes/web/coupang.js
@@ -2,6 +2,7 @@ const express = require("express");
 const router = express.Router();
 const multer = require("multer");
 const xlsx = require("xlsx");
+const safeReadXlsx = require("../../lib/safeReadXlsx");
 const fs = require("fs");
 const path = require("path");
 const { checkAuth } = require("../../middlewares/auth");
@@ -112,7 +113,7 @@ router.post("/upload", upload.single("excelFile"), async (req, res) => {
   const db = req.app.locals.db;
   try {
     const filePath = req.file.path;
-    const workbook = xlsx.readFile(filePath);
+    const workbook = safeReadXlsx(filePath);
     const sheet = workbook.Sheets[workbook.SheetNames[0]];
     const sheetData = xlsx.utils.sheet_to_json(sheet, { header: 1 });
     const dataRows = sheetData.slice(2); // 첫 2행 제거


### PR DESCRIPTION
## Summary
- add helper to suppress noisy unzip warnings from `xlsx`
- use the helper when reading Coupang Excel files

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853e82f0624832993876ba48a15bfce