### PR TITLE
Improve stock page layout

### DIFF
--- a/public/js/stock.js
+++ b/public/js/stock.js
@@ -5,8 +5,9 @@ $(document).ready(function () {
     serverSide: true,
     processing: true,
     paging: true,
+    pagingType: 'numbers',
     searching: false,
-    info: false,
+    info: true,
     pageLength: 50,
     lengthChange: false,
     columnDefs: [
@@ -26,6 +27,11 @@ $(document).ready(function () {
         }
       }
     ],
+    language: {
+      paginate: { previous: '이전', next: '다음' },
+      info: '총 _TOTAL_건 중 _START_ ~ _END_',
+      infoEmpty: '데이터가 없습니다'
+    },
     ajax: {
       url: "/api/stock",
       type: "GET",

--- a/public/main.css
+++ b/public/main.css
@@ -153,6 +153,22 @@ input[type="file"]::-webkit-file-upload-button {
   align-items: center;
 }
 
+@media (max-width: 575.98px) {
+  .action-form {
+    flex-wrap: wrap;
+  }
+  .action-form form {
+    flex: 1 1 100%;
+  }
+  .btn-upload,
+  .btn-reset {
+    width: 100%;
+  }
+  .action-form input[type="file"] {
+    width: 100%;
+  }
+}
+
 .btn-upload,
 .btn-reset {
   min-width: 130px;
@@ -180,4 +196,21 @@ input[type="file"]::-webkit-file-upload-button {
 table.auto-width {
   margin-left: auto;
   margin-right: auto;
+}
+
+/* DataTables pagination */
+.dataTables_wrapper .dataTables_paginate {
+  margin-top: 1rem;
+  display: flex;
+  justify-content: center;
+}
+
+.dataTables_wrapper .dataTables_paginate .page-link {
+  border-radius: 0.25rem;
+}
+
+.dataTables_wrapper .dataTables_paginate .page-item.active .page-link {
+  color: #fff;
+  background-color: #0d6efd;
+  border-color: #0d6efd;
 }

--- a/views/stock.ejs
+++ b/views/stock.ejs
@@ -26,7 +26,7 @@
     </div>
 
     <!-- 검색 -->
-    <div class="row row-cols-auto g-2 mb-4">
+    <div class="row row-cols-1 row-cols-sm-auto g-2 mb-4">
       <div class="col flex-grow-1">
         <input id="keyword" class="form-control" placeholder="상품명 또는 상품코드" />
       </div>


### PR DESCRIPTION
## Summary
- adjust stock search row for responsiveness
- tweak action form layout on small screens
- style DataTables pagination
- localize stock table pagination and info text

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6853e8ed89e0832994d7c2390e8752a4