### PR TITLE
Fix Coupang Excel upload

### DIFF
--- a/lib/parseCoupangExcel.js
+++ b/lib/parseCoupangExcel.js
@@ -1,0 +1,38 @@
+const safeReadXlsx = require('./safeReadXlsx');
+const xlsx = require('xlsx');
+
+/**
+ * Parse Coupang Excel file and return array of item objects
+ * @param {string} filePath
+ * @returns {Array<Object>}
+ */
+function parseCoupangExcel(filePath) {
+  const workbook = safeReadXlsx(filePath);
+  const sheet = workbook.Sheets[workbook.SheetNames[0]];
+  const rows = xlsx.utils.sheet_to_json(sheet, { header: 1 }).slice(2);
+  return rows
+    .map((row) => {
+      const obj = {};
+      obj['Option ID'] = String(row[2] ?? '').trim();
+      obj['Product name'] = row[4] ?? '';
+      obj['Option name'] = row[5] ?? '';
+
+      const inventory = Number(String(row[7]).replace(/,/g, '')) || 0;
+      obj['Orderable quantity (real-time)'] = inventory;
+
+      const salesAmount = Number(String(row[11]).replace(/,/g, '')) || 0;
+      obj['Sales amount on the last 30 days'] = salesAmount;
+
+      const salesCount = Number(String(row[13]).replace(/,/g, '')) || 0;
+      obj['Sales in the last 30 days'] = salesCount;
+
+      const daily = salesCount / 30;
+      const safety = daily * 7;
+      obj['Shortage quantity'] = inventory < safety ? Math.ceil(safety - inventory) : 0;
+
+      return obj;
+    })
+    .filter((item) => item['Option ID']);
+}
+
+module.exports = parseCoupangExcel;


### PR DESCRIPTION
## Summary
- share excel parsing logic in `parseCoupangExcel`
- use that helper in both API and web routes
- add missing file check for Coupang upload

## Testing
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6854edfcef0c83299773def367b571c8