### PR TITLE
Add numeric sorting to Coupang table

### DIFF
--- a/views/coupang.ejs
+++ b/views/coupang.ejs
@@ -94,17 +94,17 @@
               <tr>
                 <td class="text-center"><%= index + 1 %></td>
                 <% 필드.forEach(key => { %>
-                  <td>
-                    <% if (key === 'Option ID') { %>
-                      <%= 행[key] %>
-                    <% } else { 
-                         const val = 행[key];
-                         const numVal = Number(val);
-                         const isNum = !isNaN(numVal) && val !== '-' && val !== '';
-                    %>
+                  <% if (key === 'Option ID') { %>
+                    <td><%= 행[key] %></td>
+                  <% } else {
+                       const val = 행[key];
+                       const numVal = Number(val);
+                       const isNum = !isNaN(numVal) && val !== '-' && val !== '';
+                  %>
+                    <td<% if (isNum) { %> data-order="<%= numVal %>"<% } %>>
                       <%= isNum ? (numVal === 0 ? '-' : numVal.toLocaleString('ko-KR')) : val %>
-                    <% } %>
-                  </td>
+                    </td>
+                  <% } %>
                 <% }) %>
               </tr>
             <% }) %>


### PR DESCRIPTION
## Summary
- ensure numeric columns in Coupang table sort correctly

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6854eed8e0508329a80d357cc99f33d9