### PR TITLE
Enable next/previous pagination buttons

### DIFF
--- a/public/js/stock.js
+++ b/public/js/stock.js
@@ -5,7 +5,7 @@ $(document).ready(function () {
     serverSide: true,
     processing: true,
     paging: true,
-    pagingType: 'numbers',
+    pagingType: 'simple_numbers',
     searching: false,
     info: true,
     pageLength: 50,

--- a/public/main.css
+++ b/public/main.css
@@ -203,6 +203,7 @@ table.auto-width {
   margin-top: 1rem;
   display: flex;
   justify-content: center;
+  float: none;
 }
 
 .dataTables_wrapper .dataTables_paginate .page-link {


### PR DESCRIPTION
## Summary
- show next/previous controls with DataTables
- center align pagination in Bootstrap tables

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6854ee68fce0832995ff485887908db9