### PR TITLE
Add banner and logo admin pages

### DIFF
--- a/routes/web/admin.js
+++ b/routes/web/admin.js
@@ -17,23 +17,34 @@ function getViewNames() {
 }
 
 // 관리자 메인 페이지
-router.get('/', checkAdmin, async (req, res) => {
+router.get('/', checkAdmin, (req, res) => {
+  res.render('admin/index.ejs');
+});
+
+// 배너 관리 페이지
+router.get('/banner', checkAdmin, async (req, res) => {
   try {
     const db = req.app.locals.db;
-    const logoDoc = await db.collection('homepage').findOne({ key: 'logo' });
     const banners = [];
     for (let i = 1; i <= 4; i++) {
       const doc = await db.collection('homepage').findOne({ key: 'banner' + i });
       banners.push(doc?.img || '');
     }
-    const activeTab = req.query.tab || 'bannerSection';
-    res.render('admin/index.ejs', {
-      banners,
-      logo: logoDoc?.img || '',
-      activeTab,
-    });
+    res.render('admin/banner.ejs', { banners });
   } catch (err) {
-    console.error('❌ 관리자 페이지 오류:', err);
+    console.error('❌ 배너 페이지 오류:', err);
+    res.status(500).send('서버 오류');
+  }
+});
+
+// 로고 관리 페이지
+router.get('/logo', checkAdmin, async (req, res) => {
+  try {
+    const db = req.app.locals.db;
+    const logoDoc = await db.collection('homepage').findOne({ key: 'logo' });
+    res.render('admin/logo.ejs', { logo: logoDoc?.img || '' });
+  } catch (err) {
+    console.error('❌ 로고 페이지 오류:', err);
     res.status(500).send('서버 오류');
   }
 });
@@ -49,8 +60,12 @@ router.post('/banner/:idx', checkAdmin, upload.single('banner'), async (req, res
       { $set: { img: imgLocation, updatedAt: new Date() } },
       { upsert: true }
     );
-    const tab = req.query.tab || req.body.tab || 'bannerSection';
-    res.redirect(`/admin?tab=${tab}`);
+    if (req.query.redirect || req.body.redirect) {
+      res.redirect(req.query.redirect || req.body.redirect);
+    } else {
+      const tab = req.query.tab || req.body.tab || 'bannerSection';
+      res.redirect(`/admin?tab=${tab}`);
+    }
   } catch (err) {
     console.error('❌ 배너 업로드 실패:', err);
     res.status(500).send('서버 오류');
@@ -61,8 +76,12 @@ router.post('/banner/:idx/delete', checkAdmin, async (req, res) => {
   try {
     const db = req.app.locals.db;
     await db.collection('homepage').deleteOne({ key: 'banner' + req.params.idx });
-    const tabDel = req.query.tab || req.body.tab || 'bannerSection';
-    res.redirect(`/admin?tab=${tabDel}`);
+    if (req.query.redirect || req.body.redirect) {
+      res.redirect(req.query.redirect || req.body.redirect);
+    } else {
+      const tabDel = req.query.tab || req.body.tab || 'bannerSection';
+      res.redirect(`/admin?tab=${tabDel}`);
+    }
   } catch (err) {
     console.error('❌ 배너 삭제 실패:', err);
     res.status(500).send('서버 오류');
@@ -79,8 +98,12 @@ router.post('/logo', checkAdmin, upload.single('logo'), async (req, res) => {
       { $set: { img: imgLocation, updatedAt: new Date() } },
       { upsert: true }
     );
-    const tabLogo = req.query.tab || req.body.tab || 'logoSection';
-    res.redirect(`/admin?tab=${tabLogo}`);
+    if (req.query.redirect || req.body.redirect) {
+      res.redirect(req.query.redirect || req.body.redirect);
+    } else {
+      const tabLogo = req.query.tab || req.body.tab || 'logoSection';
+      res.redirect(`/admin?tab=${tabLogo}`);
+    }
   } catch (err) {
     console.error('❌ 로고 업로드 실패:', err);
     res.status(500).send('서버 오류');
@@ -91,8 +114,12 @@ router.post('/logo/delete', checkAdmin, async (req, res) => {
   try {
     const db = req.app.locals.db;
     await db.collection('homepage').deleteOne({ key: 'logo' });
-    const tabLogoDel = req.query.tab || req.body.tab || 'logoSection';
-    res.redirect(`/admin?tab=${tabLogoDel}`);
+    if (req.query.redirect || req.body.redirect) {
+      res.redirect(req.query.redirect || req.body.redirect);
+    } else {
+      const tabLogoDel = req.query.tab || req.body.tab || 'logoSection';
+      res.redirect(`/admin?tab=${tabLogoDel}`);
+    }
   } catch (err) {
     console.error('❌ 로고 삭제 실패:', err);
     res.status(500).send('서버 오류');

--- a/views/admin/banner.ejs
+++ b/views/admin/banner.ejs
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>배너 이미지 관리</title>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.6/dist/css/bootstrap.min.css" rel="stylesheet">
+  <link rel="stylesheet" href="/main.css">
+</head>
+<body>
+  <%- include('../nav.ejs') %>
+  <div class="container my-4">
+    <h1 class="mb-3">배너 이미지 관리</h1>
+    <% for (let i = 1; i <= 4; i++) { const img = banners[i-1]; %>
+      <div class="mb-4">
+        <h5 class="mb-2">배너 <%= i %></h5>
+        <% if (img) { %>
+          <img src="<%= img %>" class="img-fluid mb-2" alt="banner <%= i %>">
+        <% } else { %>
+          <p class="text-muted">현재 이미지가 없습니다.</p>
+        <% } %>
+        <form action="/admin/banner/<%= i %>?redirect=/admin/banner" method="post" enctype="multipart/form-data" class="banner-form d-flex flex-nowrap gap-2 mb-2">
+          <input type="file" name="banner" accept="image/*" class="form-control" id="bannerInput<%= i %>">
+          <button type="submit" class="btn btn-primary">업로드</button>
+        </form>
+        <% if (img) { %>
+          <form action="/admin/banner/<%= i %>/delete?redirect=/admin/banner" method="post" onsubmit="return confirm('배너를 삭제하시겠습니까?')" class="d-inline">
+            <button type="submit" class="btn btn-danger btn-sm">삭제</button>
+          </form>
+        <% } %>
+      </div>
+    <% } %>
+  </div>
+  <script>
+    document.querySelectorAll('.banner-form').forEach(form => {
+      form.addEventListener('submit', function (e) {
+        const input = form.querySelector('input[type="file"]');
+        if (!input.files || input.files.length === 0) {
+          alert('📂 파일을 선택해 주세요.');
+          e.preventDefault();
+        }
+      });
+    });
+  </script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.6/dist/js/bootstrap.bundle.min.js"></script>
+</body>
+</html>

--- a/views/admin/index.ejs
+++ b/views/admin/index.ejs
@@ -3,104 +3,21 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>관리자 - 인덱스 이미지 관리</title>
+  <title>관리자</title>
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.6/dist/css/bootstrap.min.css" rel="stylesheet">
   <link rel="stylesheet" href="/main.css">
-  <style>
-
-  </style>
 </head>
 <body>
   <%- include('../nav.ejs') %>
-  
   <div class="container my-4">
-    <div class="row">
-      <div class="col-md-3 mb-3">
-        <a href="/admin/permissions" class="btn btn-outline-secondary w-100 mb-3">접근 권한 설정</a>
-        <a href="/admin/users" class="btn btn-outline-secondary w-100 mb-3">사용자 관리</a>
-        <ul class="list-group" id="adminMenu">
-          <li class="list-group-item <%= activeTab === 'bannerSection' ? 'active' : '' %>" data-target="bannerSection">배너 이미지 관리</li>
-          <li class="list-group-item <%= activeTab === 'logoSection' ? 'active' : '' %>" data-target="logoSection">브랜드 로고 관리</li>
-        </ul>
-      </div>
-      <div class="col-md-9">
-        <div id="bannerSection" class="admin-section <%= activeTab === 'bannerSection' ? '' : 'd-none' %>">
-          <h1 class="mb-3">배너 이미지 관리</h1>
-          <% for (let i = 1; i <= 4; i++) { const img = banners[i-1]; %>
-            <div class="mb-4">
-              <h5 class="mb-2">배너 <%= i %></h5>
-              <% if (img) { %>
-                <img src="<%= img %>" class="img-fluid mb-2" alt="banner <%= i %>">
-              <% } else { %>
-                <p class="text-muted">현재 이미지가 없습니다.</p>
-              <% } %>
-              <form action="/admin/banner/<%= i %>?tab=bannerSection" method="post" enctype="multipart/form-data" class="banner-form d-flex flex-nowrap gap-2 mb-2">
-                <input type="file" name="banner" accept="image/*" class="form-control" id="bannerInput<%= i %>">
-                <button type="submit" class="btn btn-primary">업로드</button>
-              </form>
-              <% if (img) { %>
-                <form action="/admin/banner/<%= i %>/delete?tab=bannerSection" method="post" onsubmit="return confirm('배너를 삭제하시겠습니까?')" class="d-inline">
-                  <button type="submit" class="btn btn-danger btn-sm">삭제</button>
-                </form>
-              <% } %>
-            </div>
-          <% } %>
-        </div>
-
-        <div id="logoSection" class="admin-section <%= activeTab === 'logoSection' ? '' : 'd-none' %>">
-          <h2 class="mb-3">브랜드 로고 관리</h2>
-          <% if (logo) { %>
-            <img src="<%= logo %>" class="img-fluid mb-3" style="max-height:100px" alt="logo">
-          <% } else { %>
-            <p class="text-muted">저장된 로고가 없습니다.</p>
-          <% } %>
-          <form id="logoForm" action="/admin/logo?tab=logoSection" method="post" enctype="multipart/form-data" class="mt-3 d-flex gap-2 flex-wrap align-items-start">
-            <div class="flex-grow-1 mb-3">
-              <input type="file" name="logo" accept="image/*" class="form-control" id="logoInput">
-            </div>
-            <button type="submit" class="btn btn-primary">업로드</button>
-          </form>
-          <form action="/admin/logo/delete?tab=logoSection" method="POST" onsubmit="return confirm('로고 이미지를 삭제하시겠습니까?')" class="d-inline mt-3 ms-2">
-            <button type="submit" class="btn btn-danger">삭제</button>
-          </form>
-        </div>
-      </div>
+    <h1 class="mb-3">관리자 메뉴</h1>
+    <div class="list-group">
+      <a href="/admin/users" class="list-group-item list-group-item-action">사용자 관리</a>
+      <a href="/admin/permissions" class="list-group-item list-group-item-action">접근 권한 설정</a>
+      <a href="/admin/banner" class="list-group-item list-group-item-action">배너 이미지 관리</a>
+      <a href="/admin/logo" class="list-group-item list-group-item-action">브랜드 로고 관리</a>
     </div>
-
-    <script>
-      document.querySelectorAll('#adminMenu .list-group-item').forEach(item => {
-        item.addEventListener('click', () => {
-          document.querySelectorAll('#adminMenu .list-group-item').forEach(li => li.classList.remove('active'));
-          item.classList.add('active');
-          const target = item.dataset.target;
-          document.querySelectorAll('.admin-section').forEach(sec => sec.classList.add('d-none'));
-          document.getElementById(target).classList.remove('d-none');
-          const url = new URL(window.location);
-          url.searchParams.set('tab', target);
-          history.replaceState(null, '', url);
-        });
-      });
-
-      document.querySelectorAll('.banner-form').forEach(form => {
-        form.addEventListener('submit', function (e) {
-          const input = form.querySelector('input[type="file"]');
-          if (!input.files || input.files.length === 0) {
-            alert('📂 파일을 선택해 주세요.');
-            e.preventDefault();
-          }
-        });
-      });
-
-      document.getElementById('logoForm').addEventListener('submit', function (e) {
-        const fileInput = document.getElementById('logoInput');
-        if (!fileInput.files || fileInput.files.length === 0) {
-          alert('📂 파일을 선택해 주세요.');
-          e.preventDefault();
-        }
-      });
-    </script>
   </div>
-
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.6/dist/js/bootstrap.bundle.min.js"></script>
 </body>
 </html>

--- a/views/admin/logo.ejs
+++ b/views/admin/logo.ejs
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>브랜드 로고 관리</title>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.6/dist/css/bootstrap.min.css" rel="stylesheet">
+  <link rel="stylesheet" href="/main.css">
+</head>
+<body>
+  <%- include('../nav.ejs') %>
+  <div class="container my-4">
+    <h1 class="mb-3">브랜드 로고 관리</h1>
+    <% if (logo) { %>
+      <img src="<%= logo %>" class="img-fluid mb-3" style="max-height:100px" alt="logo">
+    <% } else { %>
+      <p class="text-muted">저장된 로고가 없습니다.</p>
+    <% } %>
+    <form id="logoForm" action="/admin/logo?redirect=/admin/logo" method="post" enctype="multipart/form-data" class="mt-3 d-flex gap-2 flex-wrap align-items-start">
+      <div class="flex-grow-1 mb-3">
+        <input type="file" name="logo" accept="image/*" class="form-control" id="logoInput">
+      </div>
+      <button type="submit" class="btn btn-primary">업로드</button>
+    </form>
+    <form action="/admin/logo/delete?redirect=/admin/logo" method="POST" onsubmit="return confirm('로고 이미지를 삭제하시겠습니까?')" class="d-inline mt-3 ms-2">
+      <button type="submit" class="btn btn-danger">삭제</button>
+    </form>
+  </div>
+  <script>
+    document.getElementById('logoForm').addEventListener('submit', function(e) {
+      const fileInput = document.getElementById('logoInput');
+      if (!fileInput.files || fileInput.files.length === 0) {
+        alert('📂 파일을 선택해 주세요.');
+        e.preventDefault();
+      }
+    });
+  </script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.6/dist/js/bootstrap.bundle.min.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add new `/admin/banner` and `/admin/logo` pages
- update admin routes to support new pages
- simplify admin index page and link to new pages
- allow banner/logo uploads to redirect back to their pages

## Testing
- `npm test` *(fails: `jest` not found)*
- `npm run lint` *(fails: cannot find `@eslint/js`)*

------
https://chatgpt.com/codex/tasks/task_e_6854f3cb2098832991fab6d52a71375e