### PR TITLE
Fix coupang table column mismatch

### DIFF
--- a/views/coupang.ejs
+++ b/views/coupang.ejs
@@ -110,7 +110,7 @@
             <% }) %>
           <% } else { %>
             <tr>
-              <td colspan="100%" class="text-center text-muted">📭 재고가 없습니다.</td>
+              <td colspan="<%= (필드?.length || 0) + 1 %>" class="text-center text-muted">📭 재고가 없습니다.</td>
             </tr>
           <% } %>
         </tbody>


### PR DESCRIPTION
## Summary
- adjust colspan for empty Coupang table state so DataTables doesn't throw a column count warning

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6854f8e82fbc83298f7c84de5ea2abc7