### PR TITLE
Add coupangAdd API and JS pagination

### DIFF
--- a/controllers/coupangAddController.js
+++ b/controllers/coupangAddController.js
@@ -1,0 +1,81 @@
+const path = require('path');
+const multer = require('multer');
+const xlsx = require('xlsx');
+const fs = require('fs');
+const asyncHandler = require('../middlewares/asyncHandler');
+
+// Multer storage
+const storage = multer.diskStorage({
+  destination: (req, file, cb) => cb(null, 'uploads/'),
+  filename: (req, file, cb) =>
+    cb(null, `excel_${Date.now()}${path.extname(file.originalname)}`)
+});
+exports.upload = multer({ storage }).single('excelFile');
+
+// Render page
+exports.renderPage = asyncHandler(async (req, res) => {
+  res.render('coupangAdd');
+});
+
+// DataTables API
+exports.getData = asyncHandler(async (req, res) => {
+  const db = req.app.locals.db;
+  const start = parseInt(req.query.start, 10) || 0;
+  const length = parseInt(req.query.length, 10) || 50;
+  const draw = parseInt(req.query.draw, 10) || 1;
+
+  const [rows, total] = await Promise.all([
+    db
+      .collection('coupangAdd')
+      .find()
+      .sort({ _id: -1 })
+      .skip(start)
+      .limit(length)
+      .toArray(),
+    db.collection('coupangAdd').countDocuments()
+  ]);
+
+  res.json({
+    draw,
+    recordsTotal: total,
+    recordsFiltered: total,
+    data: rows
+  });
+});
+
+// Excel upload for web route
+exports.uploadExcel = asyncHandler(async (req, res) => {
+  if (!req.file) {
+    return res.status(400).send('❌ 파일이 업로드되지 않았습니다.');
+  }
+  const filePath = req.file.path;
+  const workbook = xlsx.readFile(filePath, { cellDates: true });
+  const sheetName = workbook.SheetNames[0];
+  const data = xlsx.utils.sheet_to_json(workbook.Sheets[sheetName]);
+
+  const db = req.app.locals.db;
+  await db.collection('coupangAdd').deleteMany({});
+  if (data.length > 0) await db.collection('coupangAdd').insertMany(data);
+
+  fs.unlink(filePath, () => {});
+  if (req.flash) req.flash('성공메시지', '✅ 업로드 완료');
+  res.redirect('/coupang/add');
+});
+
+// Excel upload API
+exports.uploadExcelApi = asyncHandler(async (req, res) => {
+  if (!req.file) {
+    return res.status(400).json({ status: 'error', message: '파일이 없습니다.' });
+  }
+  const filePath = req.file.path;
+  const workbook = xlsx.readFile(filePath, { cellDates: true });
+  const sheetName = workbook.SheetNames[0];
+  const data = xlsx.utils.sheet_to_json(workbook.Sheets[sheetName]);
+
+  const db = req.app.locals.db;
+  await db.collection('coupangAdd').deleteMany({});
+  if (data.length > 0) await db.collection('coupangAdd').insertMany(data);
+
+  fs.unlink(filePath, () => {});
+  res.json({ status: 'success' });
+});

--- a/public/js/coupangAdd.js
+++ b/public/js/coupangAdd.js
@@ -1,0 +1,54 @@
+$(function () {
+  if (!$('#coupangAddTable').length) return;
+
+  const table = $('#coupangAddTable').DataTable({
+    serverSide: true,
+    processing: true,
+    paging: true,
+    pagingType: 'simple_numbers',
+    searching: false,
+    info: true,
+    pageLength: 50,
+    lengthChange: false,
+    order: [[0, 'asc']],
+    columnDefs: [{ targets: '_all', className: 'text-center' }],
+    ajax: {
+      url: '/api/coupang-add',
+      type: 'GET',
+      dataSrc: 'data',
+    },
+    columns: [
+      { data: '날짜' },
+      { data: '광고집행 옵션ID' },
+      { data: '광고집행 상품명' },
+      { data: '노출수' },
+      { data: '클릭수' },
+      { data: '광고비' },
+      { data: '클릭률' },
+    ],
+    language: {
+      paginate: { previous: '이전', next: '다음' },
+      info: '총 _TOTAL_건 중 _START_ ~ _END_',
+      infoEmpty: '데이터가 없습니다'
+    }
+  });
+
+  $('#uploadForm').on('submit', function (e) {
+    e.preventDefault();
+    const formData = new FormData(this);
+    $.ajax({
+      url: '/coupang/add/upload',
+      type: 'POST',
+      data: formData,
+      processData: false,
+      contentType: false,
+      success: () => {
+        alert('업로드 성공!');
+        table.ajax.reload(null, false);
+      },
+      error: (xhr) => {
+        alert('업로드 실패: ' + xhr.responseText);
+      }
+    });
+  });
+});

--- a/routes/api/coupangAddApi.js
+++ b/routes/api/coupangAddApi.js
@@ -1,0 +1,13 @@
+const express = require('express');
+const router = express.Router();
+const ctrl = require('../../controllers/coupangAddController');
+
+router.get('/', ctrl.getData);
+router.post('/upload', ctrl.upload, ctrl.uploadExcelApi);
+router.delete('/', async (req, res) => {
+  const db = req.app.locals.db;
+  await db.collection('coupangAdd').deleteMany({});
+  res.json({ message: '삭제 완료' });
+});
+
+module.exports = router;

--- a/routes/api/index.js
+++ b/routes/api/index.js
@@ -12,6 +12,8 @@ const router = express.Router();
 router.use("/stock", require("./stockApi"));
 // 쿠팡 재고 API
 router.use("/coupang", require("./coupangApi"));
+// 쿠팡 광고비 API
+router.use("/coupang-add", require("./coupangAddApi"));
 
 // TODO: 다른 API 라우터 추가 시 아래와 같이 등록
 // router.use("/user", require("./userApi"));

--- a/routes/web/coupangAdd.js
+++ b/routes/web/coupangAdd.js
@@ -1,86 +1,22 @@
-const express = require("express");
+const express = require('express');
 const router = express.Router();
-const multer = require("multer");
-const xlsx = require("xlsx");
-const fs = require("fs");
-const path = require("path");
+const ctrl = require('../../controllers/coupangAddController');
 
-// ─────────────────────────────────────────
-// Multer 설정
-// ─────────────────────────────────────────
-const uploadsDir = path.join(__dirname, "../../uploads");
-if (!fs.existsSync(uploadsDir)) fs.mkdirSync(uploadsDir);
-const upload = multer({
-  dest: uploadsDir,
-  limits: { fileSize: 10 * 1024 * 1024 }, // 10MB
-});
+// 페이지
+router.get('/', ctrl.renderPage);
 
-// ─────────────────────────────────────────
-// 목록 조회 (GET /coupang/add)
-// ─────────────────────────────────────────
-router.get("/", async (req, res) => {
+// 엑셀 업로드
+router.post('/upload', ctrl.upload, ctrl.uploadExcel);
+
+// 전체 삭제
+router.post('/delete-all', async (req, res) => {
   const db = req.app.locals.db;
   try {
-    const result = await db.collection("coupangAdd").find().toArray();
-    const fields = result[0]
-      ? Object.keys(result[0]).filter((k) => k !== "_id")
-      : [];
-    res.render("coupangAdd.ejs", {
-      결과: result,
-      필드: fields,
-      성공메시지: null,
-    });
+    await db.collection('coupangAdd').deleteMany({});
+    res.redirect('/coupang/add');
   } catch (err) {
-    console.error("목록 불러오기 실패:", err);
-    res.status(500).send("❌ 목록 불러오기 실패");
-  }
-});
-
-// ─────────────────────────────────────────
-// 엑셀 업로드 (POST /coupang/add/upload)
-// ─────────────────────────────────────────
-router.post("/upload", upload.single("excelFile"), async (req, res) => {
-  const db = req.app.locals.db;
-  try {
-    if (!req.file)
-      return res.status(400).send("❌ 파일이 업로드되지 않았습니다.");
-
-    const filePath = req.file.path;
-    const workbook = xlsx.readFile(filePath, { cellDates: true });
-    const sheetName = workbook.SheetNames[0];
-    const data = xlsx.utils.sheet_to_json(workbook.Sheets[sheetName]);
-
-    await db.collection("coupangAdd").deleteMany({});
-    if (data.length > 0) await db.collection("coupangAdd").insertMany(data);
-
-    fs.unlink(filePath, () => {});
-
-    const result = await db.collection("coupangAdd").find().toArray();
-    const fields = result[0]
-      ? Object.keys(result[0]).filter((k) => k !== "_id")
-      : [];
-    res.render("coupangAdd.ejs", {
-      결과: result,
-      필드: fields,
-      성공메시지: "✅ 업로드 완료",
-    });
-  } catch (err) {
-    console.error("업로드 실패:", err);
-    res.status(500).send("❌ 업로드 실패");
-  }
-});
-
-// ─────────────────────────────────────────
-// 전체 삭제 (POST /coupang/add/delete-all)
-// ─────────────────────────────────────────
-router.post("/delete-all", async (req, res) => {
-  const db = req.app.locals.db;
-  try {
-    await db.collection("coupangAdd").deleteMany({});
-    res.redirect("/coupang/add");
-  } catch (err) {
-    console.error("삭제 실패:", err);
-    res.status(500).send("❌ 삭제 실패");
+    console.error('삭제 실패:', err);
+    res.status(500).send('❌ 삭제 실패');
   }
 });
 

--- a/views/coupangAdd.ejs
+++ b/views/coupangAdd.ejs
@@ -27,7 +27,7 @@
     <% } %>
 
     <div class="action-form mb-4 d-flex gap-2 flex-wrap">
-      <form action="/coupang/add/upload" method="POST" enctype="multipart/form-data" class="d-flex gap-2 flex-nowrap">
+      <form id="uploadForm" action="/coupang/add/upload" method="POST" enctype="multipart/form-data" class="d-flex gap-2 flex-nowrap">
         <input type="file" name="excelFile" accept=".xlsx, .xls" class="form-control" required>
         <button type="submit" class="btn btn-success btn-upload">엑셀 업로드</button>
       </form>
@@ -36,44 +36,22 @@
       </form>
     </div>
 
-    <% if (결과 && 결과.length > 0) { %>
-      <p class="text-muted">🔎 총 <strong><%= 결과.length %></strong>건의 결과가 있습니다.</p>
-    <% } %>
+
 
     <div class="table-responsive">
       <table id="coupangAddTable" class="table table-bordered table-hover bg-white align-middle text-center auto-width">
-        <thead class="table-light text-center">
-          <% if (필드 && 필드.length > 0) { %>
-            <tr>
-              <% 필드.forEach(key => { %>
-                <th><%= key %></th>
-              <% }) %>
-            </tr>
-          <% } else { %>
-            <tr><th>📂 No Data</th></tr>
-          <% } %>
+        <thead class="table-light">
+          <tr>
+            <th>날짜</th>
+            <th>광고집행 옵션ID</th>
+            <th>광고집행 상품명</th>
+            <th>노출수</th>
+            <th>클릭수</th>
+            <th>광고비</th>
+            <th>클릭률</th>
+          </tr>
         </thead>
-        <tbody>
-          <% if (결과 && 결과.length > 0) { %>
-            <% 결과.forEach(row => { %>
-              <tr>
-                <% 필드.forEach(key => { 
-                     const val = row[key];
-                     const numVal = Number(val);
-                     const isNum = !isNaN(numVal) && val !== '' && val !== null;
-                %>
-                  <td>
-                    <%= isNum ? (numVal === 0 ? '-' : numVal.toLocaleString('ko-KR')) : (val || '-') %>
-                  </td>
-                <% }) %>
-              </tr>
-            <% }) %>
-          <% } else { %>
-            <tr>
-              <td colspan="100%" class="text-center text-muted">📭 데이터가 없습니다.</td>
-            </tr>
-          <% } %>
-        </tbody>
+        <tbody></tbody>
       </table>
     </div>
   </div>
@@ -82,21 +60,7 @@
   <script src="https://cdn.datatables.net/1.13.6/js/jquery.dataTables.min.js"></script>
   <script src="https://cdn.datatables.net/1.13.6/js/dataTables.bootstrap5.min.js"></script>
 
-  <% if (결과 && 결과.length > 0) { %>
-  <script>
-    $(function () {
-      $('#coupangAddTable').DataTable({
-        ordering: true,
-        order: [[0, 'asc']],
-        lengthChange: false,
-        paging: true,
-        pageLength: 50,
-        searching: false,
-        info: false
-      });
-    });
-  </script>
-  <% } %>
+  <script src="/js/coupangAdd.js"></script>
 
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.6/dist/js/bootstrap.bundle.min.js"></script>
 </body>


### PR DESCRIPTION
## Summary
- create `coupangAddController` with DataTables API and upload helpers
- expose `/api/coupang-add` routes
- refactor web routes to use controller
- rebuild `coupangAdd.ejs` to load data via AJAX
- add new client script for coupangAdd table

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6854fb6560bc8329a8f72cb7c806d5aa