### PR TITLE
Add order quantity calculator

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,3 +35,16 @@ Routes are organized under the `routes/` directory. `server.js` mounts two route
 
 This layout keeps API and web routes separate while avoiding an extra routing layer.
 
+
+## Order quantity calculator
+
+The script `scripts/calc_order_qty.js` merges ad and inventory Excel files to
+calculate recommended order quantities. Usage:
+
+```bash
+node scripts/calc_order_qty.js <ad_excel> <inventory_excel> [output.xlsx]
+```
+
+The algorithm derives average daily sales from recent conversions, applies an
+ad spend multiplier, and subtracts current stock to determine how many units
+to reorder.

--- a/lib/calcOrderQty.js
+++ b/lib/calcOrderQty.js
@@ -1,0 +1,71 @@
+const xlsx = require('xlsx');
+
+function readFirstSheet(filePath) {
+  const workbook = xlsx.readFile(filePath);
+  const sheet = workbook.Sheets[workbook.SheetNames[0]];
+  return xlsx.utils.sheet_to_json(sheet, { defval: null });
+}
+
+function toNumber(val) {
+  const num = Number(String(val).replace(/,/g, ''));
+  return isNaN(num) ? 0 : num;
+}
+
+function compute(adPath, inventoryPath, options = {}) {
+  const leadTime = options.leadTimeDays || 7;
+  const safetyStock = options.safetyStock || 20;
+
+  const adRows = readFirstSheet(adPath);
+  const invRows = readFirstSheet(inventoryPath);
+
+  const adMap = new Map();
+  for (const row of adRows) {
+    const id = row['광고집행 옵션ID'] || row['option_id'] || row['Option ID'];
+    if (!id) continue;
+    const clicks = toNumber(row['클릭수']);
+    const cpc = toNumber(row['클릭당 단가'] || row['CPC'] || row['클릭당단가']);
+    const conversions = toNumber(row['전환수']);
+    const spend = clicks * cpc;
+
+    if (!adMap.has(id)) adMap.set(id, { option_id: id, clicks: 0, conversions: 0, spend: 0 });
+    const agg = adMap.get(id);
+    agg.clicks += clicks;
+    agg.conversions += conversions;
+    agg.spend += spend;
+  }
+
+  const invMap = new Map();
+  for (const row of invRows) {
+    const id = row['Option ID'] || row['option_id'] || row['옵션ID'] || row['광고집행 옵션ID'];
+    if (!id) continue;
+    invMap.set(id, row);
+  }
+
+  const results = [];
+  for (const [id, info] of adMap.entries()) {
+    const avgDaily = info.conversions / 7;
+    const demandMultiplier = Math.min(2.0, 1 + info.spend / 10000);
+    const adjusted = avgDaily * demandMultiplier;
+    const required = adjusted * leadTime + safetyStock;
+
+    const inv = invMap.get(id) || {};
+    const stock = toNumber(inv['Orderable quantity (real-time)'] || inv['현재 출고 가능 수량']);
+    const inbound = toNumber(inv['Pending inbounds (real-time)'] || inv['입고 예정 수량']);
+    const returns = toNumber(inv['Customer returns last 30 days (D-1)'] || inv['최근 반품 수량']);
+    const available = stock + inbound - returns;
+    const orderQty = Math.max(0, Math.ceil(required - available));
+
+    results.push({
+      option_id: id,
+      avg_daily_sales: Number(avgDaily.toFixed(2)),
+      demand_multiplier: Number(demandMultiplier.toFixed(2)),
+      required_stock: Math.ceil(required),
+      available_stock: available,
+      order_qty: orderQty,
+    });
+  }
+
+  return results;
+}
+
+module.exports = compute;

--- a/scripts/calc_order_qty.js
+++ b/scripts/calc_order_qty.js
@@ -1,0 +1,22 @@
+#!/usr/bin/env node
+const fs = require('fs');
+const path = require('path');
+const compute = require('../lib/calcOrderQty');
+const xlsx = require('xlsx');
+
+const [adFile, invFile, outFile] = process.argv.slice(2);
+if (!adFile || !invFile) {
+  console.error('Usage: node calc_order_qty.js <ad_excel> <inventory_excel> [out_excel]');
+  process.exit(1);
+}
+
+const results = compute(adFile, invFile);
+if (outFile) {
+  const ws = xlsx.utils.json_to_sheet(results);
+  const wb = xlsx.utils.book_new();
+  xlsx.utils.book_append_sheet(wb, ws, 'orders');
+  xlsx.writeFile(wb, outFile);
+  console.log('Saved', outFile);
+} else {
+  console.log(JSON.stringify(results, null, 2));
+}

--- a/tests/calcOrderQty.test.js
+++ b/tests/calcOrderQty.test.js
@@ -1,0 +1,40 @@
+const fs = require('fs');
+const path = require('path');
+const xlsx = require('xlsx');
+const compute = require('../lib/calcOrderQty');
+
+test('compute order quantity from sample excels', () => {
+  const tmpDir = path.join(__dirname, 'fixtures');
+  const adPath = path.join(tmpDir, 'ad_tmp.xlsx');
+  const invPath = path.join(tmpDir, 'inv_tmp.xlsx');
+
+  const adData = [
+    { '광고집행 옵션ID': '123', 클릭수: 10, '클릭당 단가': 100, 전환수: 7 },
+    { '광고집행 옵션ID': '123', 클릭수: 5, '클릭당 단가': 100, 전환수: 0 },
+  ];
+  const wbAd = xlsx.utils.book_new();
+  xlsx.utils.book_append_sheet(wbAd, xlsx.utils.json_to_sheet(adData), 'Sheet1');
+  xlsx.writeFile(wbAd, adPath);
+
+  const invData = [
+    {
+      'Option ID': '123',
+      'Orderable quantity (real-time)': 5,
+      'Pending inbounds (real-time)': 10,
+      'Customer returns last 30 days (D-1)': 0,
+    },
+  ];
+  const wbInv = xlsx.utils.book_new();
+  xlsx.utils.book_append_sheet(wbInv, xlsx.utils.json_to_sheet(invData), 'Sheet1');
+  xlsx.writeFile(wbInv, invPath);
+
+  const result = compute(adPath, invPath);
+  expect(result).toHaveLength(1);
+  const item = result[0];
+  expect(item.option_id).toBe('123');
+  expect(item.order_qty).toBe(14);
+  expect(item.required_stock).toBe(29);
+
+  fs.unlinkSync(adPath);
+  fs.unlinkSync(invPath);
+});


### PR DESCRIPTION
## Summary
- implement order quantity calculator library `calcOrderQty.js`
- expose CLI script `calc_order_qty.js`
- add jest test and document usage in README

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685503b9594c8329b47ede9f70b5b12b