### PR TITLE
Format coupang add numbers

### DIFF
--- a/controllers/coupangAddController.js
+++ b/controllers/coupangAddController.js
@@ -51,7 +51,17 @@ exports.uploadExcel = asyncHandler(async (req, res) => {
   const filePath = req.file.path;
   const workbook = xlsx.readFile(filePath, { cellDates: true });
   const sheetName = workbook.SheetNames[0];
-  const data = xlsx.utils.sheet_to_json(workbook.Sheets[sheetName]);
+  const raw = xlsx.utils.sheet_to_json(workbook.Sheets[sheetName]);
+  const numericFields = ['노출수', '클릭수', '광고비', '클릭률'];
+  const data = raw.map(row => {
+    numericFields.forEach(f => {
+      if (row[f] !== undefined && row[f] !== null && row[f] !== '') {
+        const num = Number(String(row[f]).replace(/[^0-9.-]/g, ''));
+        row[f] = f === '클릭률' ? Number(num.toFixed(2)) : num;
+      }
+    });
+    return row;
+  });
 
   const db = req.app.locals.db;
   await db.collection('coupangAdd').deleteMany({});
@@ -70,7 +80,17 @@ exports.uploadExcelApi = asyncHandler(async (req, res) => {
   const filePath = req.file.path;
   const workbook = xlsx.readFile(filePath, { cellDates: true });
   const sheetName = workbook.SheetNames[0];
-  const data = xlsx.utils.sheet_to_json(workbook.Sheets[sheetName]);
+  const raw = xlsx.utils.sheet_to_json(workbook.Sheets[sheetName]);
+  const numericFields = ['노출수', '클릭수', '광고비', '클릭률'];
+  const data = raw.map(row => {
+    numericFields.forEach(f => {
+      if (row[f] !== undefined && row[f] !== null && row[f] !== '') {
+        const num = Number(String(row[f]).replace(/[^0-9.-]/g, ''));
+        row[f] = f === '클릭률' ? Number(num.toFixed(2)) : num;
+      }
+    });
+    return row;
+  });
 
   const db = req.app.locals.db;
   await db.collection('coupangAdd').deleteMany({});

--- a/public/js/coupangAdd.js
+++ b/public/js/coupangAdd.js
@@ -11,7 +11,11 @@ $(function () {
     pageLength: 50,
     lengthChange: false,
     order: [[0, 'asc']],
-    columnDefs: [{ targets: '_all', className: 'text-center' }],
+    columnDefs: [
+      { targets: '_all', className: 'text-center' },
+      { targets: [3, 4, 5], render: $.fn.dataTable.render.number(',', '.', 0) },
+      { targets: 6, render: (data) => parseFloat(data).toFixed(2) },
+    ],
     ajax: {
       url: '/api/coupang-add',
       type: 'GET',


### PR DESCRIPTION
## Summary
- parse Excel numeric fields when uploading Coupang ads
- show numeric columns with proper formatting in DataTables

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855078b2b208329bf96e52b86ee720f