### PR TITLE
Add daily weather page

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,3 +5,4 @@ S3_KEY=your-s3-key
 S3_SECRET=your-s3-secret
 S3_REGION=your-s3-region
 S3_BUCKET_NAME=your-bucket
+WEATHER_API_KEY=your-weather-api-key

--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ This project requires several environment variables to run:
 - `S3_BUCKET_NAME` – Name of the S3 bucket used for uploads. The server will
   automatically create this bucket if it does not exist (your AWS credentials
   must allow bucket creation).
+- `WEATHER_API_KEY` – API key from the Korean Meteorological Administration used
+  to fetch daily weather data.
 
 Copy `.env.example` to `.env` in the project root and define these values before starting the server. Make sure the file is saved as **UTF-8 without BOM** so that `dotenv` can read it correctly.
 
@@ -35,3 +37,54 @@ Routes are organized under the `routes/` directory. `server.js` mounts two route
 
 This layout keeps API and web routes separate while avoiding an extra routing layer.
 
+## Weather integration
+
+The project exposes `/api/weather/daily` which fetches forecast data from the
+Korean Meteorological Administration using `WEATHER_API_KEY`. An accompanying
+`/weather` page displays the information via AJAX.
+
+Server-side requests use `node-fetch`, which is listed in `package.json`.
+
+
+## Weather API details
+
+The weather data is sourced from the [Korean Meteorological Administration (기상청) 초단기예보 API](https://data.go.kr/iim/api/selectAPIAcountView.do#).
+
+### API Endpoint
+https://apis.data.go.kr/1360000/VilageFcstInfoService_2.0
+
+### Authentication Keys
+
+Two versions of the API key are provided:
+
+- **Encoding key**: Use this version when placing the key directly into the URL.
+- **Decoding key**: Use this when passing via `params` or using a library that handles encoding.
+
+> Your actual key values can be found in the developer portal at https://data.go.kr
+
+### Example usage with axios
+
+```js
+const axios = require("axios");
+const qs = require("qs");
+
+const fetchWeather = async () => {
+  const params = {
+    serviceKey: process.env.WEATHER_API_KEY, // must be URL encoded
+    pageNo: "1",
+    numOfRows: "1000",
+    dataType: "JSON",
+    base_date: "20240620",
+    base_time: "1200",
+    nx: "60",
+    ny: "127"
+  };
+
+  const url = `https://apis.data.go.kr/1360000/VilageFcstInfoService_2.0/getUltraSrtFcst?${qs.stringify(params)}`;
+
+  const { data } = await axios.get(url);
+  console.log(data);
+};
+
+fetchWeather();
+```

--- a/controllers/weatherController.js
+++ b/controllers/weatherController.js
@@ -1,0 +1,45 @@
+const fetch = require('node-fetch');
+const asyncHandler = require('../middlewares/asyncHandler');
+
+// Fetch daily weather from KMA API
+exports.getDailyWeather = asyncHandler(async (req, res) => {
+  const baseDate =
+    req.query.date || new Date().toISOString().slice(0, 10).replace(/-/g, '');
+  const baseTime = req.query.time || '1200';
+  const nx = req.query.nx || '60';
+  const ny = req.query.ny || '127';
+  const serviceKey = encodeURIComponent(process.env.WEATHER_API_KEY || '');
+
+  const params = new URLSearchParams({
+    serviceKey,
+    pageNo: '1',
+    numOfRows: '1000',
+    dataType: 'JSON',
+    base_date: baseDate,
+    base_time: baseTime,
+    nx,
+    ny,
+  });
+
+  const url = `https://apis.data.go.kr/1360000/VilageFcstInfoService_2.0/getUltraSrtFcst?${params}`;
+
+  const response = await fetch(url);
+  if (!response.ok) {
+    throw new Error(`Weather API error: ${response.status}`);
+  }
+  let data;
+  try {
+    data = await response.json();
+  } catch (err) {
+    const text = await response.text();
+    throw new Error(`Invalid JSON: ${text.slice(0, 100)}`);
+  }
+  const items = data?.response?.body?.items?.item || [];
+  const findVal = (cat) => items.find((i) => i.category === cat)?.fcstValue;
+
+  res.json({
+    temperature: findVal('T1H'),
+    sky: findVal('SKY'),
+    precipitationType: findVal('PTY'),
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,6 +38,7 @@
         "nodemailer": "^7.0.3",
         "passport": "^0.7.0",
         "passport-local": "^1.0.0",
+        "node-fetch": "^2.7.0",
         "tesseract.js": "^4.1.4",
         "xlsx": "^0.18.5"
       },

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "nodemailer": "^7.0.3",
     "passport": "^0.7.0",
     "passport-local": "^1.0.0",
+    "node-fetch": "^2.7.0",
     "tesseract.js": "^4.1.4",
     "xlsx": "^0.18.5"
   },

--- a/public/js/weather.js
+++ b/public/js/weather.js
@@ -1,0 +1,13 @@
+$(async function () {
+  try {
+    const res = await fetch('/api/weather/daily');
+    const data = await res.json();
+    const skyMap = { '1': '맑음', '3': '구름많음', '4': '흐림' };
+    const ptyMap = { '0': '없음', '1': '비', '2': '비/눈', '3': '눈', '4': '소나기' };
+    $('#weatherBody').html(
+      `<tr><td>${data.temperature ?? '-'}</td><td>${skyMap[data.sky] ?? data.sky ?? '-'}</td><td>${ptyMap[data.precipitationType] ?? data.precipitationType ?? '-'}</td></tr>`
+    );
+  } catch (e) {
+    $('#weatherBody').html('<tr><td colspan="3">데이터 없음</td></tr>');
+  }
+});

--- a/routes/api/index.js
+++ b/routes/api/index.js
@@ -14,6 +14,8 @@ router.use("/stock", require("./stockApi"));
 router.use("/coupang", require("./coupangApi"));
 // 쿠팡 광고비 API
 router.use("/coupang-add", require("./coupangAddApi"));
+// 날씨 API
+router.use("/weather", require("./weatherApi"));
 
 // TODO: 다른 API 라우터 추가 시 아래와 같이 등록
 // router.use("/user", require("./userApi"));

--- a/routes/api/weatherApi.js
+++ b/routes/api/weatherApi.js
@@ -1,0 +1,7 @@
+const express = require('express');
+const router = express.Router();
+const ctrl = require('../../controllers/weatherController');
+
+router.get('/daily', ctrl.getDailyWeather);
+
+module.exports = router;

--- a/routes/web/weather.js
+++ b/routes/web/weather.js
@@ -1,0 +1,9 @@
+const express = require('express');
+const router = express.Router();
+const { checkAuth } = require('../../middlewares/auth');
+
+router.get('/', checkAuth, (req, res) => {
+  res.render('weather');
+});
+
+module.exports = router;

--- a/tests/weatherApi.test.js
+++ b/tests/weatherApi.test.js
@@ -1,0 +1,58 @@
+jest.setTimeout(60000);
+
+jest.mock('../config/db', () => {
+  const mockDb = { collection: jest.fn() };
+  const mockConnect = jest.fn().mockResolvedValue(mockDb);
+  mockConnect.then = (fn) => fn(mockDb);
+  return { connectDB: mockConnect, closeDB: jest.fn().mockResolvedValue() };
+});
+
+jest.mock('node-fetch');
+const mockFetch = require('node-fetch');
+
+const request = require('supertest');
+const { initApp } = require('../server');
+const { closeDB } = require('../config/db');
+
+let app;
+
+beforeAll(async () => {
+  process.env.NODE_ENV = 'test';
+  process.env.MONGO_URI = 'mongodb://127.0.0.1:27017/testdb';
+  process.env.DB_NAME = 'testdb';
+  process.env.SESSION_SECRET = 'testsecret';
+  process.env.WEATHER_API_KEY = 'testkey';
+
+  mockFetch.mockResolvedValue({
+    ok: true,
+    json: async () => ({
+      response: {
+        body: {
+          items: {
+            item: [
+              { category: 'T1H', fcstValue: '20' },
+              { category: 'SKY', fcstValue: '1' },
+              { category: 'PTY', fcstValue: '0' },
+            ],
+          },
+        },
+      },
+    }),
+  });
+
+  app = await initApp();
+});
+
+afterAll(async () => {
+  await closeDB();
+});
+
+test('GET /api/weather/daily returns parsed weather data', async () => {
+  const res = await request(app).get('/api/weather/daily');
+  expect(res.statusCode).toBe(200);
+  expect(res.body).toEqual({
+    temperature: '20',
+    sky: '1',
+    precipitationType: '0',
+  });
+});

--- a/views/nav.ejs
+++ b/views/nav.ejs
@@ -33,6 +33,9 @@
               <a class="nav-link text-dark <%= currentUrl.startsWith('/coupang/add') ? 'active' : '' %>" href="/coupang/add">💰 매출/광고비</a>
             </li>
             <li class="nav-item">
+              <a class="nav-link text-dark <%= currentUrl.startsWith('/weather') ? 'active' : '' %>" href="/weather">🌤️ 날씨</a>
+            </li>
+            <li class="nav-item">
               <a class="nav-link text-dark <%= currentUrl.startsWith('/voucher') ? 'active' : '' %>" href="/voucher">📝 전표입력</a>
             </li>
             <li class="nav-item">

--- a/views/weather.ejs
+++ b/views/weather.ejs
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+  <meta charset="UTF-8">
+  <title>날씨 정보</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.6/dist/css/bootstrap.min.css" rel="stylesheet">
+  <link rel="stylesheet" href="/main.css">
+</head>
+<body class="bg-light">
+  <%- include('nav.ejs') %>
+
+  <div class="container my-5">
+    <h2 class="fw-bold mb-4">🌤️ 날씨 정보</h2>
+    <table class="table table-bordered bg-white text-center">
+      <thead class="table-light">
+        <tr>
+          <th>기온(℃)</th>
+          <th>하늘상태</th>
+          <th>강수형태</th>
+        </tr>
+      </thead>
+      <tbody id="weatherBody">
+        <tr>
+          <td colspan="3">Loading...</td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+
+  <script src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.6/dist/js/bootstrap.bundle.min.js"></script>
+  <script src="/js/weather.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- document WEATHER_API_KEY usage in README
- sample WEATHER_API_KEY in `.env.example`
- implement weather controller and API
- expose `/weather` page and nav link
- add supertest for new endpoint
- remove unused axios dependency
- add weather API details in README
- fix weather API handler

## Testing
- `npm test` *(fails: `jest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6854fd6d7b008329843ebd10f129eef0