### PR TITLE
Adjust mobile nav look

### DIFF
--- a/public/main.css
+++ b/public/main.css
@@ -215,3 +215,20 @@ table.auto-width {
   background-color: #0d6efd;
   border-color: #0d6efd;
 }
+
+/* Mobile navigation customizations */
+@media (max-width: 575.98px) {
+  .custom-toggler {
+    border: none;
+    padding: 0.5rem 0.75rem;
+  }
+
+  .custom-toggler .navbar-toggler-icon {
+    width: 1.6rem;
+    height: 1.6rem;
+  }
+
+  .offcanvas.menu-fit-content {
+    --bs-offcanvas-width: max-content;
+  }
+}

--- a/views/nav.ejs
+++ b/views/nav.ejs
@@ -8,11 +8,11 @@
       <% } %>
     </a>
 
-    <button class="navbar-toggler" type="button" data-bs-toggle="offcanvas" data-bs-target="#navbarOffcanvas">
+    <button class="navbar-toggler custom-toggler" type="button" data-bs-toggle="offcanvas" data-bs-target="#navbarOffcanvas">
       <span class="navbar-toggler-icon"></span>
     </button>
 
-    <div class="offcanvas offcanvas-start" tabindex="-1" id="navbarOffcanvas">
+    <div class="offcanvas offcanvas-start menu-fit-content" tabindex="-1" id="navbarOffcanvas">
       <div class="offcanvas-header">
         <h5 class="offcanvas-title">Menu</h5>
         <button type="button" class="btn-close" data-bs-dismiss="offcanvas"></button>


### PR DESCRIPTION
## Summary
- tweak navbar toggler and offcanvas design
- add responsive CSS for bigger hamburger button and fit-content menu

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: cannot find @eslint/js)*

------
https://chatgpt.com/codex/tasks/task_e_685532e950bc8329a93ccb13eb03aa3d