### PR TITLE
Implement shortage prediction algorithm

### DIFF
--- a/lib/calcOrderQty.js
+++ b/lib/calcOrderQty.js
@@ -12,8 +12,9 @@ function toNumber(val) {
 }
 
 function compute(adPath, inventoryPath, options = {}) {
-  const leadTime = options.leadTimeDays || 7;
-  const safetyStock = options.safetyStock || 20;
+  const leadTime = options.leadTimeDays || 5; // 주문→입고까지 걸리는 일수
+  const safetyDays = options.safetyDays || 3; // 안전재고 일수
+  const adRate = options.adRate || 0.2; // 기본 광고 기여율
 
   const adRows = readFirstSheet(adPath);
   const invRows = readFirstSheet(inventoryPath);
@@ -41,27 +42,41 @@ function compute(adPath, inventoryPath, options = {}) {
     invMap.set(id, row);
   }
 
+  const allIds = new Set([...invMap.keys(), ...adMap.keys()]);
   const results = [];
-  for (const [id, info] of adMap.entries()) {
-    const avgDaily = info.conversions / 7;
-    const demandMultiplier = Math.min(2.0, 1 + info.spend / 10000);
-    const adjusted = avgDaily * demandMultiplier;
-    const required = adjusted * leadTime + safetyStock;
 
+  for (const id of allIds) {
+    const adInfo = adMap.get(id) || { clicks: 0 };
     const inv = invMap.get(id) || {};
-    const stock = toNumber(inv['Orderable quantity (real-time)'] || inv['현재 출고 가능 수량']);
-    const inbound = toNumber(inv['Pending inbounds (real-time)'] || inv['입고 예정 수량']);
-    const returns = toNumber(inv['Customer returns last 30 days (D-1)'] || inv['최근 반품 수량']);
-    const available = stock + inbound - returns;
-    const orderQty = Math.max(0, Math.ceil(required - available));
+
+    // 판매량: 우선 최근 7일, 없으면 최근 30일 기준
+    const sales7 = toNumber(inv['최근 7일 판매량'] || inv['최근7일 판매량']);
+    const sales30 = toNumber(inv['최근 30일 판매량'] || inv['Sales in the last 30 days']);
+    const dailySales = sales7 > 0 ? sales7 / 7 : sales30 / 30;
+
+    const adjustedDaily = dailySales * (1 + (adInfo.clicks > 0 ? adRate : 0));
+
+    const stock = toNumber(
+      inv['Orderable quantity (real-time)'] ||
+        inv['현재 출고 가능 수량'] ||
+        inv['현재고']
+    );
+    const inbound = toNumber(inv['Pending inbounds (real-time)'] || inv['입고 예정 수량'] || inv['입고 예정']);
+
+    const daysToOOS = adjustedDaily > 0 ? stock / adjustedDaily : Infinity;
+    const orderPoint = leadTime + safetyDays;
+
+    const required = adjustedDaily * orderPoint;
+    const shortage = Math.max(0, Math.ceil(required - stock - inbound));
 
     results.push({
       option_id: id,
-      avg_daily_sales: Number(avgDaily.toFixed(2)),
-      demand_multiplier: Number(demandMultiplier.toFixed(2)),
+      daily_sales: Number(dailySales.toFixed(2)),
+      adjusted_daily_sales: Number(adjustedDaily.toFixed(2)),
+      days_to_oos: Number(daysToOOS.toFixed(2)),
       required_stock: Math.ceil(required),
-      available_stock: available,
-      order_qty: orderQty,
+      shortage_qty: shortage,
+      order_needed: daysToOOS < orderPoint,
     });
   }
 

--- a/tests/calcOrderQty.test.js
+++ b/tests/calcOrderQty.test.js
@@ -3,14 +3,13 @@ const path = require('path');
 const xlsx = require('xlsx');
 const compute = require('../lib/calcOrderQty');
 
-test('compute order quantity from sample excels', () => {
+test('compute shortage calculation from sample excels', () => {
   const tmpDir = path.join(__dirname, 'fixtures');
   const adPath = path.join(tmpDir, 'ad_tmp.xlsx');
   const invPath = path.join(tmpDir, 'inv_tmp.xlsx');
 
   const adData = [
-    { '광고집행 옵션ID': '123', 클릭수: 10, '클릭당 단가': 100, 전환수: 7 },
-    { '광고집행 옵션ID': '123', 클릭수: 5, '클릭당 단가': 100, 전환수: 0 },
+    { '광고집행 옵션ID': 'A123', 클릭수: 10 },
   ];
   const wbAd = xlsx.utils.book_new();
   xlsx.utils.book_append_sheet(wbAd, xlsx.utils.json_to_sheet(adData), 'Sheet1');
@@ -18,22 +17,23 @@ test('compute order quantity from sample excels', () => {
 
   const invData = [
     {
-      'Option ID': '123',
+      'Option ID': 'A123',
+      '최근 7일 판매량': 21,
       'Orderable quantity (real-time)': 5,
-      'Pending inbounds (real-time)': 10,
-      'Customer returns last 30 days (D-1)': 0,
+      'Pending inbounds (real-time)': 0,
     },
   ];
   const wbInv = xlsx.utils.book_new();
   xlsx.utils.book_append_sheet(wbInv, xlsx.utils.json_to_sheet(invData), 'Sheet1');
   xlsx.writeFile(wbInv, invPath);
 
-  const result = compute(adPath, invPath);
+  const result = compute(adPath, invPath, { leadTimeDays: 5, safetyDays: 3, adRate: 0.2 });
   expect(result).toHaveLength(1);
   const item = result[0];
-  expect(item.option_id).toBe('123');
-  expect(item.order_qty).toBe(14);
-  expect(item.required_stock).toBe(29);
+  expect(item.option_id).toBe('A123');
+  expect(item.shortage_qty).toBe(24);
+  expect(item.days_to_oos).toBeCloseTo(1.39, 2);
+
 
   fs.unlinkSync(adPath);
   fs.unlinkSync(invPath);


### PR DESCRIPTION
## Summary
- expand `calcOrderQty` with safety days and advertising factor
- calculate days to stockout and shortage quantity
- update unit test for new algorithm

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: cannot find @eslint/js)*

------
https://chatgpt.com/codex/tasks/task_e_6855342745ac8329a9aad3f1aa8faabb