### PR TITLE
Implement stock table visual tweaks

### DIFF
--- a/public/js/stock.js
+++ b/public/js/stock.js
@@ -1,4 +1,18 @@
 // public/js/stock.js
+
+function getStockIcon(qty) {
+  if (qty < 5) return '🔴';
+  else if (qty < 20) return '🟡';
+  return '🟢';
+}
+
+function getBrandBadge(code) {
+  if (typeof code === 'string' && code.startsWith('TD')) {
+    return '<span class="badge badge-try">TRY</span>';
+  }
+  return '';
+}
+
 $(document).ready(function () {
   // DataTable 초기화
   const table = $("#stockTable").DataTable({
@@ -19,11 +33,33 @@ $(document).ready(function () {
         }
       },
       {
+        targets: 1,
+        render: function (data) {
+          return data + ' ' + getBrandBadge(data);
+        }
+      },
+      {
+        targets: 5,
+        createdCell: function (td, cellData) {
+          $(td).addClass(cellData < 10 ? 'low-stock' : 'high-stock');
+        },
+        render: function (data) {
+          return getStockIcon(data) + ' ' + data;
+        }
+      },
+      {
         targets: 8,
         render: function (data) {
           if (!data) return '';
           const d = new Date(data);
-          return d.toLocaleString('ko-KR');
+          return d.toLocaleString('ko-KR', {
+            year: 'numeric',
+            month: '2-digit',
+            day: '2-digit',
+            hour: '2-digit',
+            minute: '2-digit',
+            hour12: false,
+          });
         }
       }
     ],
@@ -83,5 +119,4 @@ $(document).ready(function () {
       },
     });
   });
-
 });

--- a/public/main.css
+++ b/public/main.css
@@ -216,6 +216,42 @@ table.auto-width {
   border-color: #0d6efd;
 }
 
+/* 재고 수량 색상 */
+.low-stock {
+  background-color: #ffe5e5;
+  color: #d8000c;
+  font-weight: bold;
+}
+
+.high-stock {
+  background-color: #e8f5e9;
+  color: #2e7d32;
+}
+
+/* 브랜드 뱃지 */
+.badge-try {
+  background-color: #e3f2fd;
+  color: #1976d2;
+  padding: 0.25rem 0.5rem;
+  border-radius: 5px;
+  font-size: 0.8rem;
+}
+
+/* 테이블 고정 컬럼 */
+.table-container {
+  overflow-x: auto;
+}
+
+th:nth-child(2),
+td:nth-child(2),
+th:nth-child(3),
+td:nth-child(3) {
+  position: sticky;
+  left: 0;
+  background: #fff;
+  z-index: 2;
+}
+
 /* Mobile navigation customizations */
 @media (max-width: 575.98px) {
   .custom-toggler {

--- a/views/stock.ejs
+++ b/views/stock.ejs
@@ -39,7 +39,7 @@
     </div>
 
     <!-- 테이블 -->
-    <div class="table-responsive">
+    <div class="table-responsive table-container">
       <table id="stockTable" class="table table-bordered table-hover bg-white align-middle text-center auto-width">
         <thead class="table-light">
           <tr>


### PR DESCRIPTION
## Summary
- highlight low and high stock amounts
- add brand badges via JS
- format uploaded time and add stock status icons
- keep key stock columns sticky

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685536facda88329bd3472db69a5b154