### PR TITLE
Implement search & pagination on coupang summary

### DIFF
--- a/views/coupangAdd.ejs
+++ b/views/coupangAdd.ejs
@@ -24,6 +24,15 @@
       <p class="mb-0">헤더를 클릭하면 오름차순/내림차순 정렬이 가능하며 50개씩 페이지 이동이 가능합니다.</p>
     </div>
 
+    <% if (mode === 'summary') { %>
+      <form method="GET" class="mb-3 d-flex" action="/coupang/add">
+        <input type="hidden" name="mode" value="summary">
+        <input type="text" name="search" value="<%= search %>" class="form-control me-2" placeholder="상품명 또는 옵션ID 검색">
+        <button class="btn btn-outline-primary">검색</button>
+      </form>
+      <p class="text-end mb-2">총 <%= total %>건의 결과가 있습니다.</p>
+    <% } %>
+
     <% if (typeof 성공메시지 !== 'undefined' && 성공메시지) { %>
       <div class="alert alert-success alert-dismissible fade show" role="alert">
         <%= 성공메시지 %>
@@ -82,6 +91,27 @@
           <tbody></tbody>
         <% } %>
       </table>
+      <% if (mode === 'summary') { %>
+      <nav aria-label="Page navigation">
+        <ul class="pagination justify-content-center">
+          <% if (page > 1) { %>
+            <li class="page-item">
+              <a class="page-link" href="?mode=summary&page=<%= page - 1 %>&search=<%= search %>">◀ 이전</a>
+            </li>
+          <% } %>
+          <% for (let i = 1; i <= totalPages; i++) { %>
+            <li class="page-item <%= i === page ? 'active' : '' %>">
+              <a class="page-link" href="?mode=summary&page=<%= i %>&search=<%= search %>"><%= i %></a>
+            </li>
+          <% } %>
+          <% if (page < totalPages) { %>
+            <li class="page-item">
+              <a class="page-link" href="?mode=summary&page=<%= page + 1 %>&search=<%= search %>">다음 ▶</a>
+            </li>
+          <% } %>
+        </ul>
+      </nav>
+      <% } %>
     </div>
   </div>
 


### PR DESCRIPTION
## Summary
- add keyword search and pagination logic for coupang add summary view
- expose the form and results navigation in `coupangAdd.ejs`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68553fca563c83299428ea682a1b9f69