### PR TITLE
Implement coupang add summary features

### DIFF
--- a/views/coupang-add-summary.ejs
+++ b/views/coupang-add-summary.ejs
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+  <meta charset="UTF-8">
+  <title>쿠팡 광고 요약</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.6/dist/css/bootstrap.min.css" rel="stylesheet">
+  <link rel="stylesheet" href="/main.css">
+</head>
+<body class="bg-light">
+  <%- include('nav.ejs') %>
+
+  <div class="container my-5">
+    <h2 class="mb-4 fw-bold">🛒 쿠팡 광고 요약</h2>
+
+    <form method="get" class="d-flex align-items-center mb-3">
+      <input name="search" class="form-control me-2" style="max-width: 250px;" value="<%= search %>" placeholder="상품명 또는 옵션ID 검색">
+      <select name="brand" class="form-select me-2" style="max-width: 150px;">
+        <option value="">전체 브랜드</option>
+        <option value="트라이" <%= brand === '트라이' ? 'selected' : '' %>>트라이</option>
+        <option value="BYC" <%= brand === 'BYC' ? 'selected' : '' %>>BYC</option>
+        <option value="비비안" <%= brand === '비비안' ? 'selected' : '' %>>비비안</option>
+      </select>
+      <button class="btn btn-outline-primary">검색</button>
+    </form>
+
+    <table class="table table-bordered table-hover text-center">
+      <thead>
+        <tr>
+          <th>번호</th>
+          <th>상품명</th>
+          <th><a href="?sort=impressions&order=<%= sortOrder === 1 ? 'desc' : 'asc' %>">노출수 합</a></th>
+          <th><a href="?sort=clicks&order=<%= sortOrder === 1 ? 'desc' : 'asc' %>">클릭수 합</a></th>
+          <th><a href="?sort=adCost&order=<%= sortOrder === 1 ? 'desc' : 'asc' %>">광고비 합</a></th>
+          <th><a href="?sort=ctr&order=<%= sortOrder === 1 ? 'desc' : 'asc' %>">클릭률</a></th>
+        </tr>
+      </thead>
+      <tbody>
+        <% list.forEach(item => { %>
+          <tr>
+            <td><%= item.no %></td>
+            <td><%= item.name %></td>
+            <td><%= item.impressions.toLocaleString() %></td>
+            <td><%= item.clicks.toLocaleString() %></td>
+            <td><%= item.adCost.toLocaleString() %></td>
+            <td><%= item.ctr %>%</td>
+          </tr>
+        <% }) %>
+      </tbody>
+    </table>
+  </div>
+
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.6/dist/js/bootstrap.bundle.min.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- truncate product names at comma
- implement sorting, searching, and brand filter for `?mode=summary`
- render new `coupang-add-summary` view

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: cannot find @eslint/js)*

------
https://chatgpt.com/codex/tasks/task_e_68554a6c30388329872a20167b46a2ef