### PR TITLE
Enhance Coupang inventory view

### DIFF
--- a/public/js/coupang.js
+++ b/public/js/coupang.js
@@ -1,6 +1,21 @@
 $(function () {
   if (!$('#coupangTable').length) return;
-  $('#coupangTable').DataTable({
+  var showReorderOnly = false;
+
+  var reorderFilter = function (settings, data, dataIndex) {
+    if (settings.nTable.id !== 'coupangTable') return true;
+    if (!showReorderOnly) return true;
+    var api = new $.fn.dataTable.Api(settings);
+    var row = $(api.row(dataIndex).node());
+    var shortage = Number(row.data('shortage')) || 0;
+    var sales = Number(row.data('sales')) || 0;
+    var stock = Number(row.data('stock')) || 0;
+    return shortage > 0 || (sales > 0 && stock === 0);
+  };
+
+  $.fn.dataTable.ext.search.push(reorderFilter);
+
+  var table = $('#coupangTable').DataTable({
     ordering: true,
     order: [[1, 'asc']],
     columnDefs: [{ targets: 0, orderable: false }],
@@ -15,5 +30,39 @@ $(function () {
       info: '총 _TOTAL_건 중 _START_ ~ _END_',
       infoEmpty: '데이터가 없습니다'
     }
+  });
+
+
+  $('#btn-filter-reorder').on('click', function () {
+    showReorderOnly = !showReorderOnly;
+    $(this).text(showReorderOnly ? '전체 보기' : '입고 필요만 보기');
+    table.draw();
+  });
+
+  $('#btn-download-csv').on('click', function () {
+    var rows = [];
+    table.rows().every(function (rowIdx) {
+      var node = $(this.node());
+      var shortage = Number(node.data('shortage')) || 0;
+      var sales = Number(node.data('sales')) || 0;
+      var stock = Number(node.data('stock')) || 0;
+      if (shortage > 0 || (sales > 0 && stock === 0)) {
+        var data = this.data();
+        var text = $(this.node()).find('td').map(function(){return $(this).text().trim().replace(/,/g,'');}).get().slice(1);
+        rows.push(text.join(','));
+      }
+    });
+    if (!rows.length) {
+      alert('입고 필요 항목이 없습니다.');
+      return;
+    }
+    var csv = rows.join('\n');
+    var blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' });
+    var link = document.createElement('a');
+    link.href = URL.createObjectURL(blob);
+    link.download = 'reorder.csv';
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
   });
 });

--- a/public/main.css
+++ b/public/main.css
@@ -268,3 +268,21 @@ td:nth-child(3) {
     --bs-offcanvas-width: max-content;
   }
 }
+
+/* Row highlight styles for inventory status */
+.row-danger {
+  background-color: #fff3f3;
+  color: #c62828;
+  font-weight: bold;
+}
+
+.row-warning {
+  background-color: #fffde7;
+  color: #f9a825;
+}
+
+.row-muted {
+  background-color: #f4f6f8;
+  color: #9e9e9e;
+  font-style: italic;
+}

--- a/views/coupang.ejs
+++ b/views/coupang.ejs
@@ -72,6 +72,14 @@
 
     <% if (결과 && 결과.length > 0) { %>
       <p class="text-muted">🔎 총 <strong><%= 결과.length %></strong>건의 결과가 있습니다.</p>
+      <% let reorderCount = 0; 결과.forEach(item => { const s = Number(item['Shortage quantity']||0); const sales=Number(item['Sales in the last 30 days']||0); const stock=Number(item['Orderable quantity (real-time)']||0); if (s>0 || (sales>0 && stock===0)) reorderCount++; }); %>
+      <div class="alert alert-warning d-flex justify-content-between align-items-center mb-3">
+        <span>입고 필요 항목: <strong><%= reorderCount %></strong>건</span>
+        <div class="d-flex gap-2">
+          <button id="btn-filter-reorder" class="btn btn-sm btn-outline-danger">입고 필요만 보기</button>
+          <button id="btn-download-csv" class="btn btn-sm btn-outline-success">입고 요청서 다운로드</button>
+        </div>
+      </div>
     <% } %>
 
     <div class="table-responsive">
@@ -91,7 +99,15 @@
         <tbody>
           <% if (결과 && 결과.length > 0) { %>
             <% 결과.forEach((행, index) => { %>
-              <tr>
+              <% const shortage = Number(행['Shortage quantity'] || 0);
+                 const sales30 = Number(행['Sales in the last 30 days'] || 0);
+                 const stock = Number(행['Orderable quantity (real-time)'] || 0);
+                 let rowCls = '';
+                 if (shortage > 0) rowCls = 'row-danger';
+                 else if (sales30 > 0 && stock === 0) rowCls = 'row-warning';
+                 else if (sales30 === 0 && shortage === 0) rowCls = 'row-muted';
+              %>
+              <tr class="<%= rowCls %>" data-shortage="<%= shortage %>" data-sales="<%= sales30 %>" data-stock="<%= stock %>">
                 <td class="text-center"><%= index + 1 %></td>
                 <% 필드.forEach(key => { %>
                   <% if (key === 'Option ID') { %>


### PR DESCRIPTION
## Summary
- highlight rows needing restock with new classes
- show summary banner with filter and download actions
- add filter and CSV export logic on the client
- create CSS styles for highlighted rows
- fix 'reorder only' toggle by registering DataTable filter before init

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68553d41acdc8329847534588d507abb