### PR TITLE
Add summary sort features

### DIFF
--- a/controllers/coupangAddController.js
+++ b/controllers/coupangAddController.js
@@ -25,7 +25,8 @@ exports.renderPage = asyncHandler(async (req, res) => {
 
   const search = req.query.search || '';
   const brand = req.query.brand || '';
-  const sortField = req.query.sort || 'clicks';
+  // 기본 정렬: 노출수 합 내림차순
+  const sortField = req.query.sort || 'impressions';
   const sortOrder = req.query.order === 'asc' ? 1 : -1;
 
   let list = [];
@@ -64,8 +65,9 @@ exports.renderPage = asyncHandler(async (req, res) => {
       list = list.filter((item) => item.name.includes(search));
     }
 
+    // 정렬 방향에 따라 오름차순/내림차순 처리
     list.sort((a, b) => {
-      return sortOrder * ((+b[sortField] || 0) - (+a[sortField] || 0));
+      return sortOrder * ((+a[sortField] || 0) - (+b[sortField] || 0));
     });
 
     return res.render('coupang-add-summary', {

--- a/views/coupang-add-summary.ejs
+++ b/views/coupang-add-summary.ejs
@@ -25,14 +25,30 @@
     </form>
 
     <table class="table table-bordered table-hover text-center">
-      <thead>
+      <thead class="table-primary text-center">
         <tr>
           <th>번호</th>
           <th>상품명</th>
-          <th><a href="?sort=impressions&order=<%= sortOrder === 1 ? 'desc' : 'asc' %>">노출수 합</a></th>
-          <th><a href="?sort=clicks&order=<%= sortOrder === 1 ? 'desc' : 'asc' %>">클릭수 합</a></th>
-          <th><a href="?sort=adCost&order=<%= sortOrder === 1 ? 'desc' : 'asc' %>">광고비 합</a></th>
-          <th><a href="?sort=ctr&order=<%= sortOrder === 1 ? 'desc' : 'asc' %>">클릭률</a></th>
+          <th>
+            <a href="?sort=impressions&order=<%= sortField === 'impressions' && sortOrder === -1 ? 'asc' : 'desc' %>">
+              노출수 합 <%= sortField === 'impressions' ? (sortOrder === -1 ? '🔽' : '🔼') : '' %>
+            </a>
+          </th>
+          <th>
+            <a href="?sort=clicks&order=<%= sortField === 'clicks' && sortOrder === -1 ? 'asc' : 'desc' %>">
+              클릭수 합 <%= sortField === 'clicks' ? (sortOrder === -1 ? '🔽' : '🔼') : '' %>
+            </a>
+          </th>
+          <th>
+            <a href="?sort=adCost&order=<%= sortField === 'adCost' && sortOrder === -1 ? 'asc' : 'desc' %>">
+              광고비 합 <%= sortField === 'adCost' ? (sortOrder === -1 ? '🔽' : '🔼') : '' %>
+            </a>
+          </th>
+          <th>
+            <a href="?sort=ctr&order=<%= sortField === 'ctr' && sortOrder === -1 ? 'asc' : 'desc' %>">
+              클릭률 <%= sortField === 'ctr' ? (sortOrder === -1 ? '🔽' : '🔼') : '' %>
+            </a>
+          </th>
         </tr>
       </thead>
       <tbody>


### PR DESCRIPTION
## Summary
- default sort by `impressions`
- fix sort comparator
- update summary table headers with colors and clickable sort arrows

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855528d78d48329baca6b077e221f8d