### PR TITLE
Add search and Excel export to Coupang Add

### DIFF
--- a/controllers/coupangAddController.js
+++ b/controllers/coupangAddController.js
@@ -92,6 +92,8 @@ exports.getData = asyncHandler(async (req, res) => {
   const draw = parseInt(req.query.draw, 10) || 1;
   const keyword = req.query.search || '';
 
+  const regex = keyword ? new RegExp(keyword, 'i') : null;
+  
   // 기본 정렬 기준
   let sort = { _id: -1 };
 
@@ -108,14 +110,12 @@ exports.getData = asyncHandler(async (req, res) => {
     }
   }
 
-  const query = keyword
-    ? {
-        $or: [
-          { '광고집행 상품명': { $regex: keyword } },
-          { '광고집행 옵션ID': { $regex: keyword } }
-        ]
-      }
-    : {};
+  const query = regex ? {
+    $or: [
+      { '광고집행 상품명': regex },
+      { '광고집행 옵션ID': regex }
+    ]
+  } : {};
 
   const [rows, total] = await Promise.all([
     db
@@ -197,11 +197,12 @@ exports.uploadExcelApi = asyncHandler(async (req, res) => {
 exports.downloadExcel = asyncHandler(async (req, res) => {
   const db = req.app.locals.db;
   const keyword = req.query.search || '';
-  const query = keyword
+  const regex = keyword ? new RegExp(keyword, 'i') : null;
+  const query = regex
     ? {
         $or: [
-          { '광고집행 상품명': { $regex: keyword } },
-          { '광고집행 옵션ID': { $regex: keyword } },
+          { '광고집행 상품명': regex },
+          { '광고집행 옵션ID': regex },
         ],
       }
     : {};

--- a/public/js/coupangAdd.js
+++ b/public/js/coupangAdd.js
@@ -2,6 +2,7 @@ $(function () {
   const $table = $('#coupangAddTable');
   if (!$table.length || $table.data('mode') !== 'detail') return;
 
+  const urlParams = new URLSearchParams(window.location.search);
   const table = $table.DataTable({
     serverSide: true,
     processing: true,
@@ -20,7 +21,8 @@ $(function () {
     ajax: {
       url: '/api/coupang-add',
       type: 'GET',
-      dataSrc: 'data',
+      data: () => ({ search: urlParams.get('search') || '' }),
+      dataSrc: 'data'
     },
     columns: [
       { data: '날짜' },
@@ -31,6 +33,11 @@ $(function () {
       { data: '광고비' },
       { data: '클릭률' },
     ],
+    createdRow: function (row, data) {
+      if (data['광고비'] > 0 && data['클릭수'] == 0) {
+        $(row).addClass('table-danger');
+      }
+    },
     language: {
       paginate: { previous: '이전', next: '다음' },
       info: '총 _TOTAL_건 중 _START_ ~ _END_',

--- a/routes/web/coupangAdd.js
+++ b/routes/web/coupangAdd.js
@@ -8,6 +8,9 @@ router.get('/', ctrl.renderPage);
 // 엑셀 업로드
 router.post('/upload', ctrl.upload, ctrl.uploadExcel);
 
+// 엑셀 다운로드
+router.get('/download', ctrl.downloadExcel);
+
 // 전체 삭제
 router.post('/delete-all', async (req, res) => {
   const db = req.app.locals.db;

--- a/views/coupang-add-summary.ejs
+++ b/views/coupang-add-summary.ejs
@@ -21,11 +21,12 @@
         <option value="BYC" <%= brand === 'BYC' ? 'selected' : '' %>>BYC</option>
         <option value="비비안" <%= brand === '비비안' ? 'selected' : '' %>>비비안</option>
       </select>
-      <button class="btn btn-outline-primary">검색</button>
+      <button class="btn btn-outline-primary me-2">검색</button>
     </form>
+    <a href="/coupang/add/download?search=<%= search %>" class="btn btn-success mb-3">📥 엑셀 다운로드</a>
 
     <table class="table table-bordered table-hover text-center">
-      <thead>
+      <thead class="bg-primary text-white text-center">
         <tr>
           <th>번호</th>
           <th>상품명</th>

--- a/views/coupangAdd.ejs
+++ b/views/coupangAdd.ejs
@@ -24,12 +24,12 @@
       <p class="mb-0">헤더를 클릭하면 오름차순/내림차순 정렬이 가능하며 50개씩 페이지 이동이 가능합니다.</p>
     </div>
 
+    <form method="GET" class="mb-3 d-flex align-items-center" action="/coupang/add" id="searchForm">
+      <input type="hidden" name="mode" value="<%= mode %>">
+      <input type="text" name="search" value="<%= typeof search !== 'undefined' ? search : '' %>" class="form-control me-2" placeholder="상품명 또는 옵션ID 검색">
+      <button class="btn btn-outline-primary">검색</button>
+    </form>
     <% if (mode === 'summary') { %>
-      <form method="GET" class="mb-3 d-flex" action="/coupang/add">
-        <input type="hidden" name="mode" value="summary">
-        <input type="text" name="search" value="<%= search %>" class="form-control me-2" placeholder="상품명 또는 옵션ID 검색">
-        <button class="btn btn-outline-primary">검색</button>
-      </form>
       <p class="text-end mb-2">총 <%= total %>건의 결과가 있습니다.</p>
     <% } %>
 
@@ -40,21 +40,22 @@
       </div>
     <% } %>
 
-    <div class="action-form mb-4 d-flex gap-2 flex-wrap">
-      <form id="uploadForm" action="/coupang/add/upload" method="POST" enctype="multipart/form-data" class="d-flex gap-2 flex-nowrap">
-        <input type="file" name="excelFile" accept=".xlsx, .xls" class="form-control" required>
-        <button type="submit" class="btn btn-success btn-upload">엑셀 업로드</button>
-      </form>
-      <form action="/coupang/add/delete-all" method="POST" onsubmit="return confirm('정말 모든 데이터를 삭제하시겠습니까?')">
-        <button type="submit" class="btn btn-danger btn-reset">데이터 초기화</button>
-      </form>
-    </div>
+  <div class="action-form mb-4 d-flex gap-2 flex-wrap">
+    <form id="uploadForm" action="/coupang/add/upload" method="POST" enctype="multipart/form-data" class="d-flex gap-2 flex-nowrap">
+      <input type="file" name="excelFile" accept=".xlsx, .xls" class="form-control" required>
+      <button type="submit" class="btn btn-success btn-upload">엑셀 업로드</button>
+    </form>
+    <form action="/coupang/add/delete-all" method="POST" onsubmit="return confirm('정말 모든 데이터를 삭제하시겠습니까?')">
+      <button type="submit" class="btn btn-danger btn-reset">데이터 초기화</button>
+    </form>
+    <a href="/coupang/add/download?search=<%= typeof search !== 'undefined' ? search : '' %>" class="btn btn-success">📥 엑셀 다운로드</a>
+  </div>
 
 
 
     <div class="table-responsive">
       <table id="coupangAddTable" data-mode="<%= mode %>" class="table table-bordered table-hover bg-white align-middle text-center auto-width">
-        <thead class="table-light">
+        <thead class="bg-primary text-white text-center">
           <% if (mode === 'summary') { %>
             <tr>
               <th>상품명</th>


### PR DESCRIPTION
## Summary
- implement keyword filtering in Coupang add controller
- expose Excel download endpoint
- send search query from DataTables
- highlight rows without clicks
- add search form and download button
- unify header styling across pages

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68555403500c8329b33ba84224af1b82