### PR TITLE
Add pagination support for Coupang listing

### DIFF
--- a/public/js/coupang.js
+++ b/public/js/coupang.js
@@ -6,11 +6,9 @@ $(function () {
     order: [[1, 'asc']],
     columnDefs: [{ targets: 0, orderable: false }],
     lengthChange: false,
-    paging: true,
-    pageLength: 50,
-    pagingType: 'numbers',
+    paging: false,
     searching: false,
-    info: true,
+    info: false,
     language: {
       paginate: { previous: '이전', next: '다음' },
       info: '총 _TOTAL_건 중 _START_ ~ _END_',

--- a/routes/web/coupang.js
+++ b/routes/web/coupang.js
@@ -94,15 +94,23 @@ async function attachAdData(items, db) {
 // ✅ 목록 조회
 router.get("/", async (req, res) => {
   const db = req.app.locals.db; // DB 인스턴스 재사용
+  const page = parseInt(req.query.page) || 1;
+  const limit = 50;
+  const skip = (page - 1) * limit;
   const keyword = "";
   const brand = req.query.brand || "";
   try {
     const query = brand ? { "Product name": new RegExp(brand, "i") } : {};
-    let result = await db
-      .collection("coupang")
-      .find(query)
-      .sort({ "Product name": 1 })
-      .toArray();
+    const [result, total] = await Promise.all([
+      db
+        .collection("coupang")
+        .find(query)
+        .sort({ "Product name": 1 })
+        .skip(skip)
+        .limit(limit)
+        .toArray(),
+      db.collection("coupang").countDocuments(query),
+    ]);
 
     result = result.map((row) => {
       const newRow = { ...row };
@@ -125,6 +133,14 @@ router.get("/", async (req, res) => {
         ? DEFAULT_COLUMNS.filter((col) => selected.includes(col))
         : DEFAULT_COLUMNS;
 
+    const totalPage = Math.ceil(total / limit);
+    const totalCount = total;
+    const params = new URLSearchParams();
+    if (brand) params.append("brand", brand);
+    if (selected && selected.length > 0)
+      selected.forEach((f) => params.append("fields", f));
+    const queryString = params.toString();
+
     res.render("coupang.ejs", {
       결과: resultWithAds,
       필드: fields,
@@ -134,6 +150,10 @@ router.get("/", async (req, res) => {
       keyword,
       brand,
       brandOptions: BRANDS,
+      현재페이지: page,
+      전체페이지: totalPage,
+      전체건수: totalCount,
+      추가쿼리: queryString ? `&${queryString}` : "",
     });
   } catch (err) {
     console.error("GET /coupang 오류:", err);
@@ -176,6 +196,10 @@ router.post("/upload", upload.single("excelFile"), async (req, res) => {
       keyword: "",
       brand: "",
       brandOptions: BRANDS,
+      현재페이지: 1,
+      전체페이지: 1,
+      전체건수: resultWithAds.length,
+      추가쿼리: "",
     });
   } catch (err) {
     console.error("POST /coupang/upload 오류:", err);
@@ -189,6 +213,9 @@ router.get("/search", async (req, res) => {
   try {
     const keyword = req.query.keyword || "";
     const brand = req.query.brand || "";
+    const page = parseInt(req.query.page) || 1;
+    const limit = 50;
+    const skip = (page - 1) * limit;
     const regex = keyword ? new RegExp(keyword, "i") : null;
     const brandRegex = brand ? new RegExp(brand, "i") : null;
 
@@ -207,11 +234,16 @@ router.get("/search", async (req, res) => {
     }
 
     const query = conditions.length > 0 ? { $and: conditions } : {};
-    let result = await db
-      .collection("coupang")
-      .find(query)
-      .sort({ "Product name": 1 })
-      .toArray();
+    const [result, total] = await Promise.all([
+      db
+        .collection("coupang")
+        .find(query)
+        .sort({ "Product name": 1 })
+        .skip(skip)
+        .limit(limit)
+        .toArray(),
+      db.collection("coupang").countDocuments(query),
+    ]);
 
     result = result.map((row) => {
       const newRow = { ...row };
@@ -233,6 +265,15 @@ router.get("/search", async (req, res) => {
         ? DEFAULT_COLUMNS.filter((col) => selected.includes(col))
         : DEFAULT_COLUMNS;
 
+    const totalPage = Math.ceil(total / limit);
+    const totalCount = total;
+    const params = new URLSearchParams();
+    if (keyword) params.append("keyword", keyword);
+    if (brand) params.append("brand", brand);
+    if (selected && selected.length > 0)
+      selected.forEach((f) => params.append("fields", f));
+    const queryString = params.toString();
+
     res.render("coupang.ejs", {
       결과: resultWithAds,
       필드: fields,
@@ -242,6 +283,10 @@ router.get("/search", async (req, res) => {
       keyword,
       brand,
       brandOptions: BRANDS,
+      현재페이지: page,
+      전체페이지: totalPage,
+      전체건수: totalCount,
+      추가쿼리: queryString ? `&${queryString}` : "",
     });
   } catch (err) {
     console.error("GET /coupang/search 오류:", err);

--- a/views/coupang.ejs
+++ b/views/coupang.ejs
@@ -71,7 +71,7 @@
     <% } %>
 
     <% if (결과 && 결과.length > 0) { %>
-      <p class="text-muted">🔎 총 <strong><%= 결과.length %></strong>건의 결과가 있습니다.</p>
+      <p class="text-muted">🔎 전체 <strong><%= 전체건수 %></strong>건 중 <strong><%= 현재페이지 %>/<%= 전체페이지 %></strong>페이지를 보고 있습니다.</p>
       <% let reorderCount = 0; 결과.forEach(item => { const s = Number(item['Shortage quantity']||0); const sales=Number(item['Sales in the last 30 days']||0); const stock=Number(item['Orderable quantity (real-time)']||0); if (s>0 || (sales>0 && stock===0)) reorderCount++; }); %>
       <div class="alert alert-warning d-flex justify-content-between align-items-center mb-3">
         <span>입고 필요 항목: <strong><%= reorderCount %></strong>건</span>
@@ -132,6 +132,28 @@
         </tbody>
       </table>
     </div>
+
+    <% if (전체페이지 > 1) { %>
+      <nav class="my-4">
+        <ul class="pagination justify-content-center">
+          <% if (현재페이지 > 1) { %>
+            <li class="page-item">
+              <a class="page-link" href="?page=<%= 현재페이지 - 1 %><%= 추가쿼리 %>">이전</a>
+            </li>
+          <% } %>
+          <% for (let i = 1; i <= 전체페이지; i++) { %>
+            <li class="page-item <%= i === 현재페이지 ? 'active' : '' %>">
+              <a class="page-link" href="?page=<%= i %><%= 추가쿼리 %>"><%= i %></a>
+            </li>
+          <% } %>
+          <% if (현재페이지 < 전체페이지) { %>
+            <li class="page-item">
+              <a class="page-link" href="?page=<%= 현재페이지 + 1 %><%= 추가쿼리 %>">다음</a>
+            </li>
+          <% } %>
+        </ul>
+      </nav>
+    <% } %>
 
     <% if (keyword) { %>
       <h4 class="mt-5">검색 결과 그래프</h4>


### PR DESCRIPTION
## Summary
- paginate Coupang list and search routes
- show page navigation in the Coupang view
- disable client-side paging in coupang.js
- expose total count for pagination

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: missing @eslint/js)*

------
https://chatgpt.com/codex/tasks/task_e_6855556f200083299fb62cc7b2ce2693