### PR TITLE
Fix Mongo sort memory error

### DIFF
--- a/controllers/coupangAddController.js
+++ b/controllers/coupangAddController.js
@@ -110,7 +110,12 @@ exports.getData = asyncHandler(async (req, res) => {
     }
   }
 
-  let rows = await db.collection('coupangAdd').find().sort(sort).toArray();
+  let rows = await db
+    .collection('coupangAdd')
+    .find()
+    .sort(sort)
+    .allowDiskUse(true)
+    .toArray();
   const total = rows.length;
 
   if (keyword) {


### PR DESCRIPTION
## Summary
- enable disk use for sorting `coupangAdd` data to prevent MongoDB memory errors

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68555881311c8329a496487f460ffad4