### PR TITLE
Fix sorting memory error and const reassignment

### DIFF
--- a/controllers/coupangAddController.js
+++ b/controllers/coupangAddController.js
@@ -113,9 +113,7 @@ exports.getData = asyncHandler(async (req, res) => {
 
   let rows = await db
     .collection('coupangAdd')
-    .find()
-    .sort(sort)
-    .allowDiskUse(true)
+    .aggregate([{ $sort: sort }], { allowDiskUse: true })
     .toArray();
   const total = rows.length;
 

--- a/routes/web/coupang.js
+++ b/routes/web/coupang.js
@@ -101,7 +101,7 @@ router.get("/", async (req, res) => {
   const brand = req.query.brand || "";
   try {
     const query = brand ? { "Product name": new RegExp(brand, "i") } : {};
-    const [result, total] = await Promise.all([
+    const [rows, total] = await Promise.all([
       db
         .collection("coupang")
         .find(query)
@@ -111,8 +111,7 @@ router.get("/", async (req, res) => {
         .toArray(),
       db.collection("coupang").countDocuments(query),
     ]);
-
-    result = result.map((row) => {
+    let result = rows.map((row) => {
       const newRow = { ...row };
       if (typeof newRow["Option ID"] === "number") {
         newRow["Option ID"] = String(newRow["Option ID"]);
@@ -236,7 +235,7 @@ router.get("/search", async (req, res) => {
     }
 
     const query = conditions.length > 0 ? { $and: conditions } : {};
-    const [result, total] = await Promise.all([
+    const [rows, total] = await Promise.all([
       db
         .collection("coupang")
         .find(query)
@@ -246,8 +245,7 @@ router.get("/search", async (req, res) => {
         .toArray(),
       db.collection("coupang").countDocuments(query),
     ]);
-
-    result = result.map((row) => {
+    let result = rows.map((row) => {
       const newRow = { ...row };
       if (typeof newRow["Option ID"] === "number")
         newRow["Option ID"] = String(newRow["Option ID"]);


### PR DESCRIPTION
## Summary
- fix constant variable reassignment in `coupang.js`
- use aggregation with `allowDiskUse` in `coupangAddController` to avoid memory limit

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6855625f3cf08329ac5cca4e7697a1c7