### PR TITLE
Implement profile page routes

### DIFF
--- a/controllers/profileController.js
+++ b/controllers/profileController.js
@@ -1,0 +1,31 @@
+const bcrypt = require('bcrypt');
+const asyncHandler = require('../middlewares/asyncHandler');
+
+exports.renderProfilePage = asyncHandler(async (req, res) => {
+  res.render('profile');
+});
+
+exports.updateProfile = asyncHandler(async (req, res) => {
+  const db = req.app.locals.db;
+  const { email, phone, password, password2 } = req.body;
+  const updates = { email, phone };
+
+  if (password) {
+    if (password !== password2) {
+      req.flash('error', '비밀번호가 일치하지 않습니다.');
+      return res.redirect('/profile');
+    }
+    updates.password = await bcrypt.hash(password, 10);
+  }
+
+  await db.collection('user').updateOne(
+    { _id: req.user._id },
+    { $set: updates }
+  );
+
+  Object.assign(req.user, updates);
+  delete req.user.password;
+
+  req.flash('success', '회원정보가 수정되었습니다.');
+  res.redirect('/profile');
+});

--- a/routes/web/index.js
+++ b/routes/web/index.js
@@ -13,6 +13,7 @@ const protectedRoutes = new Set([
   'board',
   'coupangAdd',
   'post',
+  'profile',
 ]);
 
 fs.readdirSync(routesDir)

--- a/routes/web/profile.js
+++ b/routes/web/profile.js
@@ -1,0 +1,8 @@
+const express = require('express');
+const router = express.Router();
+const controller = require('../../controllers/profileController');
+
+router.get('/', controller.renderProfilePage);
+router.post('/', controller.updateProfile);
+
+module.exports = router;


### PR DESCRIPTION
## Summary
- add `profile` controller with GET and POST handlers
- add `profile` route
- protect `/profile` using `checkAuth`

## Testing
- `npm test` *(fails: `jest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68556557d9bc8329b59b8e7ab65a7518