### PR TITLE
Fix Coupang summary route memory error

### DIFF
--- a/controllers/coupangAddController.js
+++ b/controllers/coupangAddController.js
@@ -90,7 +90,10 @@ exports.renderPage = asyncHandler(async (req, res) => {
       { $sort: { [sortField]: sortOrder } },
     ].filter(Boolean);
 
-    const data = await db.collection('coupangAdd').aggregate(pipeline).toArray();
+    const data = await db
+      .collection('coupangAdd')
+      .aggregate(pipeline, { allowDiskUse: true })
+      .toArray();
 
     list = data.map((item, i) => ({
       no: i + 1,


### PR DESCRIPTION
## Summary
- fix aggregation for summary mode to allow using disk

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68556997219c8329b1ef503347b030c6