### PR TITLE
Fix Coupang add listing

### DIFF
--- a/views/coupang.ejs
+++ b/views/coupang.ejs
@@ -107,7 +107,7 @@
                  else if (sales30 > 0 && stock === 0) rowCls = 'row-warning';
                  else if (sales30 === 0 && shortage === 0) rowCls = 'row-muted';
               %>
-              <tr class="<%= rowCls %>" data-shortage="<%= shortage %>" data-sales="<%= sales30 %>" data-stock="<%= stock %>">
+              <tr class="<%= rowCls %> text-center" data-shortage="<%= shortage %>" data-sales="<%= sales30 %>" data-stock="<%= stock %>">
                 <td class="text-center"><%= index + 1 + 페이지크기 * (현재페이지 - 1) %></td>
                 <% 필드.forEach(key => { %>
                   <% if (key === 'Option ID') { %>
@@ -134,6 +134,7 @@
     </div>
 
     <% if (전체페이지 > 1) { %>
+      <% const groupSize = 10; const startPage = Math.floor((현재페이지 - 1) / groupSize) * groupSize + 1; const endPage = Math.min(startPage + groupSize - 1, 전체페이지); %>
       <nav class="my-4">
         <ul class="pagination justify-content-center">
           <% if (현재페이지 > 1) { %>
@@ -141,7 +142,7 @@
               <a class="page-link" href="?page=<%= 현재페이지 - 1 %><%= 추가쿼리 %>">이전</a>
             </li>
           <% } %>
-          <% for (let i = 1; i <= 전체페이지; i++) { %>
+          <% for (let i = startPage; i <= endPage; i++) { %>
             <li class="page-item <%= i === 현재페이지 ? 'active' : '' %>">
               <a class="page-link" href="?page=<%= i %><%= 추가쿼리 %>"><%= i %></a>
             </li>

--- a/views/coupangAdd.ejs
+++ b/views/coupangAdd.ejs
@@ -84,7 +84,7 @@
         <% if (mode === 'summary') { %>
           <tbody>
             <% list.forEach(item => { %>
-              <tr>
+              <tr class="text-center">
                 <td class="text-start"><%= item.productName %></td>
                 <td><%= item.impressions.toLocaleString() %></td>
                 <td><%= item.clicks.toLocaleString() %></td>
@@ -98,6 +98,7 @@
         <% } %>
       </table>
       <% if (mode === 'summary') { %>
+      <% const groupSize = 10; const startPage = Math.floor((page - 1) / groupSize) * groupSize + 1; const endPage = Math.min(startPage + groupSize - 1, totalPages); %>
       <nav aria-label="Page navigation">
         <ul class="pagination justify-content-center">
           <% if (page > 1) { %>
@@ -105,7 +106,7 @@
               <a class="page-link" href="?mode=summary&page=<%= page - 1 %>&search=<%= search %>">◀ 이전</a>
             </li>
           <% } %>
-          <% for (let i = 1; i <= totalPages; i++) { %>
+          <% for (let i = startPage; i <= endPage; i++) { %>
             <li class="page-item <%= i === page ? 'active' : '' %>">
               <a class="page-link" href="?mode=summary&page=<%= i %>&search=<%= search %>"><%= i %></a>
             </li>


### PR DESCRIPTION
## Summary
- optimize coupang add data API with filtering and pagination
- support pagination in summary view
- show only 10 page numbers at once in coupang pages
- keep table text style consistent

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685609e7460883298ca6f315aafd96eb