### PR TITLE
Fix session secret initialization

### DIFF
--- a/server.js
+++ b/server.js
@@ -1,6 +1,9 @@
-require("dotenv").config();
-const express = require("express");
 const path = require("path");
+require("dotenv").config({ path: path.join(__dirname, ".env") });
+if (!process.env.SESSION_SECRET) {
+  throw new Error("SESSION_SECRET environment variable is required");
+}
+const express = require("express");
 const session = require("express-session");
 const MongoStore = require("connect-mongo");
 const passport = require("passport");


### PR DESCRIPTION
## Summary
- ensure the `.env` file is loaded using an absolute path
- throw an explicit error when `SESSION_SECRET` is missing

## Testing
- `npm test` *(fails: jest not found)*
- `npm install --include=dev` *(fails: network access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68561695b0f0832990218e1b9f76a170