### PR TITLE
Specify Node 18 for Heroku deployments

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,5 +67,8 @@
   "directories": {
     "lib": "lib",
     "test": "tests"
+  },
+  "engines": {
+    "node": "18.x"
   }
 }


### PR DESCRIPTION
## Summary
- set `engines.node` to `18.x` in `package.json`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856313cf1fc8329bc1f3b106c77a942