### PR TITLE
Implement environment-specific configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,13 @@ This project requires several environment variables to run:
 - `WEATHER_API_KEY` – API key from the Korean Meteorological Administration used
   to fetch daily weather data.
 
-Copy `.env.example` to `.env` in the project root and define these values before starting the server. Make sure the file is saved as **UTF-8 without BOM** so that `dotenv` can read it correctly.
+Create environment-specific files based on `.env.example`:
+
+- `.env.dev`  – used when `NODE_ENV=development` for local testing
+- `.env.test` – loaded automatically during Jest runs
+- `.env.prod` – used when `NODE_ENV=production` for deployment (e.g. EC2)
+
+Each file should be saved as **UTF-8 without BOM** so that `dotenv` can read it correctly.
 
 ## Python scripts
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
     ports:
       - "3000:3000"
     env_file:
-      - .env            # 로컬 .env 값 주입
+      - .env.dev        # 로컬 개발 환경 변수
     depends_on:
       - mongo
     restart: unless-stopped

--- a/scripts/excel_to_mongo.py
+++ b/scripts/excel_to_mongo.py
@@ -11,7 +11,13 @@ from typing import Union, IO
 # ─────────────────────────────────────────────
 # ① .env 파일에서 환경변수 불러오기 (MONGO_URI 포함)
 # ─────────────────────────────────────────────
-load_dotenv()
+env_map = {
+    "production": "prod",
+    "test": "test",
+    "development": "dev",
+}
+suffix = env_map.get(os.getenv("NODE_ENV"), "dev")
+load_dotenv(f".env.{suffix}")
 
 # ─────────────────────────────────────────────
 # ② 공통 유틸 함수 정의

--- a/server.js
+++ b/server.js
@@ -1,4 +1,10 @@
-require("dotenv").config();
+const envMap = {
+  production: "prod",
+  test: "test",
+  development: "dev",
+};
+const suffix = envMap[process.env.NODE_ENV] || "dev";
+require("dotenv").config({ path: `.env.${suffix}` });
 const express = require("express");
 const path = require("path");
 const session = require("express-session");

--- a/upload.js
+++ b/upload.js
@@ -1,5 +1,11 @@
 // upload.js
-require("dotenv").config();
+const envMap = {
+  production: "prod",
+  test: "test",
+  development: "dev",
+};
+const suffix = envMap[process.env.NODE_ENV] || "dev";
+require("dotenv").config({ path: `.env.${suffix}` });
 const multer = require("multer");
 
 let upload;   // ← 공통 export용 변수


### PR DESCRIPTION
## Summary
- load dotenv files based on `NODE_ENV`
- clarify new env file usage in README
- use `.env.dev` in `docker-compose.yml`
- update Python script to use the same logic

## Testing
- `npm ci` *(fails: network access required)*
- `npm test` *(fails: jest not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68568a5a9e788329b071a7040df812cc