### PR TITLE
Fix tests using MemoryStore

### DIFF
--- a/server.js
+++ b/server.js
@@ -56,18 +56,23 @@ async function initApp() {
   app.use(methodOverride("_method"));
 
   // 5. 세션, Passport, Flash
+  const sessionStore =
+    process.env.NODE_ENV === "test"
+      ? new session.MemoryStore()
+      : MongoStore.create({
+          mongoUrl:
+            process.env.MONGO_URI || "mongodb://localhost:27017/testdb",
+          dbName: process.env.DB_NAME || "testdb",
+          collectionName: "sessions",
+          ttl: 60 * 60,
+        });
+
   app.use(
     session({
       secret: process.env.SESSION_SECRET,
       resave: false,
       saveUninitialized: false,
-      store: MongoStore.create({
-        mongoUrl:
-          process.env.MONGO_URI || "mongodb://localhost:27017/testdb",
-        dbName: process.env.DB_NAME || "testdb",
-        collectionName: "sessions",
-        ttl: 60 * 60,
-      }),
+      store: sessionStore,
       cookie: {
         httpOnly: true,
         secure: process.env.NODE_ENV === "production",


### PR DESCRIPTION
## Summary
- use `session.MemoryStore` in test environment to avoid failing session setup

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685695edafc88329a69a23d18af988e0