### PR TITLE
Fix env loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,13 +14,9 @@ This project requires several environment variables to run:
 - `WEATHER_API_KEY` – API key from the Korean Meteorological Administration used
   to fetch daily weather data.
 
-Create environment-specific files based on `.env.example`:
-
-- `.env.dev`  – used when `NODE_ENV=development` for local testing
-- `.env.test` – loaded automatically during Jest runs
-- `.env.prod` – used when `NODE_ENV=production` for deployment (e.g. EC2)
-
-Each file should be saved as **UTF-8 without BOM** so that `dotenv` can read it correctly.
+Create a single `.env` file based on `.env.example` and use it for all environments.
+The project no longer relies on `.env.dev`, `.env.test`, or `.env.prod` files.
+Ensure the file is saved as **UTF-8 without BOM** so that `dotenv` can read it correctly.
 
 ## Python scripts
 

--- a/upload.js
+++ b/upload.js
@@ -1,11 +1,5 @@
 // upload.js
-const envMap = {
-  production: "prod",
-  test: "test",
-  development: "dev",
-};
-const suffix = envMap[process.env.NODE_ENV] || "dev";
-require("dotenv").config({ path: `.env.${suffix}` });
+require("dotenv").config();
 const multer = require("multer");
 
 let upload;   // ← 공통 export용 변수


### PR DESCRIPTION
## Summary
- simplify env loading in `upload.js`
- update README to use a single `.env` file

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68569d36ac1c832981da83ac56c8ec82