### PR TITLE
Fix .env loading for server

### DIFF
--- a/server.js
+++ b/server.js
@@ -1,10 +1,4 @@
-const envMap = {
-  production: "prod",
-  test: "test",
-  development: "dev",
-};
-const suffix = envMap[process.env.NODE_ENV] || "dev";
-require("dotenv").config({ path: `.env.${suffix}` });
+require("dotenv").config();
 const express = require("express");
 const path = require("path");
 const session = require("express-session");


### PR DESCRIPTION
## Summary
- remove per-environment env file logic in `server.js`
- load `.env` directly so config matches README instructions

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6856a4bf75b88329a03edddbe3ee83e4