### PR TITLE
Fix env loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,9 @@ Create a `.env` file in the project root and define these values before starting
 the server. Make sure the file is saved as **UTF-8 without BOM** so that
 `dotenv` can read it correctly.
 
+> **Note**: The application always loads variables from `.env` in the project
+> root. Additional files such as `.env.dev` or `.env.empal` are ignored.
+
 An example configuration is provided in `.env.example`:
 
 ```bash

--- a/scripts/excel_to_mongo.py
+++ b/scripts/excel_to_mongo.py
@@ -11,7 +11,8 @@ from typing import Union, IO
 # ─────────────────────────────────────────────
 # ① .env 파일에서 환경변수 불러오기 (MONGO_URI 포함)
 # ─────────────────────────────────────────────
-load_dotenv()
+ROOT_ENV = Path(__file__).resolve().parents[1] / ".env"
+load_dotenv(dotenv_path=ROOT_ENV)
 
 # ─────────────────────────────────────────────
 # ② 공통 유틸 함수 정의

--- a/server.js
+++ b/server.js
@@ -1,6 +1,6 @@
-require("dotenv").config();
-const express = require("express");
 const path = require("path");
+require("dotenv").config({ path: path.join(__dirname, ".env") });
+const express = require("express");
 const session = require("express-session");
 const MongoStore = require("connect-mongo");
 const passport = require("passport");

--- a/upload.js
+++ b/upload.js
@@ -1,4 +1,5 @@
-require("dotenv").config();
+const path = require("path");
+require("dotenv").config({ path: path.join(__dirname, ".env") });
 const multer = require("multer");
 const multerS3 = require("multer-s3");
 const {


### PR DESCRIPTION
## Summary
- always load `.env` from project root
- clarify env usage in README

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: @eslint/js missing)*
- `python -m py_compile scripts/excel_to_mongo.py`

------
https://chatgpt.com/codex/tasks/task_e_68573ac10710832991c89652d4bd9684