### PR TITLE
Add env loader with fallback

### DIFF
--- a/config/loadEnv.js
+++ b/config/loadEnv.js
@@ -1,0 +1,15 @@
+const fs = require('fs');
+const path = require('path');
+
+function loadEnv() {
+  const envPath = path.join(__dirname, '..', '.env');
+  const examplePath = path.join(__dirname, '..', '.env.example');
+
+  if (fs.existsSync(envPath)) {
+    require('dotenv').config({ path: envPath });
+  } else if (fs.existsSync(examplePath)) {
+    require('dotenv').config({ path: examplePath });
+  }
+}
+
+module.exports = loadEnv;

--- a/server.js
+++ b/server.js
@@ -1,5 +1,5 @@
 const path = require("path");
-require("dotenv").config({ path: path.join(__dirname, ".env") });
+require("./config/loadEnv")();
 const express = require("express");
 const session = require("express-session");
 const MongoStore = require("connect-mongo");

--- a/upload.js
+++ b/upload.js
@@ -1,5 +1,5 @@
 const path = require("path");
-require("dotenv").config({ path: path.join(__dirname, ".env") });
+require("./config/loadEnv")();
 const multer = require("multer");
 const multerS3 = require("multer-s3");
 const {


### PR DESCRIPTION
## Summary
- add `config/loadEnv.js` to load `.env` or fallback to `.env.example`
- use the helper in `server.js` and `upload.js`

## Testing
- `npm test` *(fails: `jest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68573c642f688329ad9336fa66649997