### PR TITLE
Log env file loaded

### DIFF
--- a/config/loadEnv.js
+++ b/config/loadEnv.js
@@ -1,14 +1,18 @@
-const fs = require('fs');
-const path = require('path');
+const fs = require("fs");
+const path = require("path");
 
 function loadEnv() {
-  const envPath = path.join(__dirname, '..', '.env');
-  const examplePath = path.join(__dirname, '..', '.env.example');
+  const envPath = path.join(__dirname, "..", ".env");
+  const examplePath = path.join(__dirname, "..", ".env.example");
 
   if (fs.existsSync(envPath)) {
-    require('dotenv').config({ path: envPath });
+    require("dotenv").config({ path: envPath });
+    console.log("Environment variables loaded from .env");
   } else if (fs.existsSync(examplePath)) {
-    require('dotenv').config({ path: examplePath });
+    require("dotenv").config({ path: examplePath });
+    console.log("Environment variables loaded from .env.example");
+  } else {
+    console.warn("No environment file found");
   }
 }
 


### PR DESCRIPTION
## Summary
- indicate which environment file gets loaded

## Testing
- `npx prettier --write config/loadEnv.js`
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6857457f452483299767f072767a9e77