### PR TITLE
Update README and env variables

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,5 @@
-DB_URL=mongodb://localhost:27017/mydb
+MONGO_URI=mongodb://localhost:27017
+DB_NAME=mydb
 S3_KEY=YOUR_ACCESS_KEY
 S3_SECRET=YOUR_SECRET_KEY
 S3_REGION=YOUR_REGION

--- a/README.md
+++ b/README.md
@@ -1,8 +1,13 @@
 # My Bode Project
 
+`config/loadEnv.js` loads environment settings before the server starts. It
+first checks for a `.env` file in the project root and falls back to
+`.env.example` when that file is missing.
+
 This project requires several environment variables to run:
 
-- `DB_URL` – MongoDB connection string
+- `MONGO_URI` – MongoDB connection string
+- `DB_NAME` – MongoDB database name
 - `S3_KEY` – AWS S3 access key
 - `S3_SECRET` – AWS S3 secret key
 - `S3_REGION` – AWS S3 region where the bucket resides
@@ -15,7 +20,8 @@ the server. Make sure the file is saved as **UTF-8 without BOM** so that
 `dotenv` can read it correctly.
 
 > **Note**: The application always loads variables from `.env` in the project
-> root. Additional files such as `.env.dev` or `.env.empal` are ignored.
+> root. Additional files such as `.env.dev` or `.env.empal` are ignored unless
+> you rename one of them to `.env`.
 
 An example configuration is provided in `.env.example`:
 

--- a/lib/SimpleMongoStore.js
+++ b/lib/SimpleMongoStore.js
@@ -2,12 +2,12 @@
 const session = require("express-session");
 const { MongoClient } = require("mongodb");
 
-const MONGO_URL = process.env.DB_URL || "mongodb://localhost:27017";
+const MONGO_URI = process.env.MONGO_URI || "mongodb://localhost:27017";
 const DB_NAME = "forum";
 
 let db;
 
-MongoClient.connect(MONGO_URL).then((client) => {
+MongoClient.connect(MONGO_URI).then((client) => {
   db = client.db(DB_NAME);
 });
 


### PR DESCRIPTION
## Summary
- document fallback behavior of `config/loadEnv.js`
- rename `DB_URL` variable to `MONGO_URI` and show `DB_NAME`
- clarify that alternate `.env.*` files are ignored unless renamed
- update example environment file
- update `SimpleMongoStore` to use `MONGO_URI`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6857457be478832988d5c5dd69144612