### PR TITLE
Standardize Mongo environment variables

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,5 @@
-DB_URL=mongodb://localhost:27017/mydb
+MONGO_URI=mongodb://localhost:27017/mydb
+DB_NAME=forum
 S3_KEY=YOUR_ACCESS_KEY
 S3_SECRET=YOUR_SECRET_KEY
 S3_REGION=YOUR_REGION

--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@
 
 This project requires several environment variables to run:
 
-- `DB_URL` – MongoDB connection string
+- `MONGO_URI` – MongoDB connection string
+- `DB_NAME`  – MongoDB database name
 - `S3_KEY` – AWS S3 access key
 - `S3_SECRET` – AWS S3 secret key
 - `S3_REGION` – AWS S3 region where the bucket resides

--- a/controllers/tryController.js
+++ b/controllers/tryController.js
@@ -5,7 +5,7 @@ const { MongoClient } = require("mongodb");
 const csv = require("csvtojson");
 
 const MONGO_URI = process.env.MONGO_URI || "mongodb://localhost:27017";
-const DB_NAME = "try_brand";
+const DB_NAME = process.env.DB_NAME || "try_brand";
 const COLLECTION = "inventory";
 
 async function runPython(scriptPath, excelPath) {

--- a/lib/SimpleMongoStore.js
+++ b/lib/SimpleMongoStore.js
@@ -2,8 +2,8 @@
 const session = require("express-session");
 const { MongoClient } = require("mongodb");
 
-const MONGO_URL = process.env.DB_URL || "mongodb://localhost:27017";
-const DB_NAME = "forum";
+const MONGO_URL = process.env.MONGO_URI || "mongodb://localhost:27017";
+const DB_NAME = process.env.DB_NAME || "forum";
 
 let db;
 


### PR DESCRIPTION
## Summary
- rename `DB_URL` to `MONGO_URI` and introduce `DB_NAME` in `.env.example`
- read `MONGO_URI` and `DB_NAME` from environment in the Mongo session store
- use `DB_NAME` env var in `tryController`
- document new variables in the README

## Testing
- `npm test` *(fails: `npm: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6857457542108329abdb36e109ef9601