### PR TITLE
Use single .env file

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,0 @@
-MONGO_URI=mongodb://localhost:27017/mydb
-DB_NAME=forum
-S3_KEY=YOUR_ACCESS_KEY
-S3_SECRET=YOUR_SECRET_KEY
-S3_REGION=YOUR_REGION
-S3_BUCKET_NAME=your-bucket-name
-SESSION_SECRET=your-session-secret

--- a/README.md
+++ b/README.md
@@ -18,11 +18,16 @@ the server. Make sure the file is saved as **UTF-8 without BOM** so that
 > **Note**: The application always loads variables from `.env` in the project
 > root. Additional files such as `.env.dev` or `.env.empal` are ignored.
 
-An example configuration is provided in `.env.example`:
+Create a `.env` file containing values similar to the following:
 
 ```bash
-cp .env.example .env
-# then edit .env with your real credentials
+MONGO_URI=mongodb://localhost:27017/mydb
+DB_NAME=forum
+S3_KEY=YOUR_ACCESS_KEY
+S3_SECRET=YOUR_SECRET_KEY
+S3_REGION=YOUR_REGION
+S3_BUCKET_NAME=your-bucket-name
+SESSION_SECRET=your-session-secret
 ```
 
 ## Python scripts

--- a/config/loadEnv.js
+++ b/config/loadEnv.js
@@ -3,16 +3,12 @@ const path = require("path");
 
 function loadEnv() {
   const envPath = path.join(__dirname, "..", ".env");
-  const examplePath = path.join(__dirname, "..", ".env.example");
 
   if (fs.existsSync(envPath)) {
     require("dotenv").config({ path: envPath });
     console.log("Environment variables loaded from .env");
-  } else if (fs.existsSync(examplePath)) {
-    require("dotenv").config({ path: examplePath });
-    console.log("Environment variables loaded from .env.example");
   } else {
-    console.warn("No environment file found");
+    console.warn("No .env file found");
   }
 }
 


### PR DESCRIPTION
## Summary
- only load `.env` in loadEnv
- delete `.env.example`
- document required environment values directly in README

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685749e673e88329b2c4641b212c3c0b