### PR TITLE
Fix missing loadEnv module

### DIFF
--- a/config/loadEnv.js
+++ b/config/loadEnv.js
@@ -1,0 +1,7 @@
+const path = require('path');
+const dotenv = require('dotenv');
+
+module.exports = function loadEnv() {
+  const envPath = path.resolve(__dirname, '..', '.env');
+  dotenv.config({ path: envPath });
+};


### PR DESCRIPTION
## Summary
- load environment variables from `.env` file

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685751a92bd483299207b73b209c4385