### PR TITLE
Add Coupang open API support

### DIFF
--- a/controllers/coupangOpenController.js
+++ b/controllers/coupangOpenController.js
@@ -1,0 +1,11 @@
+const { coupangRequest } = require('../lib/coupangApiClient');
+const asyncHandler = require('../middlewares/asyncHandler');
+
+// Fetch product information from Coupang API
+exports.getProduct = asyncHandler(async (req, res) => {
+  const productId = req.params.id;
+  const vendorId = process.env.CP_VENDOR_ID;
+  const path = `/v2/providers/openapi/apis/api/v1/vendors/${vendorId}/products/${productId}`;
+  const data = await coupangRequest('GET', path);
+  res.json(data);
+});

--- a/lib/coupangApiClient.js
+++ b/lib/coupangApiClient.js
@@ -1,0 +1,60 @@
+const crypto = require('crypto');
+const fetch = require('node-fetch');
+
+/**
+ * Sign Coupang Open API request
+ * @param {string} method HTTP method
+ * @param {string} urlPath Path including query string
+ * @param {string} secretKey API secret key
+ * @param {string} timestamp Unix epoch string
+ * @returns {string} signature
+ */
+function signRequest(method, urlPath, secretKey, timestamp) {
+  const message = `${timestamp}${method}${urlPath}`;
+  return crypto.createHmac('sha256', secretKey).update(message).digest('hex');
+}
+
+/**
+ * Perform request to Coupang Open API
+ * @param {string} method HTTP method
+ * @param {string} path API path (without host)
+ * @param {object} [options] Optional settings: query, body
+ */
+async function coupangRequest(method, path, options = {}) {
+  const accessKey = process.env.CP_ACCESS_KEY;
+  const secretKey = process.env.CP_SECRET_KEY;
+  const vendorId = process.env.CP_VENDOR_ID;
+  const host = process.env.CP_API_HOST || 'https://api-gateway.coupang.com';
+
+  if (!accessKey || !secretKey || !vendorId) {
+    throw new Error('Coupang API credentials are not set');
+  }
+
+  const queryStr = options.query
+    ? '?' + new URLSearchParams(options.query).toString()
+    : '';
+  const urlPath = `${path}${queryStr}`;
+  const timestamp = Date.now().toString();
+  const signature = signRequest(method, urlPath, secretKey, timestamp);
+
+  const headers = {
+    Authorization: `CEA algorithm=HmacSHA256, access-key=${accessKey}, signed-date=${timestamp}, signature=${signature}`,
+    'Content-Type': 'application/json; charset=UTF-8',
+    'X-EXTENDED-VENDOR-ID': vendorId,
+  };
+
+  const res = await fetch(host + urlPath, {
+    method,
+    headers,
+    body: options.body ? JSON.stringify(options.body) : undefined,
+  });
+
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`Coupang API error: ${res.status} ${text}`);
+  }
+
+  return res.json();
+}
+
+module.exports = { coupangRequest };

--- a/routes/api/coupangOpenApi.js
+++ b/routes/api/coupangOpenApi.js
@@ -1,0 +1,7 @@
+const express = require('express');
+const router = express.Router();
+const ctrl = require('../../controllers/coupangOpenController');
+
+router.get('/product/:id', ctrl.getProduct);
+
+module.exports = router;

--- a/routes/api/index.js
+++ b/routes/api/index.js
@@ -14,6 +14,8 @@ router.use("/stock", require("./stockApi"));
 router.use("/coupang", require("./coupangApi"));
 // 쿠팡 광고비 API
 router.use("/coupang-add", require("./coupangAddApi"));
+// 쿠팡 오픈 API 연동
+router.use("/coupang-open", require("./coupangOpenApi"));
 // 날씨 API
 router.use("/weather", require("./weatherApi"));
 

--- a/tests/coupangOpenApi.test.js
+++ b/tests/coupangOpenApi.test.js
@@ -1,0 +1,45 @@
+jest.setTimeout(60000);
+
+jest.mock('../config/db', () => {
+  const mockDb = { collection: jest.fn() };
+  const mockConnect = jest.fn().mockResolvedValue(mockDb);
+  mockConnect.then = (fn) => fn(mockDb);
+  return { connectDB: mockConnect, closeDB: jest.fn().mockResolvedValue() };
+});
+
+jest.mock('node-fetch');
+const mockFetch = require('node-fetch');
+
+const request = require('supertest');
+const { initApp } = require('../server');
+const { closeDB } = require('../config/db');
+
+let app;
+
+beforeAll(async () => {
+  process.env.NODE_ENV = 'test';
+  process.env.MONGO_URI = 'mongodb://127.0.0.1:27017/testdb';
+  process.env.DB_NAME = 'testdb';
+  process.env.SESSION_SECRET = 'testsecret';
+  process.env.CP_ACCESS_KEY = 'access';
+  process.env.CP_SECRET_KEY = 'secret';
+  process.env.CP_VENDOR_ID = 'vendor';
+
+  mockFetch.mockResolvedValue({
+    ok: true,
+    json: async () => ({ productId: '1234', name: 'Sample' }),
+  });
+
+  app = await initApp();
+});
+
+afterAll(async () => {
+  await closeDB();
+});
+
+test('GET /api/coupang-open/product/:id returns product data', async () => {
+  const res = await request(app).get('/api/coupang-open/product/1234');
+  expect(res.statusCode).toBe(200);
+  expect(res.body).toEqual({ productId: '1234', name: 'Sample' });
+  expect(mockFetch).toHaveBeenCalled();
+});


### PR DESCRIPTION
## Summary
- add helper `lib/coupangApiClient.js` for making signed Coupang requests
- add `coupangOpenController` with product fetch example
- expose `/api/coupang-open/product/:id` route
- wire new route in API index
- add unit test for the new route

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6858cb98808483299e2fa3a62b0b7e5f