### PR TITLE
Add contributing guide for tests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,18 @@
+# Contributing
+
+Thank you for taking the time to contribute to this project. The following section explains how to run the automated tests.
+
+## Testing
+
+Install dependencies before executing the test suite. This step requires network access so npm can download packages such as Jest.
+
+```bash
+npm install
+```
+
+After installation, run the tests with:
+
+```bash
+npm test
+```
+


### PR DESCRIPTION
## Summary
- add `CONTRIBUTING.md` with instructions on installing dependencies prior to running tests
- mention that installing dependencies requires network access for packages like Jest

## Testing
- `npm install` *(fails: network access blocked)*
- `npm test` *(fails: jest not found due to failed install)*

------
https://chatgpt.com/codex/tasks/task_e_6858ce688a288329a809ee44deeb11a7