### PR TITLE
Document Coupang product API usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,10 @@ This project requires several environment variables to run:
   must allow bucket creation).
 - `WEATHER_API_KEY` – API key from the Korean Meteorological Administration used
   to fetch daily weather data.
+- `CP_ACCESS_KEY` – Coupang Open API access key.
+- `CP_SECRET_KEY` – Coupang Open API secret key used to sign requests.
+- `CP_VENDOR_ID` – Your Coupang vendor ID.
+- `CP_API_HOST` – Base URL for the Coupang Open API (defaults to `https://api-gateway.coupang.com`).
 
 Copy `.env.example` to `.env` in the project root and define these values before starting the server. Make sure the file is saved as **UTF-8 without BOM** so that `dotenv` can read it correctly.
 
@@ -37,6 +41,22 @@ Routes are organized under the `routes/` directory. `server.js` mounts two route
 
 This layout keeps API and web routes separate while avoiding an extra routing layer.
 
+## Coupang product endpoint
+
+`/api/coupang-open/product/:id` fetches product details from the Coupang Open API.
+The server must be configured with `CP_ACCESS_KEY`, `CP_SECRET_KEY` and `CP_VENDOR_ID`.
+Optionally, `CP_API_HOST` can override the default host.
+
+```js
+const axios = require('axios');
+
+const getProduct = async (id) => {
+  const { data } = await axios.get(`http://localhost:3000/api/coupang-open/product/${id}`);
+  console.log(data);
+};
+
+getProduct('1234');
+```
 
 =======
 


### PR DESCRIPTION
## Summary
- document Coupang Open API environment variables
- describe `/api/coupang-open/product/:id` endpoint with usage example

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6858ce649778832987535c345d470639