### PR TITLE
Add analytics dashboard and inventory scheduler

### DIFF
--- a/controllers/analyticsController.js
+++ b/controllers/analyticsController.js
@@ -1,0 +1,40 @@
+const asyncHandler = require('../middlewares/asyncHandler');
+
+async function aggregateMetrics(db) {
+  const pipeline = [
+    {
+      $group: {
+        _id: '$optionId',
+        impressions: { $sum: '$impressions' },
+        clicks: { $sum: '$clicks' },
+        adCost: { $sum: '$adCost' },
+        ctr: { $avg: '$ctr' },
+        cpc: { $avg: '$cpc' },
+      },
+    },
+    {
+      $project: {
+        _id: 0,
+        optionId: '$_id',
+        impressions: 1,
+        clicks: 1,
+        adCost: 1,
+        ctr: 1,
+        cpc: 1,
+      },
+    },
+  ];
+  return db.collection('adMetrics').aggregate(pipeline).toArray();
+}
+
+exports.getMetrics = asyncHandler(async (req, res) => {
+  const db = req.app.locals.db;
+  const data = await aggregateMetrics(db);
+  res.json(data);
+});
+
+exports.renderPage = asyncHandler(async (req, res) => {
+  const db = req.app.locals.db;
+  const metrics = await aggregateMetrics(db);
+  res.render('analytics', { metrics });
+});

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "moment": "^2.30.1",
     "mongodb": "^6.5.0",
     "mongoose": "^8.3.1",
+    "node-cron": "^3.0.2",
     "morgan": "^1.10.0",
     "multer": "^2.0.1",
     "multer-s3": "^3.0.1",

--- a/public/js/analytics.js
+++ b/public/js/analytics.js
@@ -1,0 +1,36 @@
+document.addEventListener('DOMContentLoaded', () => {
+  if (!window.metrics) return;
+  const labels = metrics.map(m => m.optionId);
+  const ctr = metrics.map(m => m.ctr);
+  const cpc = metrics.map(m => m.cpc);
+  const ctx = document.getElementById('adChart');
+  new Chart(ctx, {
+    type: 'bar',
+    data: {
+      labels,
+      datasets: [
+        {
+          label: 'CTR (%)',
+          data: ctr,
+          backgroundColor: 'rgba(54, 162, 235, 0.5)',
+          yAxisID: 'y',
+        },
+        {
+          label: 'CPC',
+          data: cpc,
+          backgroundColor: 'rgba(255, 99, 132, 0.5)',
+          yAxisID: 'y1',
+        },
+      ],
+    },
+    options: {
+      responsive: true,
+      scales: {
+        y1: {
+          position: 'right',
+          grid: { drawOnChartArea: false },
+        },
+      },
+    },
+  });
+});

--- a/routes/api/analytics.js
+++ b/routes/api/analytics.js
@@ -1,0 +1,7 @@
+const express = require('express');
+const router = express.Router();
+const ctrl = require('../../controllers/analyticsController');
+
+router.get('/', ctrl.getMetrics);
+
+module.exports = router;

--- a/routes/api/index.js
+++ b/routes/api/index.js
@@ -18,6 +18,8 @@ router.use("/coupang-add", require("./coupangAddApi"));
 router.use("/coupang-open", require("./coupangOpenApi"));
 // 날씨 API
 router.use("/weather", require("./weatherApi"));
+// 광고 성과 API
+router.use("/analytics", require("./analytics"));
 
 // TODO: 다른 API 라우터 추가 시 아래와 같이 등록
 // router.use("/user", require("./userApi"));

--- a/routes/web/analytics.js
+++ b/routes/web/analytics.js
@@ -1,0 +1,7 @@
+const express = require('express');
+const router = express.Router();
+const ctrl = require('../../controllers/analyticsController');
+
+router.get('/', ctrl.renderPage);
+
+module.exports = router;

--- a/routes/web/index.js
+++ b/routes/web/index.js
@@ -14,6 +14,7 @@ const protectedRoutes = new Set([
   'coupangAdd',
   'post',
   'profile',
+  'analytics',
 ]);
 
 fs.readdirSync(routesDir)

--- a/server.js
+++ b/server.js
@@ -14,6 +14,7 @@ const webRouter = require("./routes/web");
 const apiRouter = require("./routes/api");
 const { checkAuth } = require("./middlewares/auth");
 const errorHandler = require("./middlewares/errorHandler");
+const { startCronJobs } = require("./services/cronJobs");
 
 const app = express();
 
@@ -21,6 +22,7 @@ async function initApp() {
   // 1. MongoDB 연결
   const db = await connectDB();
   app.locals.db = db;
+  startCronJobs(db);
 
   // 2. Passport 설정
   require("./config/passport")(passport, db);

--- a/services/cronJobs.js
+++ b/services/cronJobs.js
@@ -1,0 +1,75 @@
+const cron = require('node-cron');
+const { coupangRequest } = require('../lib/coupangApiClient');
+
+async function updateInventory(db) {
+  const ids = await db.collection('coupang').distinct('Option ID');
+  for (const id of ids) {
+    try {
+      const path = `/v2/providers/openapi/apis/api/v1/marketplace/vendor-items/${id}`;
+      const data = await coupangRequest('GET', path);
+      const item = {
+        optionId: id,
+        optionName: data?.data?.optionName || '',
+        productName: data?.data?.sellerProductName || '',
+        price: data?.data?.price || 0,
+        stock: data?.data?.approvedStock || 0,
+        updatedAt: new Date(),
+      };
+      await db.collection('productStock').updateOne({ optionId: id }, { $set: item }, { upsert: true });
+    } catch (err) {
+      console.error('❌ Inventory fetch failed:', id, err.message);
+    }
+  }
+}
+
+async function calcAdMetrics(db) {
+  const pipeline = [
+    {
+      $group: {
+        _id: '$광고집행 옵션ID',
+        impressions: { $sum: '$노출수' },
+        clicks: { $sum: '$클릭수' },
+        adCost: { $sum: '$광고비' },
+      },
+    },
+    {
+      $project: {
+        _id: 0,
+        optionId: '$_id',
+        impressions: 1,
+        clicks: 1,
+        adCost: 1,
+        ctr: {
+          $cond: [
+            { $gt: ['$impressions', 0] },
+            {
+              $round: [
+                { $multiply: [{ $divide: ['$clicks', '$impressions'] }, 100] },
+                2,
+              ],
+            },
+            0,
+          ],
+        },
+        cpc: {
+          $cond: [{ $gt: ['$clicks', 0] }, { $round: [{ $divide: ['$adCost', '$clicks'] }, 2] }, 0],
+        },
+      },
+    },
+  ];
+  const data = await db.collection('coupangAdd').aggregate(pipeline).toArray();
+  for (const row of data) {
+    await db.collection('adMetrics').updateOne(
+      { optionId: row.optionId },
+      { $set: { ...row, updatedAt: new Date() } },
+      { upsert: true },
+    );
+  }
+}
+
+function startCronJobs(db) {
+  cron.schedule('0 * * * *', () => updateInventory(db));
+  cron.schedule('30 0 * * *', () => calcAdMetrics(db));
+}
+
+module.exports = { startCronJobs };

--- a/views/analytics.ejs
+++ b/views/analytics.ejs
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+  <meta charset="UTF-8">
+  <title>광고 성과 대시보드</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.6/dist/css/bootstrap.min.css" rel="stylesheet">
+  <link rel="stylesheet" href="/main.css">
+  <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+</head>
+<body class="bg-light">
+  <%- include('nav.ejs') %>
+  <div class="container my-5">
+    <h2 class="fw-bold mb-4">📈 광고 성과 대시보드</h2>
+    <canvas id="adChart" height="120"></canvas>
+  </div>
+  <script>
+    const metrics = <%- JSON.stringify(metrics) %>;
+  </script>
+  <script src="/js/analytics.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.6/dist/js/bootstrap.bundle.min.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- schedule inventory and advertising metrics updates with `node-cron`
- expose metrics via new API and render analytics dashboard
- display CTR and CPC charts using Chart.js

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6858d161b4808329a21065c509e6ae04