### PR TITLE
Add Coupang API EJS test page

### DIFF
--- a/routes/web/coupangApiClient.js
+++ b/routes/web/coupangApiClient.js
@@ -1,0 +1,24 @@
+const express = require('express');
+const router = express.Router();
+const { coupangRequest } = require('../../lib/coupangApiClient');
+
+router.get('/', (req, res) => {
+  res.render('coupangApiClient.ejs', { result: null, error: null });
+});
+
+router.get('/product', async (req, res) => {
+  const id = req.query.id;
+  if (!id) {
+    return res.render('coupangApiClient.ejs', { result: null, error: '상품 ID가 필요합니다.' });
+  }
+  try {
+    const vendorId = process.env.CP_VENDOR_ID;
+    const path = `/v2/providers/openapi/apis/api/v1/vendors/${vendorId}/products/${id}`;
+    const data = await coupangRequest('GET', path);
+    res.render('coupangApiClient.ejs', { result: JSON.stringify(data, null, 2), error: null });
+  } catch (err) {
+    res.render('coupangApiClient.ejs', { result: null, error: err.message });
+  }
+});
+
+module.exports = router;

--- a/views/coupangApiClient.ejs
+++ b/views/coupangApiClient.ejs
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+  <meta charset="UTF-8">
+  <title>쿠팡 API 테스트</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.6/dist/css/bootstrap.min.css" rel="stylesheet">
+  <link rel="stylesheet" href="/main.css">
+</head>
+<body class="bg-light">
+  <%- include('nav.ejs') %>
+
+  <div class="container my-5">
+    <h2 class="fw-bold mb-4">🛒 쿠팡 API 테스트</h2>
+    <form action="/coupangApiClient/product" method="get" class="mb-4">
+      <div class="input-group">
+        <input type="text" name="id" class="form-control" placeholder="상품 ID" required>
+        <button type="submit" class="btn btn-primary">조회</button>
+      </div>
+    </form>
+
+    <% if (error) { %>
+      <div class="alert alert-danger"><%= error %></div>
+    <% } %>
+    <% if (result) { %>
+      <pre class="bg-white border p-3"><%= result %></pre>
+    <% } %>
+  </div>
+
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.6/dist/js/bootstrap.bundle.min.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add web route `coupangApiClient` to test Coupang Open API requests
- create `coupangApiClient.ejs` view to display request results

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: cannot find package `@eslint/js`)*

------
https://chatgpt.com/codex/tasks/task_e_6858e524e7408329b5669cd8b56e8ae3