### PR TITLE
Switch Coupang signature to Base64

### DIFF
--- a/lib/coupangApiClient.js
+++ b/lib/coupangApiClient.js
@@ -11,7 +11,7 @@ const fetch = require('node-fetch');
  */
 function signRequest(method, urlPath, secretKey, timestamp) {
   const message = `${timestamp}${method}${urlPath}`;
-  return crypto.createHmac('sha256', secretKey).update(message).digest('hex');
+  return crypto.createHmac('sha256', secretKey).update(message).digest('base64');
 }
 
 /**

--- a/tests/coupangApiClient.test.js
+++ b/tests/coupangApiClient.test.js
@@ -30,7 +30,7 @@ test('coupangRequest sends signed request and returns data', async () => {
   const expectedSignature = crypto
     .createHmac('sha256', 'secret')
     .update('1600000000000GET/test?a=1')
-    .digest('hex');
+    .digest('base64');
 
   expect(mockFetch).toHaveBeenCalledWith(
     'https://api.example.com/test?a=1',


### PR DESCRIPTION
## Summary
- update coupang API HMAC signature to return Base64
- expect Base64-encoded signatures in tests

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6858f94715848329b42f80352ec63358