### PR TITLE
Add Coupang API helper module

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,17 @@ Some features convert Excel files to CSV using Python. Install the Python depend
 pip install -r requirements.txt
 ```
 
-The `requirements.txt` file lists the minimal packages (`pandas` and `openpyxl`) needed to parse Excel files.
+The `requirements.txt` file lists the minimal packages (`pandas`, `openpyxl` and `requests`) needed to parse Excel files and access the Coupang API.
+
+### Coupang API helper
+
+The module `scripts/coupang_api.py` signs and sends requests to the Coupang Open API. Set `CP_ACCESS_KEY`, `CP_SECRET_KEY` and `CP_VENDOR_ID` in your environment.
+
+Example:
+
+```bash
+python scripts/coupang_api.py GET /v2/providers/openapi/apis/api/v1/marketplace/seller-products/12345
+```
 
 ## Router structure
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,4 @@
 pandas
 openpyxl
+
+requests

--- a/scripts/coupang_api.py
+++ b/scripts/coupang_api.py
@@ -1,0 +1,53 @@
+import os
+import hmac
+import hashlib
+import time
+from urllib.parse import urlencode
+import requests
+
+
+def sign(method: str, url_path: str, secret_key: str, timestamp: str) -> str:
+    """Return Coupang API signature."""
+    message = f"{timestamp}{method}{url_path}"
+    return hmac.new(secret_key.encode("utf-8"), message.encode("utf-8"), hashlib.sha256).hexdigest()
+
+
+def coupang_request(method: str, path: str, *, query: dict | None = None, body: dict | None = None):
+    """Send a request to the Coupang Open API."""
+    access_key = os.getenv("CP_ACCESS_KEY")
+    secret_key = os.getenv("CP_SECRET_KEY")
+    vendor_id = os.getenv("CP_VENDOR_ID")
+    host = os.getenv("CP_API_HOST", "https://api-gateway.coupang.com")
+
+    if not access_key or not secret_key or not vendor_id:
+        raise RuntimeError("Coupang API credentials are not set")
+
+    query_str = "?" + urlencode(query) if query else ""
+    url_path = f"{path}{query_str}"
+    timestamp = str(int(time.time() * 1000))
+    signature = sign(method, url_path, secret_key, timestamp)
+
+    headers = {
+        "Authorization": f"CEA algorithm=HmacSHA256, access-key={access_key}, signed-date={timestamp}, signature={signature}",
+        "Content-Type": "application/json; charset=UTF-8",
+        "X-EXTENDED-VENDOR-ID": vendor_id,
+    }
+
+    resp = requests.request(method, host + url_path, headers=headers, json=body)
+    if not resp.ok:
+        raise RuntimeError(f"Coupang API error: {resp.status_code} {resp.text}")
+    return resp.json()
+
+
+if __name__ == "__main__":
+    import argparse, json
+
+    parser = argparse.ArgumentParser(description="Call Coupang Open API")
+    parser.add_argument("method")
+    parser.add_argument("path")
+    parser.add_argument("--query", help="Query string like key=val&key2=val2")
+    args = parser.parse_args()
+
+    q = dict(pair.split("=", 1) for pair in args.query.split("&")) if args.query else None
+    data = coupang_request(args.method.upper(), args.path, query=q)
+    print(json.dumps(data, ensure_ascii=False, indent=2))

--- a/tests/test_coupang_api.py
+++ b/tests/test_coupang_api.py
@@ -1,0 +1,45 @@
+import os
+import unittest
+from unittest.mock import patch, Mock
+
+from scripts.coupang_api import sign, coupang_request
+
+
+class CoupangApiTests(unittest.TestCase):
+    def test_sign(self):
+        sig = sign("GET", "/test?a=1", "secret", "1600000000000")
+        self.assertEqual(
+            sig,
+            "ee6f07919c1619aeb42e975369a390ec3990c5c2043434f6d4554f308eb2ae63",
+        )
+
+    @patch("requests.request")
+    @patch("time.time", return_value=1600000000)
+    def test_coupang_request_signing(self, mock_time, mock_request):
+        os.environ["CP_ACCESS_KEY"] = "access"
+        os.environ["CP_SECRET_KEY"] = "secret"
+        os.environ["CP_VENDOR_ID"] = "vendor"
+        os.environ["CP_API_HOST"] = "https://api.example.com"
+
+        mock_resp = Mock(ok=True)
+        mock_resp.json.return_value = {"result": "ok"}
+        mock_request.return_value = mock_resp
+
+        data = coupang_request("GET", "/test", query={"a": "1"})
+
+        expected_sig = "ee6f07919c1619aeb42e975369a390ec3990c5c2043434f6d4554f308eb2ae63"
+        mock_request.assert_called_with(
+            "GET",
+            "https://api.example.com/test?a=1",
+            headers={
+                "Authorization": f"CEA algorithm=HmacSHA256, access-key=access, signed-date=1600000000000, signature={expected_sig}",
+                "Content-Type": "application/json; charset=UTF-8",
+                "X-EXTENDED-VENDOR-ID": "vendor",
+            },
+            json=None,
+        )
+        self.assertEqual(data, {"result": "ok"})
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- create Python module for calling Coupang Open API
- document helper usage in README
- add requests to requirements.txt
- unit test signing logic

## Testing
- `pip install -r requirements.txt` *(fails: Tunnel connection failed)*
- `npm test` *(fails: jest: not found)*
- `python -m unittest tests/test_coupang_api.py` *(fails: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_6858f94a54508329b287f806a0f53459