### PR TITLE
Add RocketGross create API

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,3 +11,4 @@ CP_SECRET_KEY=your-coupang-secret-key
 CP_VENDOR_ID=your-coupang-vendor-id
 # optional - default is https://api-gateway.coupang.com
 CP_API_HOST=https://api-gateway.coupang.com
+CP_RG_AUTH_TOKEN=your-rocketgross-token

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ This project requires several environment variables to run:
 - `CP_SECRET_KEY` – Coupang Open API secret key
 - `CP_VENDOR_ID` – Vendor ID issued by Coupang
 - `CP_API_HOST` – Base URL for the Coupang Open API (optional)
+- `CP_RG_AUTH_TOKEN` – Token for RocketGross API calls (enable the feature in WING first)
 
 
 Copy `.env.example` to `.env` in the project root and define these values before starting the server. Make sure the file is saved as **UTF-8 without BOM** so that `dotenv` can read it correctly.
@@ -58,6 +59,23 @@ const getProduct = async (id) => {
 };
 
 getProduct('1234');
+```
+
+## RocketGross product creation
+
+Enable the **RocketGross** API in WING and copy the issued token to
+`CP_RG_AUTH_TOKEN`.
+Then you can register a product through `/api/coupang-open/product/create`:
+
+```js
+const axios = require('axios');
+
+const createProduct = async (body) => {
+  const { data } = await axios.post('http://localhost:3000/api/coupang-open/product/create', body);
+  console.log(data);
+};
+
+createProduct({ name: 'Sample' });
 ```
 
 =======

--- a/controllers/coupangOpenController.js
+++ b/controllers/coupangOpenController.js
@@ -9,3 +9,21 @@ exports.getProduct = asyncHandler(async (req, res) => {
   const data = await coupangRequest('GET', path);
   res.json(data);
 });
+
+// Create product via RocketGross
+exports.createRocketGrossProduct = asyncHandler(async (req, res) => {
+  const vendorId = process.env.CP_VENDOR_ID;
+  const path = `/v2/providers/openapi/apis/api/v1/vendors/${vendorId}/rocket-gross/product`;
+  const headers = {};
+
+  if (process.env.CP_RG_AUTH_TOKEN) {
+    headers['X-ROCKETGROSS-AUTH-TOKEN'] = process.env.CP_RG_AUTH_TOKEN;
+  }
+
+  const data = await coupangRequest('POST', path, {
+    body: req.body,
+    headers,
+  });
+
+  res.json(data);
+});

--- a/lib/coupangApiClient.js
+++ b/lib/coupangApiClient.js
@@ -18,7 +18,7 @@ function signRequest(method, urlPath, secretKey, timestamp) {
  * Perform request to Coupang Open API
  * @param {string} method HTTP method
  * @param {string} path API path (without host)
- * @param {object} [options] Optional settings: query, body
+ * @param {object} [options] Optional settings: query, body, headers
  */
 async function coupangRequest(method, path, options = {}) {
   const accessKey = process.env.CP_ACCESS_KEY;
@@ -41,6 +41,7 @@ async function coupangRequest(method, path, options = {}) {
     Authorization: `CEA algorithm=HmacSHA256, access-key=${accessKey}, signed-date=${timestamp}, signature=${signature}`,
     'Content-Type': 'application/json; charset=UTF-8',
     'X-EXTENDED-VENDOR-ID': vendorId,
+    ...(options.headers || {}),
   };
 
   const res = await fetch(host + urlPath, {

--- a/routes/api/coupangOpenApi.js
+++ b/routes/api/coupangOpenApi.js
@@ -3,5 +3,6 @@ const router = express.Router();
 const ctrl = require('../../controllers/coupangOpenController');
 
 router.get('/product/:id', ctrl.getProduct);
+router.post('/product/create', ctrl.createRocketGrossProduct);
 
 module.exports = router;

--- a/tests/coupangOpenCreate.test.js
+++ b/tests/coupangOpenCreate.test.js
@@ -1,0 +1,48 @@
+jest.setTimeout(60000);
+
+jest.mock('../config/db', () => {
+  const mockDb = { collection: jest.fn() };
+  const mockConnect = jest.fn().mockResolvedValue(mockDb);
+  mockConnect.then = (fn) => fn(mockDb);
+  return { connectDB: mockConnect, closeDB: jest.fn().mockResolvedValue() };
+});
+
+jest.mock('node-fetch');
+const mockFetch = require('node-fetch');
+
+const request = require('supertest');
+const { initApp } = require('../server');
+const { closeDB } = require('../config/db');
+
+let app;
+
+beforeAll(async () => {
+  process.env.NODE_ENV = 'test';
+  process.env.MONGO_URI = 'mongodb://127.0.0.1:27017/testdb';
+  process.env.DB_NAME = 'testdb';
+  process.env.SESSION_SECRET = 'testsecret';
+  process.env.CP_ACCESS_KEY = 'access';
+  process.env.CP_SECRET_KEY = 'secret';
+  process.env.CP_VENDOR_ID = 'vendor';
+  process.env.CP_RG_AUTH_TOKEN = 'token';
+
+  mockFetch.mockResolvedValue({
+    ok: true,
+    json: async () => ({ result: 'ok' }),
+  });
+
+  app = await initApp();
+});
+
+afterAll(async () => {
+  await closeDB();
+});
+
+test('POST /api/coupang-open/product/create creates product', async () => {
+  const res = await request(app)
+    .post('/api/coupang-open/product/create')
+    .send({ name: 'Sample' });
+  expect(res.statusCode).toBe(200);
+  expect(res.body).toEqual({ result: 'ok' });
+  expect(mockFetch).toHaveBeenCalled();
+});


### PR DESCRIPTION
## Summary
- support optional request headers in `coupangRequest`
- add RocketGross product creation controller and route
- document RocketGross token and usage in README
- provide `.env.example` placeholder for the token
- test new RocketGross creation endpoint

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6858f94c9ab483298478c28a50e08584