### PR TITLE
Improve Coupang page performance

### DIFF
--- a/config/initIndexes.js
+++ b/config/initIndexes.js
@@ -1,0 +1,12 @@
+async function initIndexes(db) {
+  try {
+    const coupangCollection = db.collection('coupang');
+    if (typeof coupangCollection.createIndex === 'function') {
+      await coupangCollection.createIndex({ 'Product name': 1 });
+    }
+  } catch (err) {
+    console.error('Failed to create indexes:', err.message);
+  }
+}
+
+module.exports = { initIndexes };

--- a/server.js
+++ b/server.js
@@ -10,6 +10,7 @@ const helmet = require("helmet");
 const compression = require("compression");
 const flash = require("connect-flash");
 const { connectDB } = require("./config/db");
+const { initIndexes } = require("./config/initIndexes");
 const webRouter = require("./routes/web");
 const apiRouter = require("./routes/api");
 const { checkAuth } = require("./middlewares/auth");
@@ -21,6 +22,7 @@ const app = express();
 async function initApp() {
   // 1. MongoDB 연결
   const db = await connectDB();
+  await initIndexes(db);
   app.locals.db = db;
   startCronJobs(db);
 


### PR DESCRIPTION
## Summary
- add an index initialization helper
- create Coupang collection index during server startup

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685900647c288329bfb4a25b82e45e7f