### PR TITLE
Fix Coupang search and add brand filter

### DIFF
--- a/controllers/coupangAddController.js
+++ b/controllers/coupangAddController.js
@@ -133,6 +133,7 @@ exports.renderPage = asyncHandler(async (req, res) => {
   res.render('coupangAdd', {
     mode,
     search,
+    brand,
   });
 });
 
@@ -146,6 +147,7 @@ exports.getData = asyncHandler(async (req, res) => {
     typeof req.query.search === 'string'
       ? req.query.search
       : req.query.search?.value || '';
+  const brand = req.query.brand || '';
 
   // 기본 정렬 기준
   let sort = { _id: -1 };
@@ -163,14 +165,19 @@ exports.getData = asyncHandler(async (req, res) => {
     }
   }
 
-  const filter = keyword
-    ? {
-        $or: [
-          { '광고집행 상품명': { $regex: keyword, $options: 'i' } },
-          { '광고집행 옵션ID': { $regex: keyword, $options: 'i' } },
-        ],
-      }
-    : {};
+  const conditions = [];
+  if (keyword) {
+    conditions.push({
+      $or: [
+        { '광고집행 상품명': { $regex: keyword, $options: 'i' } },
+        { '광고집행 옵션ID': { $regex: keyword, $options: 'i' } },
+      ],
+    });
+  }
+  if (brand) {
+    conditions.push({ '광고집행 상품명': { $regex: brand, $options: 'i' } });
+  }
+  const filter = conditions.length ? { $and: conditions } : {};
 
   const [total, recordsFiltered, rows] = await Promise.all([
     db.collection('coupangAdd').countDocuments(),

--- a/public/js/coupangAdd.js
+++ b/public/js/coupangAdd.js
@@ -24,6 +24,9 @@ $(function () {
         if (typeof pageSearch !== 'undefined') {
           d.search = pageSearch;
         }
+        if (typeof pageBrand !== 'undefined') {
+          d.brand = pageBrand;
+        }
       },
       dataSrc: 'data',
     },

--- a/views/coupang-add-summary.ejs
+++ b/views/coupang-add-summary.ejs
@@ -24,10 +24,11 @@
       <select name="brand" class="form-select me-2" style="max-width: 150px;">
         <option value="">전체 브랜드</option>
         <option value="트라이" <%= brand === '트라이' ? 'selected' : '' %>>트라이</option>
+        <option value="좋은사람들" <%= brand === '좋은사람들' ? 'selected' : '' %>>좋은사람들</option>
         <option value="BYC" <%= brand === 'BYC' ? 'selected' : '' %>>BYC</option>
         <option value="비비안" <%= brand === '비비안' ? 'selected' : '' %>>비비안</option>
       </select>
-      <button class="btn btn-outline-primary">검색</button>
+      <button class="btn btn-outline-primary search-send">검색</button>
     </form>
 
     <table class="table table-bordered table-hover text-center">

--- a/views/coupangAdd.ejs
+++ b/views/coupangAdd.ejs
@@ -28,14 +28,28 @@
       <form method="GET" class="mb-3 d-flex" action="/coupang/add">
         <input type="hidden" name="mode" value="summary">
         <input type="text" name="search" value="<%= search %>" class="form-control me-2" placeholder="상품명 또는 옵션ID 검색">
-        <button class="btn btn-outline-primary">검색</button>
+        <select name="brand" class="form-select me-2" style="max-width: 150px;">
+          <option value="">전체 브랜드</option>
+          <option value="트라이" <%= brand === '트라이' ? 'selected' : '' %>>트라이</option>
+          <option value="좋은사람들" <%= brand === '좋은사람들' ? 'selected' : '' %>>좋은사람들</option>
+          <option value="BYC" <%= brand === 'BYC' ? 'selected' : '' %>>BYC</option>
+          <option value="비비안" <%= brand === '비비안' ? 'selected' : '' %>>비비안</option>
+        </select>
+        <button class="btn btn-outline-primary search-send">검색</button>
       </form>
       <p class="text-end mb-2">총 <%= total %>건의 결과가 있습니다.</p>
     <% } else { %>
       <form method="GET" class="d-flex align-items-center mb-3" action="/coupang/add">
         <input type="hidden" name="mode" value="detail">
         <input name="search" class="form-control me-2" value="<%= search %>" placeholder="상품명 또는 옵션ID 검색">
-        <button class="btn btn-outline-primary">검색</button>
+        <select name="brand" class="form-select me-2" style="max-width: 150px;">
+          <option value="">전체 브랜드</option>
+          <option value="트라이" <%= brand === '트라이' ? 'selected' : '' %>>트라이</option>
+          <option value="좋은사람들" <%= brand === '좋은사람들' ? 'selected' : '' %>>좋은사람들</option>
+          <option value="BYC" <%= brand === 'BYC' ? 'selected' : '' %>>BYC</option>
+          <option value="비비안" <%= brand === '비비안' ? 'selected' : '' %>>비비안</option>
+        </select>
+        <button class="btn btn-outline-primary search-send">검색</button>
       </form>
     <% } %>
 
@@ -60,7 +74,7 @@
 
     <div class="table-responsive">
       <table id="coupangAddTable" data-mode="<%= mode %>" class="table table-bordered table-hover bg-white align-middle text-center auto-width">
-        <thead class="table-light">
+        <thead class="table-primary">
           <% if (mode === 'summary') { %>
             <tr>
               <th>상품명</th>
@@ -126,7 +140,11 @@
   <script src="https://cdn.datatables.net/1.13.6/js/jquery.dataTables.min.js"></script>
   <script src="https://cdn.datatables.net/1.13.6/js/dataTables.bootstrap5.min.js"></script>
 
-  <script>var pageMode = '<%= mode %>'; var pageSearch = '<%= search %>';</script>
+  <script>
+    var pageMode = '<%= mode %>';
+    var pageSearch = '<%= search %>';
+    var pageBrand = '<%= brand %>';
+  </script>
   <script src="/js/coupangAdd.js"></script>
 
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.6/dist/js/bootstrap.bundle.min.js"></script>


### PR DESCRIPTION
## Summary
- unify header color in `coupangAdd` table
- support brand filter for detail data view
- add brand dropdown to search forms
- include additional brand "좋은사람들"
- pass brand parameter in DataTables requests

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: cannot find @eslint/js)*

------
https://chatgpt.com/codex/tasks/task_e_68590b65fdd08329b9334a85ab269c92