### PR TITLE
Improve table styling consistency

### DIFF
--- a/public/js/coupang.js
+++ b/public/js/coupang.js
@@ -9,6 +9,7 @@ $(function () {
     paging: false,
     searching: false,
     info: false,
+    responsive: true,
     language: {
       paginate: { previous: '이전', next: '다음' },
       info: '총 _TOTAL_건 중 _START_ ~ _END_',

--- a/public/js/coupangAdd.js
+++ b/public/js/coupangAdd.js
@@ -11,6 +11,7 @@ $(function () {
     info: true,
     pageLength: 50,
     lengthChange: false,
+    responsive: true,
     order: [[0, 'asc']],
     columnDefs: [
       { targets: '_all', className: 'text-center' },

--- a/public/js/stock.js
+++ b/public/js/stock.js
@@ -24,6 +24,7 @@ $(document).ready(function () {
     info: true,
     pageLength: 50,
     lengthChange: false,
+    responsive: true,
     columnDefs: [
       { targets: '_all', className: 'text-center' },
       {

--- a/public/main.css
+++ b/public/main.css
@@ -276,6 +276,13 @@ td:nth-child(3) {
   font-size: 0.9rem;
 }
 
+/* Global DataTables cell size */
+.dataTable td,
+.dataTable th {
+  font-size: 0.9rem;
+  white-space: nowrap;
+}
+
 /* Dashboard card styles */
 .dashboard-cards .card {
   transition: transform 0.2s;

--- a/views/coupangAdd.ejs
+++ b/views/coupangAdd.ejs
@@ -59,7 +59,7 @@
 
 
     <div class="table-responsive">
-      <table id="coupangAddTable" data-mode="<%= mode %>" class="table table-bordered table-hover bg-white align-middle text-center auto-width">
+      <table id="coupangAddTable" data-mode="<%= mode %>" class="table table-bordered table-hover table-striped bg-white align-middle text-center auto-width">
         <thead class="table-light">
           <% if (mode === 'summary') { %>
             <tr>

--- a/views/stock.ejs
+++ b/views/stock.ejs
@@ -40,7 +40,7 @@
 
     <!-- 테이블 -->
     <div class="table-responsive table-container">
-      <table id="stockTable" class="table table-bordered table-hover bg-white align-middle text-center auto-width">
+      <table id="stockTable" class="table table-bordered table-hover table-striped bg-white align-middle text-center auto-width">
         <thead class="table-light">
           <tr>
             <th>#</th>


### PR DESCRIPTION
## Summary
- unify table striped style for stock and coupang add pages
- make DataTables responsive across stock, coupang and coupangAdd
- apply global DataTables font style

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68590e0f4bb88329a45950265214aa9c