### PR TITLE
Improve Coupang sort & filter

### DIFF
--- a/public/js/coupang.js
+++ b/public/js/coupang.js
@@ -1,43 +1,24 @@
 $(function () {
   if (!$('#coupangTable').length) return;
-  var showReorderOnly = false;
-  var table = $('#coupangTable').DataTable({
-    ordering: true,
-    order: [[1, 'asc']],
-    columnDefs: [{ targets: 0, orderable: false }],
-    lengthChange: false,
-    paging: false,
-    searching: false,
-    info: false,
-    language: {
-      paginate: { previous: '이전', next: '다음' },
-      info: '총 _TOTAL_건 중 _START_ ~ _END_',
-      infoEmpty: '데이터가 없습니다'
-    }
-  });
-
-  $.fn.dataTable.ext.search.push(function (settings, data, dataIndex) {
-    if (!showReorderOnly) return true;
-    var row = $(table.row(dataIndex).node());
-    var shortage = Number(row.data('shortage')) || 0;
-    return shortage > 0;
-  });
 
   $('#btn-filter-reorder').on('click', function () {
-    showReorderOnly = !showReorderOnly;
-    $(this).text(showReorderOnly ? '전체 보기' : '입고 필요만 보기');
-    table.draw();
+    var url = new URL(window.location.href);
+    var show = url.searchParams.get('shortage') === '1';
+    if (show) url.searchParams.delete('shortage');
+    else url.searchParams.set('shortage', '1');
+    url.searchParams.set('page', '1');
+    window.location.href = url.toString();
   });
 
   $('#btn-download-csv').on('click', function () {
     var rows = [];
-    table.rows().every(function (rowIdx) {
-      var node = $(this.node());
-      var shortage = Number(node.data('shortage')) || 0;
+    $('#coupangTable tbody tr').each(function () {
+      var shortage = Number($(this).data('shortage')) || 0;
       if (shortage > 0) {
-        var data = this.data();
-        var text = $(this.node()).find('td').map(function(){return $(this).text().trim().replace(/,/g,'');}).get().slice(1);
-        rows.push(text.join(','));
+        var cols = $(this).find('td').map(function () {
+          return $(this).text().trim().replace(/,/g, '');
+        }).get().slice(1);
+        rows.push(cols.join(','));
       }
     });
     if (!rows.length) {

--- a/views/coupang.ejs
+++ b/views/coupang.ejs
@@ -6,7 +6,6 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.6/dist/css/bootstrap.min.css" rel="stylesheet">
   <link rel="stylesheet" href="/main.css">
-  <link rel="stylesheet" href="https://cdn.datatables.net/1.13.6/css/dataTables.bootstrap5.min.css">
 </head>
 <body class="bg-light">
 
@@ -16,7 +15,7 @@
   <div class="container my-5">
     <h2 class="mb-4 fw-bold">🛒 쿠팡재고</h2>
     <div class="alert alert-info mb-4">
-      <p class="mb-1">헤더를 클릭하면 오름차순/내림차순 정렬이 가능하며 50개씩 페이지 이동이 가능합니다.</p>
+      <p class="mb-1">헤더를 클릭하면 전체 데이터를 기준으로 오름차순/내림차순 정렬합니다.</p>
       <p class="mb-0">검색 후에는 옵션명과 30일 판매량을 그래프로 확인할 수 있습니다.</p>
     </div>
 
@@ -72,11 +71,10 @@
 
     <% if (결과 && 결과.length > 0) { %>
       <p class="text-muted">🔎 전체 <strong><%= 전체건수 %></strong>건 중 <strong><%= 현재페이지 %>/<%= 전체페이지 %></strong>페이지를 보고 있습니다.</p>
-      <% let reorderCount = 0; 결과.forEach(item => { const s = Number(item['Shortage quantity']||0); const sales=Number(item['Sales in the last 30 days']||0); const stock=Number(item['Orderable quantity (real-time)']||0); if (s>0 || (sales>0 && stock===0)) reorderCount++; }); %>
       <div class="alert alert-warning d-flex justify-content-between align-items-center mb-3">
         <span>입고 필요 항목: <strong><%= reorderCount %></strong>건</span>
         <div class="d-flex gap-2">
-          <button id="btn-filter-reorder" class="btn btn-sm btn-outline-danger">입고 필요만 보기</button>
+          <button id="btn-filter-reorder" class="btn btn-sm btn-outline-danger"><%= shortageOnly ? '전체 보기' : '입고 필요만 보기' %></button>
           <button id="btn-download-csv" class="btn btn-sm btn-outline-success">입고 요청서 다운로드</button>
         </div>
       </div>
@@ -89,7 +87,13 @@
             <tr>
               <th>번호</th>
               <% 필드.forEach((key) => { %>
-                <th><%= 한글?.[key] || key %></th>
+                <% const nextOrder = sortField === key && sortOrder === 1 ? 'desc' : 'asc'; %>
+                <th>
+                  <a href="?page=1&sort=<%= encodeURIComponent(key) %>&order=<%= nextOrder %><%= 추가쿼리.replace(/&?(sort|order)=[^&]*/g,'').replace(/^&/, '&') %>">
+                    <%= 한글?.[key] || key %>
+                    <% if (sortField === key) { %><%= sortOrder === 1 ? '▲' : '▼' %><% } %>
+                  </a>
+                </th>
               <% }) %>
             </tr>
           <% } else { %>
@@ -159,10 +163,6 @@
   </div>
 
   <script src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
-  <script src="https://cdn.datatables.net/1.13.6/js/jquery.dataTables.min.js"></script>
-  <script src="https://cdn.datatables.net/1.13.6/js/dataTables.bootstrap5.min.js"></script>
-
-
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.6/dist/js/bootstrap.bundle.min.js"></script>
   <script src="/js/coupang.js"></script>
 </body>


### PR DESCRIPTION
## Summary
- support global sort and shortage filter on Coupang routes
- add toggle logic for viewing shortage items only
- update Coupang inventory page to use server-side sort links
- simplify JS logic and CSV export

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68590ea3849c83298eb8d987ba5bbb9d