### PR TITLE
Enhance summary page

### DIFF
--- a/views/coupang-add-summary.ejs
+++ b/views/coupang-add-summary.ejs
@@ -27,6 +27,7 @@
         <option value="좋은사람들" <%= brand === '좋은사람들' ? 'selected' : '' %>>좋은사람들</option>
         <option value="BYC" <%= brand === 'BYC' ? 'selected' : '' %>>BYC</option>
         <option value="비비안" <%= brand === '비비안' ? 'selected' : '' %>>비비안</option>
+        <option value="제임스딘" <%= brand === '제임스딘' ? 'selected' : '' %>>제임스딘</option>
       </select>
       <button class="btn btn-outline-primary search-send">검색</button>
     </form>
@@ -77,6 +78,28 @@
         <% }) %>
       </tbody>
     </table>
+    <% const groupSize = 10;
+       const startPage = Math.floor((page - 1) / groupSize) * groupSize + 1;
+       const endPage = Math.min(startPage + groupSize - 1, totalPages); %>
+    <nav aria-label="Page navigation">
+      <ul class="pagination justify-content-center">
+        <% if (page > 1) { %>
+          <li class="page-item">
+            <a class="page-link" href="?mode=summary&page=<%= page - 1 %>&search=<%= search %>&brand=<%= brand %>">◀ 이전</a>
+          </li>
+        <% } %>
+        <% for (let i = startPage; i <= endPage; i++) { %>
+          <li class="page-item <%= i === page ? 'active' : '' %>">
+            <a class="page-link" href="?mode=summary&page=<%= i %>&search=<%= search %>&brand=<%= brand %>"><%= i %></a>
+          </li>
+        <% } %>
+        <% if (page < totalPages) { %>
+          <li class="page-item">
+            <a class="page-link" href="?mode=summary&page=<%= page + 1 %>&search=<%= search %>&brand=<%= brand %>">다음 ▶</a>
+          </li>
+        <% } %>
+      </ul>
+    </nav>
   </div>
 
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.6/dist/js/bootstrap.bundle.min.js"></script>


### PR DESCRIPTION
## Summary
- include new brand `제임스딘` in brand filter
- add pagination UI to navigate summary results

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: cannot find `@eslint/js`)*

------
https://chatgpt.com/codex/tasks/task_e_6859121d58708329b4e38b9410f5bc20