### PR TITLE
Fix sort order in summary table

### DIFF
--- a/views/coupang-add-summary.ejs
+++ b/views/coupang-add-summary.ejs
@@ -95,8 +95,8 @@
       th.addEventListener('click', () => {
         const field = th.dataset.field;
         const currentField = '<%= sortField %>';
-        const currentOrder = <%= sortOrder %>;
-        const nextOrder = field === currentField && currentOrder === -1 ? 'asc' : 'desc';
+        const currentOrder = '<%= sortOrder === 1 ? 'asc' : 'desc' %>';
+        const nextOrder = field === currentField && currentOrder === 'desc' ? 'asc' : 'desc';
         const params = new URLSearchParams(window.location.search);
         params.set('sort', field);
         params.set('order', nextOrder);


### PR DESCRIPTION
## Summary
- fix sort order logic for Coupang add summary table

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68591d52408c8329a62d2a73980fcf1e