### PR TITLE
Unify table design with stock page

### DIFF
--- a/public/js/coupang.js
+++ b/public/js/coupang.js
@@ -5,7 +5,10 @@ $(function () {
   var table = $('#coupangTable').DataTable({
     ordering: true,
     order: [[1, 'asc']],
-    columnDefs: [{ targets: 0, orderable: false }],
+    columnDefs: [
+      { targets: '_all', className: 'text-center' },
+      { targets: 0, orderable: false }
+    ],
     lengthChange: false,
     paging: false,
     searching: false,

--- a/public/js/coupangAddSummary.js
+++ b/public/js/coupangAddSummary.js
@@ -1,0 +1,19 @@
+$(function () {
+  const table = $('#summaryTable');
+  if (!table.length) return;
+  table.DataTable({
+    ordering: true,
+    order: [[1, 'asc']],
+    paging: false,
+    searching: false,
+    info: false,
+    lengthChange: false,
+    responsive: true,
+    columnDefs: [{ targets: '_all', className: 'text-center' }],
+    language: {
+      paginate: { previous: '이전', next: '다음' },
+      info: '총 _TOTAL_건 중 _START_ ~ _END_',
+      infoEmpty: '데이터가 없습니다'
+    }
+  });
+});

--- a/views/coupang-add-summary.ejs
+++ b/views/coupang-add-summary.ejs
@@ -6,6 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.6/dist/css/bootstrap.min.css" rel="stylesheet">
   <link rel="stylesheet" href="/main.css">
+  <link rel="stylesheet" href="https://cdn.datatables.net/1.13.6/css/dataTables.bootstrap5.min.css">
 </head>
 <body class="bg-light">
   <%- include('nav.ejs') %>
@@ -32,40 +33,32 @@
       <button class="btn btn-outline-primary search-send">검색</button>
     </form>
 
-    <table class="simple-table text-center">
-      <thead class="text-center">
-        <tr>
-          <th>번호</th>
-          <th class="sortable" data-field="name">
-            상품명 <span class="sort-indicator"><%= sortField === 'name' ? (sortOrder === -1 ? '🔽' : '🔼') : '' %></span>
-          </th>
-          <th class="sortable" data-field="impressions">
-            노출수 합 <span class="sort-indicator"><%= sortField === 'impressions' ? (sortOrder === -1 ? '🔽' : '🔼') : '' %></span>
-          </th>
-          <th class="sortable" data-field="clicks">
-            클릭수 합 <span class="sort-indicator"><%= sortField === 'clicks' ? (sortOrder === -1 ? '🔽' : '🔼') : '' %></span>
-          </th>
-          <th class="sortable" data-field="adCost">
-            광고비 합 <span class="sort-indicator"><%= sortField === 'adCost' ? (sortOrder === -1 ? '🔽' : '🔼') : '' %></span>
-          </th>
-          <th class="sortable" data-field="ctr">
-            클릭률 <span class="sort-indicator"><%= sortField === 'ctr' ? (sortOrder === -1 ? '🔽' : '🔼') : '' %></span>
-          </th>
-        </tr>
-      </thead>
-      <tbody>
-        <% list.forEach(item => { %>
+    <div class="table-responsive table-container">
+      <table id="summaryTable" class="table table-bordered table-hover table-striped bg-white align-middle text-center auto-width">
+        <thead class="table-light text-center">
           <tr>
-            <td><%= item.no %></td>
-            <td><%= item.productName %></td>
-            <td><%= item.impressions.toLocaleString() %></td>
-            <td><%= item.clicks.toLocaleString() %></td>
-            <td><%= item.adCost.toLocaleString() %></td>
-            <td><%= item.ctr %>%</td>
+            <th>번호</th>
+            <th>상품명</th>
+            <th>노출수 합</th>
+            <th>클릭수 합</th>
+            <th>광고비 합</th>
+            <th>클릭률</th>
           </tr>
-        <% }) %>
-      </tbody>
-    </table>
+        </thead>
+        <tbody>
+          <% list.forEach(item => { %>
+            <tr>
+              <td><%= item.no %></td>
+              <td><%= item.productName %></td>
+              <td><%= item.impressions.toLocaleString() %></td>
+              <td><%= item.clicks.toLocaleString() %></td>
+              <td><%= item.adCost.toLocaleString() %></td>
+              <td><%= item.ctr %>%</td>
+            </tr>
+          <% }) %>
+        </tbody>
+      </table>
+    </div>
     <% const groupSize = 10;
        const startPage = Math.floor((page - 1) / groupSize) * groupSize + 1;
        const endPage = Math.min(startPage + groupSize - 1, totalPages); %>
@@ -90,21 +83,10 @@
     </nav>
   </div>
 
-  <script>
-    document.querySelectorAll('th.sortable').forEach(th => {
-      th.addEventListener('click', () => {
-        const field = th.dataset.field;
-        const currentField = '<%= sortField %>';
-        const currentOrder = '<%= sortOrder === 1 ? 'asc' : 'desc' %>';
-        const nextOrder = field === currentField && currentOrder === 'desc' ? 'asc' : 'desc';
-        const params = new URLSearchParams(window.location.search);
-        params.set('sort', field);
-        params.set('order', nextOrder);
-        params.set('page', '1');
-        window.location.search = params.toString();
-      });
-    });
-  </script>
+  <script src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
+  <script src="https://cdn.datatables.net/1.13.6/js/jquery.dataTables.min.js"></script>
+  <script src="https://cdn.datatables.net/1.13.6/js/dataTables.bootstrap5.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.6/dist/js/bootstrap.bundle.min.js"></script>
+  <script src="/js/coupangAddSummary.js"></script>
 </body>
 </html>

--- a/views/coupang.ejs
+++ b/views/coupang.ejs
@@ -6,6 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.6/dist/css/bootstrap.min.css" rel="stylesheet">
   <link rel="stylesheet" href="/main.css">
+  <link rel="stylesheet" href="https://cdn.datatables.net/1.13.6/css/dataTables.bootstrap5.min.css">
 </head>
 <body class="bg-light">
 
@@ -79,8 +80,8 @@
       </div>
     <% } %>
 
-    <div class="table-responsive">
-      <table id="coupangTable" class="table table-bordered table-sm align-middle text-center auto-width coupang-table">
+    <div class="table-responsive table-container">
+      <table id="coupangTable" class="table table-bordered table-hover table-striped bg-white align-middle text-center auto-width coupang-table">
         <thead class="table-light text-center">
           <% if (필드 && 필드.length > 0) { %>
             <tr>
@@ -152,6 +153,8 @@
   </div>
 
   <script src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
+  <script src="https://cdn.datatables.net/1.13.6/js/jquery.dataTables.min.js"></script>
+  <script src="https://cdn.datatables.net/1.13.6/js/dataTables.bootstrap5.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.6/dist/js/bootstrap.bundle.min.js"></script>
   <script src="/js/coupang.js"></script>
 </body>

--- a/views/coupangAdd.ejs
+++ b/views/coupangAdd.ejs
@@ -72,9 +72,9 @@
 
 
 
-    <div class="table-responsive">
+    <div class="table-responsive table-container">
 
-      <table id="coupangAddTable" data-mode="<%= mode %>" class="table table-bordered table-hover bg-white align-middle text-center auto-width">
+      <table id="coupangAddTable" data-mode="<%= mode %>" class="table table-bordered table-hover table-striped bg-white align-middle text-center auto-width">
         <thead class="table-primary">
 
           <% if (mode === 'summary') { %>


### PR DESCRIPTION
## Summary
- apply bootstrap DataTables styling to Coupang pages
- use common table classes for uniform look
- add a DataTable script for the summary page

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68591f6cf03483298a9c1b97e02b2cc9