### PR TITLE
Add upload/reset alerts and tweak table style

### DIFF
--- a/public/js/coupangAdd.js
+++ b/public/js/coupangAdd.js
@@ -49,6 +49,7 @@ $(function () {
 
   $('#uploadForm').on('submit', function (e) {
     e.preventDefault();
+    alert('업로드 중입니다. 잠시만 기다려주세요.');
     const formData = new FormData(this);
     $.ajax({
       url: '/coupang/add/upload',
@@ -64,5 +65,12 @@ $(function () {
         alert('업로드 실패: ' + xhr.responseText);
       }
     });
+  });
+
+  $('#resetForm').on('submit', function () {
+    if (!confirm('정말 모든 데이터를 삭제하시겠습니까?')) {
+      return false;
+    }
+    alert('데이터 삭제 중입니다. 잠시만 기다려주세요.');
   });
 });

--- a/public/main.css
+++ b/public/main.css
@@ -319,3 +319,8 @@ td:nth-child(3) {
 .simple-table tbody tr:hover {
   background-color: #f1f1f1;
 }
+
+/* Remove stripe color from first row */
+.table-striped > tbody > tr:first-child {
+  background-color: transparent;
+}

--- a/views/coupangAdd.ejs
+++ b/views/coupangAdd.ejs
@@ -65,7 +65,7 @@
         <input type="file" name="excelFile" accept=".xlsx, .xls" class="form-control" required>
         <button type="submit" class="btn btn-success btn-upload">엑셀 업로드</button>
       </form>
-      <form action="/coupang/add/delete-all" method="POST" onsubmit="return confirm('정말 모든 데이터를 삭제하시겠습니까?')">
+      <form id="resetForm" action="/coupang/add/delete-all" method="POST">
         <button type="submit" class="btn btn-danger btn-reset">데이터 초기화</button>
       </form>
     </div>


### PR DESCRIPTION
## Summary
- notify users that Excel uploads are processing
- ask for confirmation and show progress alert for data reset
- remove stripe colour on first row of tables

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68592374a5688329987d39ccd85d865b