### PR TITLE
Enable full data sorting on coupang page

### DIFF
--- a/public/js/coupang.js
+++ b/public/js/coupang.js
@@ -3,8 +3,7 @@ $(function () {
   var url = new URL(window.location.href);
   var showReorderOnly = url.searchParams.get('shortage') === '1';
   var table = $('#coupangTable').DataTable({
-    ordering: true,
-    order: [[1, 'asc']],
+    ordering: false,
     columnDefs: [
       { targets: '_all', className: 'text-center' },
       { targets: 0, orderable: false }
@@ -21,22 +20,35 @@ $(function () {
     }
   });
 
-  $.fn.dataTable.ext.search.push(function (settings, data, dataIndex) {
-    if (!showReorderOnly) return true;
-    var row = $(table.row(dataIndex).node());
-    var shortage = Number(row.data('shortage')) || 0;
-    return shortage > 0;
-  });
-
   if (showReorderOnly) {
     $('#btn-filter-reorder').text('전체 보기');
-    table.draw();
   }
 
   $('#btn-filter-reorder').on('click', function () {
-    showReorderOnly = !showReorderOnly;
-    $(this).text(showReorderOnly ? '전체 보기' : '입고 필요만 보기');
-    table.draw();
+    var url = new URL(window.location.href);
+    if (showReorderOnly) {
+      url.searchParams.delete('shortage');
+    } else {
+      url.searchParams.set('shortage', '1');
+    }
+    url.searchParams.set('page', '1');
+    window.location.href = url.pathname + '?' + url.searchParams.toString();
+  });
+
+  $('#coupangTable thead').on('click', 'th.sortable', function () {
+    var field = $(this).data('field');
+    if (!field) return;
+    var url = new URL(window.location.href);
+    var currentSort = url.searchParams.get('sort') || 'Product name';
+    var currentOrder = url.searchParams.get('order') || 'asc';
+    var order = 'asc';
+    if (currentSort === field && currentOrder === 'asc') {
+      order = 'desc';
+    }
+    url.searchParams.set('sort', field);
+    url.searchParams.set('order', order);
+    url.searchParams.set('page', '1');
+    window.location.href = url.pathname + '?' + url.searchParams.toString();
   });
 
   $('#btn-download-csv').on('click', function () {

--- a/views/coupang.ejs
+++ b/views/coupang.ejs
@@ -86,8 +86,11 @@
           <% if (필드 && 필드.length > 0) { %>
             <tr>
               <th>번호</th>
-              <% 필드.forEach((key) => { %>
-                <th><%= 한글?.[key] || key %></th>
+              <% 필드.forEach((key) => {
+                   const isCurrent = sortField === key;
+                   const arrow = isCurrent ? (sortOrder === 1 ? ' ▲' : ' ▼') : '';
+              %>
+                <th class="sortable" data-field="<%= key %>"><%= 한글?.[key] || key %><%= arrow %></th>
               <% }) %>
             </tr>
           <% } else { %>


### PR DESCRIPTION
## Summary
- disable client-side ordering in coupang page
- add server driven sort links on table headers
- redirect to the server when toggling shortage filter or clicking table headers

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: cannot find eslint config)*

------
https://chatgpt.com/codex/tasks/task_e_68592429d0d883298664a3b38eb835b3