### PR TITLE
Fix Coupang shortage filter and server-side sorting

### DIFF
--- a/public/js/coupang.js
+++ b/public/js/coupang.js
@@ -3,8 +3,7 @@ $(function () {
   var url = new URL(window.location.href);
   var showReorderOnly = url.searchParams.get('shortage') === '1';
   var table = $('#coupangTable').DataTable({
-    ordering: true,
-    order: [[1, 'asc']],
+    ordering: false,
     columnDefs: [
       { targets: '_all', className: 'text-center' },
       { targets: 0, orderable: false }
@@ -21,22 +20,18 @@ $(function () {
     }
   });
 
-  $.fn.dataTable.ext.search.push(function (settings, data, dataIndex) {
-    if (!showReorderOnly) return true;
-    var row = $(table.row(dataIndex).node());
-    var shortage = Number(row.data('shortage')) || 0;
-    return shortage > 0;
-  });
-
   if (showReorderOnly) {
     $('#btn-filter-reorder').text('전체 보기');
-    table.draw();
   }
 
   $('#btn-filter-reorder').on('click', function () {
-    showReorderOnly = !showReorderOnly;
-    $(this).text(showReorderOnly ? '전체 보기' : '입고 필요만 보기');
-    table.draw();
+    var url = new URL(window.location.href);
+    if (showReorderOnly) {
+      url.searchParams.delete('shortage');
+    } else {
+      url.searchParams.set('shortage', '1');
+    }
+    window.location.href = url.toString();
   });
 
   $('#btn-download-csv').on('click', function () {

--- a/routes/web/coupang.js
+++ b/routes/web/coupang.js
@@ -116,11 +116,14 @@ router.get("/", async (req, res) => {
 
     const totalPage = Math.ceil(total / limit);
     const totalCount = total;
-    const params = new URLSearchParams();
-    if (brand) params.append("brand", brand);
+    const baseParams = new URLSearchParams();
+    if (brand) baseParams.append("brand", brand);
     if (selected && selected.length > 0)
-      selected.forEach((f) => params.append("fields", f));
-    if (shortageOnly) params.append("shortage", "1");
+      selected.forEach((f) => baseParams.append("fields", f));
+    if (shortageOnly) baseParams.append("shortage", "1");
+    if (page > 1) baseParams.append("page", page);
+    const baseQuery = baseParams.toString();
+    const params = new URLSearchParams(baseQuery);
     if (sortField !== "Product name") params.append("sort", sortField);
     if (req.query.order) params.append("order", req.query.order);
     const queryString = params.toString();
@@ -138,6 +141,7 @@ router.get("/", async (req, res) => {
       전체페이지: totalPage,
       전체건수: totalCount,
       추가쿼리: queryString ? `&${queryString}` : "",
+      기본쿼리: baseQuery,
       페이지크기: limit,
       sortField,
       sortOrder,
@@ -267,12 +271,15 @@ router.get("/search", async (req, res) => {
 
     const totalPage = Math.ceil(total / limit);
     const totalCount = total;
-    const params = new URLSearchParams();
-    if (keyword) params.append("keyword", keyword);
-    if (brand) params.append("brand", brand);
+    const baseParams = new URLSearchParams();
+    if (keyword) baseParams.append("keyword", keyword);
+    if (brand) baseParams.append("brand", brand);
     if (selected && selected.length > 0)
-      selected.forEach((f) => params.append("fields", f));
-    if (shortageOnly) params.append("shortage", "1");
+      selected.forEach((f) => baseParams.append("fields", f));
+    if (shortageOnly) baseParams.append("shortage", "1");
+    if (page > 1) baseParams.append("page", page);
+    const baseQuery = baseParams.toString();
+    const params = new URLSearchParams(baseQuery);
     if (sortField !== "Product name") params.append("sort", sortField);
     if (req.query.order) params.append("order", req.query.order);
     const queryString = params.toString();
@@ -290,6 +297,7 @@ router.get("/search", async (req, res) => {
       전체페이지: totalPage,
       전체건수: totalCount,
       추가쿼리: queryString ? `&${queryString}` : "",
+      기본쿼리: baseQuery,
       페이지크기: limit,
       sortField,
       sortOrder,

--- a/views/coupang.ejs
+++ b/views/coupang.ejs
@@ -87,7 +87,14 @@
             <tr>
               <th>번호</th>
               <% 필드.forEach((key) => { %>
-                <th><%= 한글?.[key] || key %></th>
+                <th>
+                  <a href="?<%= 기본쿼리 %><%= 기본쿼리 ? '&' : '' %>sort=<%= key %>&order=<%= sortField === key && sortOrder === 1 ? 'desc' : 'asc' %>" class="text-decoration-none text-dark">
+                    <%= 한글?.[key] || key %>
+                    <% if (sortField === key) { %>
+                      <%= sortOrder === 1 ? '▲' : '▼' %>
+                    <% } %>
+                  </a>
+                </th>
               <% }) %>
             </tr>
           <% } else { %>


### PR DESCRIPTION
## Summary
- implement server-side query building for Coupang list views
- add base query string for sorting links
- update Coupang inventory page header to reload with sorting params
- enable shortage filter via page reload instead of DataTables

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68592722016483299d689a51b842d1eb