### PR TITLE
Fix Coupang Excel parser

### DIFF
--- a/lib/parseCoupangExcel.js
+++ b/lib/parseCoupangExcel.js
@@ -1,6 +1,11 @@
 const safeReadXlsx = require('./safeReadXlsx');
 const xlsx = require('xlsx');
 
+function toNumber(val) {
+  const num = Number(String(val).replace(/[,▲▼]/g, ''));
+  return isNaN(num) ? 0 : num;
+}
+
 /**
  * Parse Coupang Excel file and return array of item objects
  * @param {string} filePath
@@ -17,15 +22,15 @@ function parseCoupangExcel(filePath) {
       obj['Product name'] = row[4] ?? '';
       obj['Option name'] = row[5] ?? '';
 
-      const inventory = Number(String(row[7]).replace(/,/g, '')) || 0;
+      const inventory = toNumber(row[7]);
       obj['Orderable quantity (real-time)'] = inventory;
 
-      // 30일 판매금액은 옵션 ID 행 기준으로 10번째 값
-      const salesAmount = Number(String(row[9]).replace(/,/g, '')) || 0;
+      // 30일 판매금액은 옵션 ID 행 기준으로 12번째 값
+      const salesAmount = toNumber(row[11]);
       obj['Sales amount on the last 30 days'] = salesAmount;
 
-      // 30일 판매량은 옵션 ID 행 기준으로 12번째 값
-      const salesCount = Number(String(row[11]).replace(/,/g, '')) || 0;
+      // 30일 판매량은 옵션 ID 행 기준으로 14번째 값
+      const salesCount = toNumber(row[13]);
       obj['Sales in the last 30 days'] = salesCount;
 
       const daily = salesCount / 30;


### PR DESCRIPTION
## Summary
- update index positions for 30-day sales values
- strip ▲/▼ symbols when reading numeric fields

## Testing
- `npm test` *(fails: jest not found)*
- `python3 -m unittest tests/test_coupang_api.py` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_68593dbfba548329a64066f1e1eb134b