### PR TITLE
Improve Coupang search UX

### DIFF
--- a/public/js/coupang.js
+++ b/public/js/coupang.js
@@ -81,4 +81,21 @@ $(function () {
     link.click();
     document.body.removeChild(link);
   });
+
+  // ✅ 검색 처리
+  $('.search-send').on('click', function () {
+    const brand = $('#search-brand').val();
+    const keyword = $('#search-keyword').val().trim();
+    const params = new URLSearchParams();
+    if (keyword) params.append('keyword', keyword);
+    if (brand) params.append('brand', brand);
+    window.location.href = '/coupang/search?' + params.toString();
+  });
+
+  $('#search-keyword').on('keydown', function (e) {
+    if (e.key === 'Enter') {
+      e.preventDefault();
+      $('.search-send').click();
+    }
+  });
 });

--- a/public/js/coupangAdd.js
+++ b/public/js/coupangAdd.js
@@ -1,8 +1,10 @@
 $(function () {
+  const mode = typeof pageMode !== 'undefined' ? pageMode : 'detail';
   const $table = $('#coupangAddTable');
-  if (!$table.length || $table.data('mode') !== 'detail') return;
+  let table;
 
-  const table = $table.DataTable({
+  if ($table.length && mode === 'detail') {
+    table = $table.DataTable({
     serverSide: true,
     processing: true,
     paging: true,
@@ -67,10 +69,29 @@ $(function () {
     });
   });
 
-  $('#resetForm').on('submit', function () {
-    if (!confirm('정말 모든 데이터를 삭제하시겠습니까?')) {
-      return false;
+    $('#resetForm').on('submit', function () {
+      if (!confirm('정말 모든 데이터를 삭제하시겠습니까?')) {
+        return false;
+      }
+      alert('데이터 삭제 중입니다. 잠시만 기다려주세요.');
+    });
+  }
+
+  // ✅ 검색 처리 (summary/detail 공통)
+  $('.search-send').on('click', function () {
+    const keyword = $('#search-keyword').val().trim();
+    const brand = $('#search-brand').val();
+    const params = new URLSearchParams();
+    if (mode) params.append('mode', mode);
+    if (keyword) params.append('search', keyword);
+    if (brand) params.append('brand', brand);
+    window.location.href = '/coupang/add?' + params.toString();
+  });
+
+  $('#search-keyword').on('keydown', function (e) {
+    if (e.key === 'Enter') {
+      e.preventDefault();
+      $('.search-send').click();
     }
-    alert('데이터 삭제 중입니다. 잠시만 기다려주세요.');
   });
 });

--- a/public/js/coupangAddSummary.js
+++ b/public/js/coupangAddSummary.js
@@ -16,4 +16,22 @@ $(function () {
       infoEmpty: '데이터가 없습니다'
     }
   });
+
+  // 검색 핸들러 (요약 화면)
+  $('.search-send').on('click', function () {
+    const keyword = $('#search-keyword').val().trim();
+    const brand = $('#search-brand').val();
+    const params = new URLSearchParams();
+    params.append('mode', 'summary');
+    if (keyword) params.append('search', keyword);
+    if (brand) params.append('brand', brand);
+    window.location.href = '/coupang/add?' + params.toString();
+  });
+
+  $('#search-keyword').on('keydown', function (e) {
+    if (e.key === 'Enter') {
+      e.preventDefault();
+      $('.search-send').click();
+    }
+  });
 });

--- a/views/coupang-add-summary.ejs
+++ b/views/coupang-add-summary.ejs
@@ -19,10 +19,10 @@
       <a href="/coupang/add?mode=summary" class="btn <%= mode === 'summary' ? 'btn-success' : 'btn-outline-success' %>">상품명 통합 보기</a>
     </div>
 
-    <form method="get" action="/coupang/add" class="d-flex align-items-center mb-3">
-      <input type="hidden" name="mode" value="summary">
-      <input name="search" class="form-control me-2" style="max-width: 250px;" value="<%= search %>" placeholder="상품명 또는 옵션ID 검색">
-      <select name="brand" class="form-select me-2" style="max-width: 150px;">
+    <div id="search-form" class="d-flex align-items-center mb-3">
+      <input type="hidden" id="search-mode" value="summary">
+      <input id="search-keyword" class="form-control me-2" style="max-width: 250px;" value="<%= search %>" placeholder="상품명 또는 옵션ID 검색">
+      <select id="search-brand" name="brand" class="form-select me-2" style="max-width: 150px;">
         <option value="">전체 브랜드</option>
         <option value="트라이" <%= brand === '트라이' ? 'selected' : '' %>>트라이</option>
         <option value="좋은사람들" <%= brand === '좋은사람들' ? 'selected' : '' %>>좋은사람들</option>
@@ -31,7 +31,7 @@
         <option value="제임스딘" <%= brand === '제임스딘' ? 'selected' : '' %>>제임스딘</option>
       </select>
       <button class="btn btn-outline-primary search-send">검색</button>
-    </form>
+    </div>
 
     <div class="table-responsive table-container">
       <table id="summaryTable" class="table table-bordered table-hover table-striped bg-white align-middle text-center auto-width">
@@ -87,6 +87,12 @@
   <script src="https://cdn.datatables.net/1.13.6/js/jquery.dataTables.min.js"></script>
   <script src="https://cdn.datatables.net/1.13.6/js/dataTables.bootstrap5.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.6/dist/js/bootstrap.bundle.min.js"></script>
-  <script src="/js/coupangAddSummary.js"></script>
+<script>
+  var pageMode = '<%= mode %>';
+  var pageSearch = '<%= search %>';
+  var pageBrand = '<%= brand %>';
+</script>
+<script src="/js/coupangAdd.js"></script>
+<script src="/js/coupangAddSummary.js"></script>
 </body>
 </html>

--- a/views/coupang.ejs
+++ b/views/coupang.ejs
@@ -38,9 +38,9 @@
     </div>
 
     <!-- 검색 -->
-    <form action="/coupang/search" method="GET" class="row row-cols-auto g-2 mb-4">
+    <div id="search-form" class="row row-cols-auto g-2 mb-4">
       <div class="col">
-        <select name="brand" class="form-select">
+        <select id="search-brand" class="form-select">
           <option value="">전체 브랜드</option>
           <% if (brandOptions) { brandOptions.forEach(b => { %>
             <option value="<%= b %>" <%= b === brand ? 'selected' : '' %>><%= b %></option>
@@ -48,12 +48,12 @@
         </select>
       </div>
       <div class="col flex-grow-1">
-        <input type="text" name="keyword" value="<%= keyword || '' %>" class="form-control" placeholder="상품명, 옵션명 또는 옵션ID 입력">
+        <input type="text" id="search-keyword" class="form-control" value="<%= keyword || '' %>" placeholder="상품명, 옵션명 또는 옵션ID 입력">
       </div>
       <div class="col">
-        <button class="btn btn-outline-primary" type="submit">검색</button>
+        <button class="btn btn-outline-primary search-send" type="button">검색</button>
       </div>
-    </form>
+    </div>
 
     <% if (전체필드 && 전체필드.length > 0) { %>
       <form action="/coupang" method="GET" class="mb-4">

--- a/views/coupangAdd.ejs
+++ b/views/coupangAdd.ejs
@@ -25,10 +25,10 @@
     </div>
 
     <% if (mode === 'summary') { %>
-      <form method="GET" class="mb-3 d-flex" action="/coupang/add">
-        <input type="hidden" name="mode" value="summary">
-        <input type="text" name="search" value="<%= search %>" class="form-control me-2" placeholder="상품명 또는 옵션ID 검색">
-        <select name="brand" class="form-select me-2" style="max-width: 150px;">
+      <div id="search-form" class="mb-3 d-flex">
+        <input type="hidden" id="search-mode" value="summary">
+        <input type="text" id="search-keyword" class="form-control me-2" value="<%= search %>" placeholder="상품명 또는 옵션ID 검색">
+        <select id="search-brand" name="brand" class="form-select me-2" style="max-width: 150px;">
           <option value="">전체 브랜드</option>
           <option value="트라이" <%= brand === '트라이' ? 'selected' : '' %>>트라이</option>
           <option value="좋은사람들" <%= brand === '좋은사람들' ? 'selected' : '' %>>좋은사람들</option>
@@ -36,13 +36,13 @@
           <option value="비비안" <%= brand === '비비안' ? 'selected' : '' %>>비비안</option>
         </select>
         <button class="btn btn-outline-primary search-send">검색</button>
-      </form>
+      </div>
       <p class="text-end mb-2">총 <%= total %>건의 결과가 있습니다.</p>
     <% } else { %>
-      <form method="GET" class="d-flex align-items-center mb-3" action="/coupang/add">
-        <input type="hidden" name="mode" value="detail">
-        <input name="search" class="form-control me-2" value="<%= search %>" placeholder="상품명 또는 옵션ID 검색">
-        <select name="brand" class="form-select me-2" style="max-width: 150px;">
+      <div id="search-form" class="d-flex align-items-center mb-3">
+        <input type="hidden" id="search-mode" value="detail">
+        <input id="search-keyword" class="form-control me-2" value="<%= search %>" placeholder="상품명 또는 옵션ID 검색">
+        <select id="search-brand" name="brand" class="form-select me-2" style="max-width: 150px;">
           <option value="">전체 브랜드</option>
           <option value="트라이" <%= brand === '트라이' ? 'selected' : '' %>>트라이</option>
           <option value="좋은사람들" <%= brand === '좋은사람들' ? 'selected' : '' %>>좋은사람들</option>
@@ -50,7 +50,7 @@
           <option value="비비안" <%= brand === '비비안' ? 'selected' : '' %>>비비안</option>
         </select>
         <button class="btn btn-outline-primary search-send">검색</button>
-      </form>
+      </div>
     <% } %>
 
     <% if (typeof 성공메시지 !== 'undefined' && 성공메시지) { %>


### PR DESCRIPTION
## Summary
- allow searching Coupang inventory without submitting a form
- add jQuery handler to build query string and redirect
- fix search on summary page

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68593c98cf4483298db416038483e629