### PR TITLE
Fix Coupang parsing and simplify table headers

### DIFF
--- a/lib/parseCoupangExcel.js
+++ b/lib/parseCoupangExcel.js
@@ -25,12 +25,12 @@ function parseCoupangExcel(filePath) {
       const inventory = toNumber(row[7]);
       obj['Orderable quantity (real-time)'] = inventory;
 
-      // 30일 판매금액은 옵션 ID 행 기준으로 12번째 값
-      const salesAmount = toNumber(row[11]);
-      obj['Sales amount on the last 30 days'] = salesAmount;
+  // 30일 판매금액은 옵션 ID 행 기준으로 11번째 값
+  const salesAmount = toNumber(row[10]);
+  obj['Sales amount on the last 30 days'] = salesAmount;
 
-      // 30일 판매량은 옵션 ID 행 기준으로 14번째 값
-      const salesCount = toNumber(row[13]);
+  // 30일 판매량은 옵션 ID 행 기준으로 13번째 값
+  const salesCount = toNumber(row[12]);
       obj['Sales in the last 30 days'] = salesCount;
 
       const daily = salesCount / 30;

--- a/routes/web/coupang.js
+++ b/routes/web/coupang.js
@@ -72,9 +72,6 @@ router.get("/", async (req, res) => {
   const skip = (page - 1) * limit;
   const keyword = "";
   const brand = req.query.brand || "";
-  const sortField =
-    DEFAULT_COLUMNS.includes(req.query.sort) ? req.query.sort : "Product name";
-  const sortOrder = req.query.order === "desc" ? -1 : 1;
   const shortageOnly = req.query.shortage === "1";
   try {
     const query = brand ? { "Product name": new RegExp(brand, "i") } : {};
@@ -83,7 +80,7 @@ router.get("/", async (req, res) => {
       db
         .collection("coupang")
         .find(query)
-        .sort({ [sortField]: sortOrder })
+        .sort({ "Product name": 1 })
         .skip(skip)
         .limit(limit)
         .toArray(),
@@ -124,8 +121,6 @@ router.get("/", async (req, res) => {
     if (page > 1) baseParams.append("page", page);
     const baseQuery = baseParams.toString();
     const params = new URLSearchParams(baseQuery);
-    if (sortField !== "Product name") params.append("sort", sortField);
-    if (req.query.order) params.append("order", req.query.order);
     const queryString = params.toString();
 
     res.render("coupang.ejs", {
@@ -143,8 +138,6 @@ router.get("/", async (req, res) => {
       추가쿼리: queryString ? `&${queryString}` : "",
       기본쿼리: baseQuery,
       페이지크기: limit,
-      sortField,
-      sortOrder,
       shortageOnly,
       reorderCount,
     });
@@ -227,9 +220,6 @@ router.get("/search", async (req, res) => {
       conditions.push({ "Product name": brandRegex });
     }
 
-    const sortField =
-      DEFAULT_COLUMNS.includes(req.query.sort) ? req.query.sort : "Product name";
-    const sortOrder = req.query.order === "desc" ? -1 : 1;
     const shortageOnly = req.query.shortage === "1";
 
     const query = conditions.length > 0 ? { $and: conditions } : {};
@@ -242,7 +232,7 @@ router.get("/search", async (req, res) => {
       db
         .collection("coupang")
         .find(query)
-        .sort({ [sortField]: sortOrder })
+        .sort({ "Product name": 1 })
         .skip(skip)
         .limit(limit)
         .toArray(),
@@ -280,8 +270,6 @@ router.get("/search", async (req, res) => {
     if (page > 1) baseParams.append("page", page);
     const baseQuery = baseParams.toString();
     const params = new URLSearchParams(baseQuery);
-    if (sortField !== "Product name") params.append("sort", sortField);
-    if (req.query.order) params.append("order", req.query.order);
     const queryString = params.toString();
 
     res.render("coupang.ejs", {
@@ -299,8 +287,6 @@ router.get("/search", async (req, res) => {
       추가쿼리: queryString ? `&${queryString}` : "",
       기본쿼리: baseQuery,
       페이지크기: limit,
-      sortField,
-      sortOrder,
       shortageOnly,
       reorderCount,
     });

--- a/views/coupang.ejs
+++ b/views/coupang.ejs
@@ -87,14 +87,7 @@
             <tr>
               <th>번호</th>
               <% 필드.forEach((key) => { %>
-                <th>
-                  <a href="?<%= 기본쿼리 %><%= 기본쿼리 ? '&' : '' %>sort=<%= key %>&order=<%= sortField === key && sortOrder === 1 ? 'desc' : 'asc' %>" class="text-decoration-none text-dark">
-                    <%= 한글?.[key] || key %>
-                    <% if (sortField === key) { %>
-                      <%= sortOrder === 1 ? '▲' : '▼' %>
-                    <% } %>
-                  </a>
-                </th>
+                <th><%= 한글?.[key] || key %></th>
               <% }) %>
             </tr>
           <% } else { %>


### PR DESCRIPTION
## Summary
- fix incorrect column offsets in `parseCoupangExcel`
- remove sorting query parameters from Coupang routes and view
- simplify Coupang table headers

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685945e33b0c8329b06f2b95760d50f5