### PR TITLE
Fix search routes and add sorting options

### DIFF
--- a/routes/web/coupang.js
+++ b/routes/web/coupang.js
@@ -72,6 +72,9 @@ router.get("/", async (req, res) => {
   const skip = (page - 1) * limit;
   const keyword = "";
   const brand = req.query.brand || "";
+  const sortField =
+    DEFAULT_COLUMNS.includes(req.query.sort) ? req.query.sort : "Product name";
+  const sortOrder = req.query.order === "desc" ? -1 : 1;
   const shortageOnly = req.query.shortage === "1";
   try {
     const query = brand ? { "Product name": new RegExp(brand, "i") } : {};
@@ -80,7 +83,7 @@ router.get("/", async (req, res) => {
       db
         .collection("coupang")
         .find(query)
-        .sort({ "Product name": 1 })
+        .sort({ [sortField]: sortOrder })
         .skip(skip)
         .limit(limit)
         .toArray(),
@@ -121,6 +124,8 @@ router.get("/", async (req, res) => {
     if (page > 1) baseParams.append("page", page);
     const baseQuery = baseParams.toString();
     const params = new URLSearchParams(baseQuery);
+    if (sortField !== "Product name") params.append("sort", sortField);
+    if (req.query.order) params.append("order", req.query.order);
     const queryString = params.toString();
 
     res.render("coupang.ejs", {
@@ -138,6 +143,8 @@ router.get("/", async (req, res) => {
       추가쿼리: queryString ? `&${queryString}` : "",
       기본쿼리: baseQuery,
       페이지크기: limit,
+      sortField,
+      sortOrder,
       shortageOnly,
       reorderCount,
     });
@@ -220,6 +227,9 @@ router.get("/search", async (req, res) => {
       conditions.push({ "Product name": brandRegex });
     }
 
+    const sortField =
+      DEFAULT_COLUMNS.includes(req.query.sort) ? req.query.sort : "Product name";
+    const sortOrder = req.query.order === "desc" ? -1 : 1;
     const shortageOnly = req.query.shortage === "1";
 
     const query = conditions.length > 0 ? { $and: conditions } : {};
@@ -232,7 +242,7 @@ router.get("/search", async (req, res) => {
       db
         .collection("coupang")
         .find(query)
-        .sort({ "Product name": 1 })
+        .sort({ [sortField]: sortOrder })
         .skip(skip)
         .limit(limit)
         .toArray(),
@@ -270,6 +280,8 @@ router.get("/search", async (req, res) => {
     if (page > 1) baseParams.append("page", page);
     const baseQuery = baseParams.toString();
     const params = new URLSearchParams(baseQuery);
+    if (sortField !== "Product name") params.append("sort", sortField);
+    if (req.query.order) params.append("order", req.query.order);
     const queryString = params.toString();
 
     res.render("coupang.ejs", {
@@ -289,6 +301,8 @@ router.get("/search", async (req, res) => {
       페이지크기: limit,
       shortageOnly,
       reorderCount,
+      sortField,
+      sortOrder,
     });
   } catch (err) {
     console.error("GET /coupang/search 오류:", err);

--- a/routes/web/search.js
+++ b/routes/web/search.js
@@ -10,14 +10,33 @@ router.get("/", async (req, res) => {
 
   const page = parseInt(req.query.page || "1");
   const limit = 5;
+  const sortField =
+    ["title", "createdAt"].includes(req.query.sort)
+      ? req.query.sort
+      : "createdAt";
+  const sortOrder = req.query.order === "asc" ? 1 : -1;
 
   try {
-    const { docs, totalPage } = await searchPosts(db, val, page, limit);
+    const { docs, totalPage } = await searchPosts(
+      db,
+      val,
+      page,
+      limit,
+      sortField,
+      sortOrder
+    );
+    const baseParams = new URLSearchParams({ val });
+    if (sortField !== "createdAt") baseParams.append("sort", sortField);
+    if (req.query.order) baseParams.append("order", req.query.order);
+    const baseQuery = baseParams.toString();
     res.render("search.ejs", {
       글목록: docs,
       현재페이지: page,
       전체페이지: totalPage,
       val,
+      sortField,
+      sortOrder,
+      기본쿼리: baseQuery,
     });
   } catch (err) {
     console.error("❌ 검색 오류:", err);

--- a/routes/web/shop.js
+++ b/routes/web/shop.js
@@ -10,14 +10,33 @@ router.get("/", async (req, res) => {
 
   const page = parseInt(req.query.page || "1");
   const limit = 5;
+  const sortField =
+    ["title", "createdAt"].includes(req.query.sort)
+      ? req.query.sort
+      : "createdAt";
+  const sortOrder = req.query.order === "asc" ? 1 : -1;
 
   try {
-    const { docs, totalPage } = await searchPosts(db, val, page, limit);
+    const { docs, totalPage } = await searchPosts(
+      db,
+      val,
+      page,
+      limit,
+      sortField,
+      sortOrder
+    );
+    const baseParams = new URLSearchParams({ val });
+    if (sortField !== "createdAt") baseParams.append("sort", sortField);
+    if (req.query.order) baseParams.append("order", req.query.order);
+    const baseQuery = baseParams.toString();
     res.render("search.ejs", {
       글목록: docs,
       현재페이지: page,
       전체페이지: totalPage,
       val,
+      sortField,
+      sortOrder,
+      기본쿼리: baseQuery,
     });
   } catch (err) {
     console.error("❌ 검색 오류:", err);

--- a/services/searchService.js
+++ b/services/searchService.js
@@ -13,7 +13,14 @@ function highlight(text = '', term = '') {
   return escapeHtml(text).replace(regex, (m) => `<mark>${m}</mark>`);
 }
 
-async function searchPosts(db, term, page = 1, limit = 5) {
+async function searchPosts(
+  db,
+  term,
+  page = 1,
+  limit = 5,
+  sortField = 'createdAt',
+  sortOrder = -1
+) {
   const skip = (page - 1) * limit;
   const pipeline = [
     {
@@ -26,6 +33,7 @@ async function searchPosts(db, term, page = 1, limit = 5) {
         },
       },
     },
+    { $sort: { [sortField]: sortOrder } },
     { $skip: skip },
     { $limit: limit },
   ];
@@ -53,7 +61,13 @@ async function searchPosts(db, term, page = 1, limit = 5) {
     const regex = new RegExp(escapeRegExp(term), 'i');
     const filter = { $or: [{ title: regex }, { content: regex }] };
     [docs, countRes] = await Promise.all([
-      db.collection('post').find(filter).skip(skip).limit(limit).toArray(),
+      db
+        .collection('post')
+        .find(filter)
+        .sort({ [sortField]: sortOrder })
+        .skip(skip)
+        .limit(limit)
+        .toArray(),
       db.collection('post').countDocuments(filter),
     ]);
     countRes = [{ total: countRes }];

--- a/views/coupang.ejs
+++ b/views/coupang.ejs
@@ -87,7 +87,17 @@
             <tr>
               <th>번호</th>
               <% 필드.forEach((key) => { %>
-                <th><%= 한글?.[key] || key %></th>
+                <th>
+                  <a
+                    href="?<%= 기본쿼리 %><%= 기본쿼리 ? '&' : '' %>sort=<%= key %>&order=<%= sortField === key && sortOrder === 1 ? 'desc' : 'asc' %>"
+                    class="text-decoration-none text-dark"
+                  >
+                    <%= 한글?.[key] || key %>
+                    <% if (sortField === key) { %>
+                      <%= sortOrder === 1 ? '▲' : '▼' %>
+                    <% } %>
+                  </a>
+                </th>
               <% }) %>
             </tr>
           <% } else { %>

--- a/views/search.ejs
+++ b/views/search.ejs
@@ -26,7 +26,12 @@
         alert('검색어를 입력하세요.');
         return;
       }
-      location.href = '/search?val=' + encodeURIComponent(input);
+      const params = new URLSearchParams({
+        val: input,
+        sort: '<%= sortField %>',
+        order: '<%= sortOrder === 1 ? "asc" : "desc" %>'
+      });
+      location.href = '/search?' + params.toString();
     });
 
     document.querySelector('.search').addEventListener('keydown', function(e){
@@ -64,19 +69,19 @@
     <div class="pagination text-center mt-4">
       <% if (전체페이지 > 1) { %>
         <% if (현재페이지 > 1) { %>
-          <a href="/search?val=<%= val %>&page=<%= 현재페이지 - 1 %>">◀ 이전</a>
+          <a href="/search?<%= 기본쿼리 %>&page=<%= 현재페이지 - 1 %>">◀ 이전</a>
         <% } %>
 
         <% for (let i = 1; i <= 전체페이지; i++) { %>
           <% if (i === 현재페이지) { %>
             <strong>[<%= i %>]</strong>
           <% } else { %>
-            <a href="/search?val=<%= val %>&page=<%= i %>">[<%= i %>]</a>
+            <a href="/search?<%= 기본쿼리 %>&page=<%= i %>">[<%= i %>]</a>
           <% } %>
         <% } %>
 
         <% if (현재페이지 < 전체페이지) { %>
-          <a href="/search?val=<%= val %>&page=<%= 현재페이지 + 1 %>">다음 ▶</a>
+          <a href="/search?<%= 기본쿼리 %>&page=<%= 현재페이지 + 1 %>">다음 ▶</a>
         <% } %>
       <% } %>
     </div>


### PR DESCRIPTION
## Summary
- reintroduce sorting logic on Coupang search/list pages
- allow post search endpoints to sort by title or createdAt
- make `searchPosts` support sorting
- preserve search parameters in pagination links

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: ESLint missing)*

------
https://chatgpt.com/codex/tasks/task_e_68594aa0952083299c80ad29782bee33