### PR TITLE
Update home route and table style

### DIFF
--- a/server.js
+++ b/server.js
@@ -117,7 +117,7 @@ async function initApp() {
   // 8. 기본 경로 처리
   // 루트에서는 대시보드로 리다이렉트하여 바로 서비스를 이용할 수 있도록 함
   app.get("/", (req, res) => {
-    res.redirect(302, "/stock");
+    res.render("index.ejs");
   });
   app.get("/dashboard", checkAuth, (req, res) => {
     const menus = ["/stock", "/list", "/write"];

--- a/views/coupangAdd.ejs
+++ b/views/coupangAdd.ejs
@@ -75,7 +75,7 @@
     <div class="table-responsive table-container">
 
       <table id="coupangAddTable" data-mode="<%= mode %>" class="table table-bordered table-hover table-striped bg-white align-middle text-center auto-width">
-        <thead class="table-primary">
+        <thead>
 
           <% if (mode === 'summary') { %>
             <tr>


### PR DESCRIPTION
## Summary
- show index page at `/` instead of redirecting to stock
- remove header color from coupangAdd table

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: cannot find module '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685a333bd5e48329a7678fe5927b0969