### PR TITLE
Fix health test redirect

### DIFF
--- a/tests/health.test.js
+++ b/tests/health.test.js
@@ -49,7 +49,7 @@ describe("GET /stock", () => {
   it(
     "should return 302 redirect (CI 환경)",
     async () => {
-      const res = await request(app).get("/");
+      const res = await request(app).get("/").redirects(0);
       expect(res.statusCode).toBe(302);
     },
     60000 // 개별 테스트 타임아웃 (60초)


### PR DESCRIPTION
## Summary
- fix failing redirect assertion in health.test.js

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a35def108832981045926934dfd15