### PR TITLE
Fix stock search and nav responsiveness

### DIFF
--- a/controllers/stockController.js
+++ b/controllers/stockController.js
@@ -24,7 +24,10 @@ exports.getStockData = asyncHandler(async (req, res) => {
   const start  = parseInt(req.query.start, 10) || 0;
   const length = parseInt(req.query.length, 10) || 50;
   const draw   = parseInt(req.query.draw, 10) || 1;
-  const searchVal = req.query.search ? req.query.search.value : '';
+  // DataTables 기본 파서(querystring)는 search[value] 형태로 전달됨
+  const searchVal = req.query['search[value]'] ||
+                    (req.query.search && req.query.search.value) ||
+                    '';
 
   const query = searchVal
     ? {

--- a/public/js/stock.js
+++ b/public/js/stock.js
@@ -26,6 +26,7 @@ $(document).ready(function () {
     pageLength: 50,
     lengthChange: false,
     responsive: true,
+    order: [[1, 'asc']],
     columnDefs: [
       { targets: '_all', className: 'text-center' },
       {

--- a/views/nav.ejs
+++ b/views/nav.ejs
@@ -77,3 +77,15 @@
     </div>
   </div>
 </nav>
+<script>
+  document.addEventListener('DOMContentLoaded', function () {
+    var offcanvasEl = document.getElementById('navbarOffcanvas');
+    if (!offcanvasEl) return;
+    var offcanvas = bootstrap.Offcanvas.getOrCreateInstance(offcanvasEl);
+    offcanvasEl.querySelectorAll('.nav-link').forEach(function (link) {
+      link.addEventListener('click', function () {
+        if (offcanvas) offcanvas.hide();
+      });
+    });
+  });
+</script>


### PR DESCRIPTION
## Summary
- improve server-side search parsing for inventory
- default sort stock table by item code
- close mobile navigation after selecting a link

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a401c25d083299e4d5daad073cfeb