### PR TITLE
Add multi-field search and sorting to stock page

### DIFF
--- a/public/js/stock.js
+++ b/public/js/stock.js
@@ -1,16 +1,16 @@
 // public/js/stock.js
 
 function getStockIcon(qty) {
-  if (qty < 5) return '🔴';
-  else if (qty < 20) return '🟡';
-  return '🟢';
+  if (qty < 5) return "🔴";
+  else if (qty < 20) return "🟡";
+  return "🟢";
 }
 
 function getBrandBadge(code) {
-  if (typeof code === 'string' && code.startsWith('TD')) {
+  if (typeof code === "string" && code.startsWith("TD")) {
     return '<span class="badge badge-try">TRY</span>';
   }
-  return '';
+  return "";
 }
 
 $(document).ready(function () {
@@ -19,61 +19,66 @@ $(document).ready(function () {
     serverSide: true,
     processing: true,
     paging: true,
-    pagingType: 'simple_numbers',
-    searching: true,
-    dom: 'lrtip',
+    pagingType: "simple_numbers",
+    searching: false,
+    dom: "lrtip",
     info: true,
     pageLength: 50,
     lengthChange: false,
     responsive: true,
-    order: [[1, 'asc']],
+    order: [[1, "asc"]],
     columnDefs: [
-      { targets: '_all', className: 'text-center' },
+      { targets: "_all", className: "text-center" },
       {
         targets: 0,
         render: function (data, type, row, meta) {
           return meta.row + meta.settings._iDisplayStart + 1;
-        }
+        },
       },
       {
         targets: 1,
         render: function (data) {
-          return data + ' ' + getBrandBadge(data);
-        }
+          return data + " " + getBrandBadge(data);
+        },
       },
       {
         targets: 5,
         createdCell: function (td, cellData) {
-          $(td).addClass(cellData < 10 ? 'low-stock' : 'high-stock');
+          $(td).addClass(cellData < 10 ? "low-stock" : "high-stock");
         },
         render: function (data) {
-          return getStockIcon(data) + ' ' + data;
-        }
+          return getStockIcon(data) + " " + data;
+        },
       },
       {
         targets: 8,
         render: function (data) {
-          if (!data) return '';
+          if (!data) return "";
           const d = new Date(data);
-          return d.toLocaleString('ko-KR', {
-            year: 'numeric',
-            month: '2-digit',
-            day: '2-digit',
-            hour: '2-digit',
-            minute: '2-digit',
+          return d.toLocaleString("ko-KR", {
+            year: "numeric",
+            month: "2-digit",
+            day: "2-digit",
+            hour: "2-digit",
+            minute: "2-digit",
             hour12: false,
           });
-        }
-      }
+        },
+      },
     ],
     language: {
-      paginate: { previous: '이전', next: '다음' },
-      info: '총 _TOTAL_건 중 _START_ ~ _END_',
-      infoEmpty: '데이터가 없습니다'
+      paginate: { previous: "이전", next: "다음" },
+      info: "총 _TOTAL_건 중 _START_ ~ _END_",
+      infoEmpty: "데이터가 없습니다",
     },
     ajax: {
       url: "/api/stock",
       type: "GET",
+      data: function (d) {
+        d.item_code = $("#itemCode").val().trim();
+        d.color = $("#color").val().trim();
+        d.size = $("#size").val().trim();
+      },
       dataSrc: "data",
     },
     columns: [
@@ -91,16 +96,16 @@ $(document).ready(function () {
 
   // 검색 버튼
   $("#btnSearch").on("click", function () {
-    const keyword = $("#keyword").val().trim();
-    table.search(keyword).draw();
+    table.ajax.reload();
   });
 
   // 새로고침 버튼
   $("#btnRefresh").on("click", function () {
-    $("#keyword").val("");
-    table.search("").draw();
+    $("#itemCode").val("");
+    $("#color").val("");
+    $("#size").val("");
+    table.ajax.reload();
   });
-
 
   // 엑셀 업로드
   $("#uploadForm").on("submit", function (e) {
@@ -108,7 +113,7 @@ $(document).ready(function () {
     const formData = new FormData(this);
 
     $.ajax({
-      url: "/stock/upload",   // 서버 라우터와 일치
+      url: "/stock/upload", // 서버 라우터와 일치
       type: "POST",
       data: formData,
       processData: false,

--- a/views/stock.ejs
+++ b/views/stock.ejs
@@ -26,14 +26,23 @@
     </div>
 
     <!-- 검색 -->
-    <div class="row row-cols-1 row-cols-sm-auto g-2 mb-4">
-      <div class="col flex-grow-1">
-        <input id="keyword" class="form-control" placeholder="상품명 또는 상품코드" />
+    <div class="row g-2 mb-4 align-items-end">
+      <div class="col">
+        <label for="itemCode" class="form-label">품번</label>
+        <input id="itemCode" class="form-control" placeholder="품번" />
       </div>
       <div class="col">
+        <label for="color" class="form-label">색상</label>
+        <input id="color" class="form-control" placeholder="색상" />
+      </div>
+      <div class="col">
+        <label for="size" class="form-label">사이즈</label>
+        <input id="size" class="form-control" placeholder="사이즈" />
+      </div>
+      <div class="col-auto">
         <button id="btnSearch" class="btn btn-outline-primary">검색</button>
       </div>
-      <div class="col">
+      <div class="col-auto">
         <button id="btnRefresh" class="btn btn-secondary">새로고침</button>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- enhance stock search: filter by item code, color and size
- enable header-based sorting on the server
- update bootstrap UI for separate search fields

## Testing
- `npm run lint` *(fails: cannot find ESLint module)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a47dc71ec832984650da921d23adb