### PR TITLE
Handle Offer condition for stock shortage

### DIFF
--- a/lib/parseCoupangExcel.js
+++ b/lib/parseCoupangExcel.js
@@ -31,6 +31,7 @@ function parseCoupangExcel(filePath) {
   const optionIdIdx = findIndex(['Option ID', '옵션ID']);
   const productNameIdx = findIndex(['Product name', '상품명']);
   const optionNameIdx = findIndex(['Option name', '옵션명']);
+  const offerCondIdx = findIndex(['Offer condition', '상품상태', '판매상태']);
   const inventoryIdx = findIndex(['Orderable quantity (real-time)', '재고량']);
   const salesAmountIdx = findIndex([
     'Sales amount on the last 30 days',
@@ -52,6 +53,8 @@ function parseCoupangExcel(filePath) {
       obj['Option ID'] = String(row[optionIdIdx] ?? '').trim();
       obj['Product name'] = row[productNameIdx] ?? '';
       obj['Option name'] = row[optionNameIdx] ?? '';
+      const condition = String(row[offerCondIdx] ?? '').trim();
+      obj['Offer condition'] = condition;
 
       const inventory = toNumber(row[inventoryIdx]);
       obj['Orderable quantity (real-time)'] = inventory;
@@ -64,7 +67,9 @@ function parseCoupangExcel(filePath) {
 
       const daily = salesCount / 30;
       const safety = daily * 7;
-      obj['Shortage quantity'] = inventory < safety ? Math.ceil(safety - inventory) : 0;
+      const isNew = condition.toUpperCase() === 'NEW' || condition === '';
+      obj['Shortage quantity'] =
+        isNew && inventory < safety ? Math.ceil(safety - inventory) : 0;
 
       return obj;
     })

--- a/routes/web/coupang.js
+++ b/routes/web/coupang.js
@@ -20,6 +20,7 @@ const 한글 = {
   "Option ID": "옵션ID",
   "Product name": "상품명",
   "Option name": "옵션명",
+  "Offer condition": "상품상태",
   "Orderable quantity (real-time)": "재고량",
   "Sales amount on the last 30 days": "30일 판매금액",
   "Sales in the last 30 days": "30일 판매량",
@@ -31,6 +32,7 @@ const DEFAULT_COLUMNS = [
   "Option ID",
   "Product name",
   "Option name",
+  "Offer condition",
   "Orderable quantity (real-time)",
   "Sales amount on the last 30 days",
   "Sales in the last 30 days",
@@ -49,6 +51,11 @@ const NUMERIC_COLUMNS = [
 
 function addShortage(items) {
   return items.map((item) => {
+    const condition = String(item["Offer condition"] || "").trim().toUpperCase();
+    if (condition && condition !== "NEW") {
+      item["Shortage quantity"] = 0;
+      return item;
+    }
     const sales30 = Number(item["Sales in the last 30 days"] || 0);
     const inventory = Number(item["Orderable quantity (real-time)"] || 0);
     const daily = sales30 / 30;


### PR DESCRIPTION
## Summary
- parse `Offer condition` column when importing Coupang Excel files
- include `Offer condition` in Coupang views and translation map
- compute shortage only when the offer condition is `NEW`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a5870a11c8329b6d89211ba272e54