### PR TITLE
Fix Coupang parser

### DIFF
--- a/lib/parseCoupangExcel.js
+++ b/lib/parseCoupangExcel.js
@@ -14,7 +14,10 @@ function toNumber(val) {
 function parseCoupangExcel(filePath) {
   const workbook = safeReadXlsx(filePath);
   const sheet = workbook.Sheets[workbook.SheetNames[0]];
-  const rows = xlsx.utils.sheet_to_json(sheet, { header: 1 });
+  // 'raw: false' ensures numeric-like cells are read using the
+  // displayed text value so that columns such as "상품상태" are
+  // treated as strings rather than numbers when importing.
+  const rows = xlsx.utils.sheet_to_json(sheet, { header: 1, raw: false });
 
   if (rows.length < 2) return [];
 


### PR DESCRIPTION
## Summary
- fix Excel parser to always read product condition column as text

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a5b4fca5c832999b1471b4fd38559