### PR TITLE
Fix Coupang parser header detection

### DIFF
--- a/lib/parseCoupangExcel.js
+++ b/lib/parseCoupangExcel.js
@@ -21,7 +21,19 @@ function parseCoupangExcel(filePath) {
 
   if (rows.length < 2) return [];
 
-  const headers = rows[1].map((h) => String(h).trim());
+  // Some reports include a title row before the actual header. Find the header
+  // row dynamically by looking for a column that matches "Option ID".
+  const headerRowIdx = rows.findIndex((r) =>
+    r.some((c) =>
+      String(c)
+        .replace(/\s+/g, '')
+        .toLowerCase()
+        .includes('optionid'),
+    ),
+  );
+  if (headerRowIdx === -1) return [];
+
+  const headers = rows[headerRowIdx].map((h) => String(h).trim());
 
   // find the index of a column header by matching against several possible names
   // whitespace and case differences are ignored and partial matches are allowed
@@ -50,7 +62,7 @@ function parseCoupangExcel(filePath) {
   ]);
 
   return rows
-    .slice(2)
+    .slice(headerRowIdx + 1)
     .map((row) => {
       const obj = {};
       obj['Option ID'] = String(row[optionIdIdx] ?? '').trim();


### PR DESCRIPTION
## Summary
- handle optional title row in `parseCoupangExcel`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a5f1e1338832995b337628c5a8dbd