### PR TITLE
Fix coupang column style and add condition storage

### DIFF
--- a/lib/parseCoupangExcel.js
+++ b/lib/parseCoupangExcel.js
@@ -69,7 +69,8 @@ function parseCoupangExcel(filePath) {
       obj['Product name'] = row[productNameIdx] ?? '';
       obj['Option name'] = row[optionNameIdx] ?? '';
       const condition = String(row[offerCondIdx] ?? '').trim();
-      obj['Offer condition'] = condition;
+      // 기본값을 'NEW'로 지정하여 값이 없을 때도 저장되도록 한다
+      obj['Offer condition'] = condition || 'NEW';
 
       const inventory = toNumber(row[inventoryIdx]);
       obj['Orderable quantity (real-time)'] = inventory;

--- a/public/js/coupang.js
+++ b/public/js/coupang.js
@@ -9,8 +9,9 @@ $(function () {
     ordering: true,
     columnDefs: [
       { targets: '_all', className: 'text-center' },
-      { targets: 1, className: 'text-primary' },
-      { targets: 2, className: 'text-success text-start' }
+      // 텍스트 색상을 기본값으로 돌려 가독성을 높인다
+      { targets: 1, className: 'text-start' },
+      { targets: 2, className: 'text-start' }
     ],
     lengthChange: false,
     paging: false,

--- a/public/js/coupangAdd.js
+++ b/public/js/coupangAdd.js
@@ -17,8 +17,9 @@ $(function () {
     order: [[0, 'asc']],
     columnDefs: [
       { targets: '_all', className: 'text-center' },
-      { targets: 1, className: 'text-primary' },
-      { targets: 2, className: 'text-success text-start' },
+      // 텍스트 컬러는 기본 색상 사용
+      { targets: 1, className: 'text-start' },
+      { targets: 2, className: 'text-start' },
       { targets: [3, 4, 5], render: $.fn.dataTable.render.number(',', '.', 0) },
       { targets: 6, render: (data) => parseFloat(data).toFixed(2) },
     ],

--- a/public/main.css
+++ b/public/main.css
@@ -322,3 +322,10 @@ td:nth-child(3) {
 .table-danger .low-stock {
   color: #842029;
 }
+
+/* Stock table subtle shadow and rounded corners */
+#stockTable {
+  border-radius: 0.5rem;
+  overflow: hidden;
+  box-shadow: 0 0.25rem 0.75rem rgba(0, 0, 0, 0.05);
+}

--- a/views/coupang.ejs
+++ b/views/coupang.ejs
@@ -112,13 +112,13 @@
                 <td class="text-center"><%= index + 1 + 페이지크기 * (현재페이지 - 1) %></td>
                 <% 필드.forEach(key => { %>
                   <% if (key === 'Option ID') { %>
-                    <td class="text-center text-primary"><%= 행[key] %></td>
+                    <td class="text-center"><%= 행[key] %></td>
                   <% } else {
                        const val = 행[key];
                        const numVal = Number(val);
                        const isNum = !isNaN(numVal) && val !== '-' && val !== '';
                   %>
-                    <td class="text-center<%= key === 'Shortage quantity' && shortage > 0 ? ' low-stock' : '' %><%= key === 'Product name' ? ' text-primary' : '' %><%= key === 'Option name' ? ' text-success' : '' %>"<% if (isNum) { %> data-order="<%= numVal %>"<% } %>>
+                    <td class="text-center<%= key === 'Shortage quantity' && shortage > 0 ? ' low-stock' : '' %>"<% if (isNum) { %> data-order="<%= numVal %>"<% } %>>
                       <%= isNum ? (numVal === 0 ? '-' : numVal.toLocaleString('ko-KR')) : val %>
                     </td>
                   <% } %>

--- a/views/coupangAdd.ejs
+++ b/views/coupangAdd.ejs
@@ -101,7 +101,7 @@
           <tbody>
             <% list.forEach(item => { %>
               <tr class="text-center">
-                <td class="text-start text-primary"><%= item.productName %></td>
+                <td class="text-start"><%= item.productName %></td>
                 <td><%= item.impressions.toLocaleString() %></td>
                 <td><%= item.clicks.toLocaleString() %></td>
                 <td><%= item.adCost.toLocaleString() %></td>

--- a/views/stock.ejs
+++ b/views/stock.ejs
@@ -49,7 +49,7 @@
 
     <!-- 테이블 -->
     <div class="table-responsive table-container">
-      <table id="stockTable" class="table table-striped simple-table table-sm bg-white align-middle text-center auto-width">
+      <table id="stockTable" class="table table-striped table-hover shadow-sm rounded simple-table table-sm bg-white align-middle text-center auto-width">
         <thead class="table-light">
           <tr>
             <th>#</th>


### PR DESCRIPTION
## Summary
- make offer condition always saved as `NEW` when empty
- remove colored text from coupang inventory/ads tables
- refine stock table style with hover effect and subtle shadow

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a62e3e05c8329a8051a48f9399cb2