### PR TITLE
Fix numeric parsing and style

### DIFF
--- a/lib/parseCoupangExcel.js
+++ b/lib/parseCoupangExcel.js
@@ -2,7 +2,11 @@ const safeReadXlsx = require('./safeReadXlsx');
 const xlsx = require('xlsx');
 
 function toNumber(val) {
-  const num = Number(String(val).replace(/[,▲▼]/g, ''));
+  // Remove all non-numeric characters so values like "1,234원" are parsed
+  // correctly. This prevents sales fields from being interpreted as zero
+  // when the spreadsheet stores numbers as text.
+  const cleaned = String(val).replace(/[^0-9.-]/g, '');
+  const num = Number(cleaned);
   return isNaN(num) ? 0 : num;
 }
 

--- a/public/main.css
+++ b/public/main.css
@@ -239,6 +239,7 @@ td:nth-child(3) {
   left: 0;
   background: var(--bs-table-bg, #fff);
   z-index: 2;
+  color: #000;
 }
 
 /* Mobile navigation customizations */


### PR DESCRIPTION
## Summary
- parse Coupang Excel numbers regardless of text format
- ensure sticky columns show black text

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: cannot find eslint)*

------
https://chatgpt.com/codex/tasks/task_e_685a665982a8832996da31b5ed7efc4e