### PR TITLE
Align DataTables styling with Bootstrap

### DIFF
--- a/public/js/common-dt.js
+++ b/public/js/common-dt.js
@@ -1,0 +1,18 @@
+function createDataTable(selector, opts = {}) {
+  return $(selector).DataTable(
+    Object.assign(
+      {
+        lengthChange: false,
+        pagingType: 'simple_numbers',
+        responsive: true,
+        language: {
+          paginate: { previous: '이전', next: '다음' },
+          info: '총 _TOTAL_건 중 _START_ ~ _END_',
+          infoEmpty: '데이터가 없습니다',
+          emptyTable: '데이터가 없습니다.'
+        }
+      },
+      opts
+    )
+  );
+}

--- a/public/js/coupang.js
+++ b/public/js/coupang.js
@@ -5,7 +5,7 @@ $(function () {
   const showReorderOnly = url.searchParams.get('shortage') === '1';
 
   // ✅ DataTable 초기화
-  const table = $('#coupangTable').DataTable({
+  const table = createDataTable('#coupangTable', {
     ordering: true,
     columnDefs: [
       { targets: '_all', className: 'text-center' },
@@ -13,17 +13,10 @@ $(function () {
       { targets: 1, className: 'text-start' },
       { targets: 2, className: 'text-start' }
     ],
-    lengthChange: false,
     paging: false,
     searching: false,
     info: false,
-    responsive: true,
-    language: {
-      paginate: { previous: '이전', next: '다음' },
-      info: '총 _TOTAL_건 중 _START_ ~ _END_',
-      infoEmpty: '데이터가 없습니다',
-      emptyTable: '📭 재고가 없습니다.'
-    }
+    language: { emptyTable: '📭 재고가 없습니다.' }
   });
 
   // ✅ 입고필요 필터 버튼

--- a/public/js/coupangAdd.js
+++ b/public/js/coupangAdd.js
@@ -4,16 +4,13 @@ $(function () {
   let table;
 
   if ($table.length && mode === 'detail') {
-    table = $table.DataTable({
+    table = createDataTable('#coupangAddTable', {
     serverSide: true,
     processing: true,
     paging: true,
-    pagingType: 'simple_numbers',
     searching: false,
     info: true,
     pageLength: 50,
-    lengthChange: false,
-    responsive: true,
     order: [[0, 'asc']],
     columnDefs: [
       { targets: '_all', className: 'text-center' },
@@ -44,12 +41,7 @@ $(function () {
       { data: '클릭수' },
       { data: '광고비' },
       { data: '클릭률' },
-    ],
-    language: {
-      paginate: { previous: '이전', next: '다음' },
-      info: '총 _TOTAL_건 중 _START_ ~ _END_',
-      infoEmpty: '데이터가 없습니다'
-    }
+    ]
   });
 
   $('#uploadForm').on('submit', function (e) {

--- a/public/js/coupangAddSummary.js
+++ b/public/js/coupangAddSummary.js
@@ -1,7 +1,7 @@
 $(function () {
-  const table = $('#summaryTable');
-  if (!table.length) return;
-  table.DataTable({
+  const table = '#summaryTable';
+  if (!$(table).length) return;
+  createDataTable(table, {
     ordering: true,
     order: [[1, 'asc']],
     paging: false,
@@ -10,11 +10,6 @@ $(function () {
     lengthChange: false,
     responsive: true,
     columnDefs: [{ targets: '_all', className: 'text-center' }],
-    language: {
-      paginate: { previous: '이전', next: '다음' },
-      info: '총 _TOTAL_건 중 _START_ ~ _END_',
-      infoEmpty: '데이터가 없습니다'
-    }
   });
 
   // 검색 핸들러 (요약 화면)

--- a/public/js/stock.js
+++ b/public/js/stock.js
@@ -4,17 +4,14 @@
 
 $(document).ready(function () {
   // DataTable 초기화
-  const table = $("#stockTable").DataTable({
+  const table = createDataTable('#stockTable', {
     serverSide: true,
     processing: true,
     paging: true,
-    pagingType: "simple_numbers",
     searching: false,
-    dom: "lrtip",
+    dom: 'lrtip',
     info: true,
     pageLength: 50,
-    lengthChange: false,
-    responsive: true,
     order: [[1, "asc"]],
     columnDefs: [
       { targets: "_all", className: "text-center" },

--- a/public/main.css
+++ b/public/main.css
@@ -279,29 +279,6 @@ td:nth-child(3) {
   font-size: 2.5rem;
 }
 
-/* Simple table style for summary page */
-.simple-table {
-  width: 100%;
-  border-collapse: collapse;
-}
-
-.simple-table th,
-.simple-table td {
-  border: 1px solid #dee2e6;
-  padding: 0.5rem;
-}
-
-.simple-table th {
-  background-color: #f8f9fa;
-}
-
-.simple-table tbody tr:nth-child(even) {
-  background-color: #fafafa;
-}
-
-.simple-table tbody tr:hover {
-  background-color: #f1f1f1;
-}
 
 /* Remove stripe color from first row */
 .table-striped > tbody > tr:first-child {

--- a/views/coupang-add-summary.ejs
+++ b/views/coupang-add-summary.ejs
@@ -87,6 +87,7 @@
   <script src="https://cdn.datatables.net/1.13.6/js/jquery.dataTables.min.js"></script>
   <script src="https://cdn.datatables.net/1.13.6/js/dataTables.bootstrap5.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.6/dist/js/bootstrap.bundle.min.js"></script>
+  <script src="/js/common-dt.js"></script>
 <script>
   var pageMode = '<%= mode %>';
   var pageSearch = '<%= search %>';

--- a/views/coupang.ejs
+++ b/views/coupang.ejs
@@ -162,6 +162,7 @@
   <script src="https://cdn.datatables.net/1.13.6/js/jquery.dataTables.min.js"></script>
   <script src="https://cdn.datatables.net/1.13.6/js/dataTables.bootstrap5.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.6/dist/js/bootstrap.bundle.min.js"></script>
+  <script src="/js/common-dt.js"></script>
   <script src="/js/coupang.js"></script>
 </body>
 </html>

--- a/views/coupangAdd.ejs
+++ b/views/coupangAdd.ejs
@@ -141,6 +141,7 @@
   <script src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
   <script src="https://cdn.datatables.net/1.13.6/js/jquery.dataTables.min.js"></script>
   <script src="https://cdn.datatables.net/1.13.6/js/dataTables.bootstrap5.min.js"></script>
+  <script src="/js/common-dt.js"></script>
 
   <script>
     var pageMode = '<%= mode %>';

--- a/views/layouts/main.ejs
+++ b/views/layouts/main.ejs
@@ -18,5 +18,6 @@
   <script src="https://cdn.datatables.net/1.13.6/js/jquery.dataTables.min.js"></script>
   <script src="https://cdn.datatables.net/1.13.6/js/dataTables.bootstrap5.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.6/dist/js/bootstrap.bundle.min.js"></script>
+  <script src="/js/common-dt.js"></script>
 </body>
 </html>

--- a/views/stock.ejs
+++ b/views/stock.ejs
@@ -49,7 +49,7 @@
 
     <!-- 테이블 -->
     <div class="table-responsive table-container">
-      <table id="stockTable" class="table table-striped table-hover shadow-sm rounded simple-table table-sm bg-white align-middle text-center auto-width">
+      <table id="stockTable" class="table table-striped table-hover shadow-sm rounded table-sm bg-white align-middle text-center auto-width">
         <thead class="table-light">
           <tr>
             <th>#</th>
@@ -73,6 +73,7 @@
   <script src="https://cdn.datatables.net/1.13.6/js/jquery.dataTables.min.js"></script>
   <script src="https://cdn.datatables.net/1.13.6/js/dataTables.bootstrap5.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.6/dist/js/bootstrap.bundle.min.js"></script>
+  <script src="/js/common-dt.js"></script>
   <script src="/js/stock.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- remove custom simple-table rules
- add helper script `common-dt.js` and load it from layout and pages
- refactor DataTables initialization to use shared defaults
- cleanup stock table markup

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685a63c46a988329aea373de3e191ccb