### PR TITLE
Fix Coupang Excel numeric import

### DIFF
--- a/lib/parseCoupangExcel.js
+++ b/lib/parseCoupangExcel.js
@@ -2,11 +2,15 @@ const safeReadXlsx = require('./safeReadXlsx');
 const xlsx = require('xlsx');
 
 function toNumber(val) {
-  // Remove all non-numeric characters so values like "1,234원" are parsed
-  // correctly. This prevents sales fields from being interpreted as zero
-  // when the spreadsheet stores numbers as text.
+  // Attempt direct conversion first to handle scientific notation like "1.2E+3".
+  let num = Number(val);
+  if (!isNaN(num)) return num;
+
+  // Fall back to stripping non-numeric characters so values like "1,234원" are
+  // parsed correctly. This prevents sales fields from being interpreted as
+  // zero when the spreadsheet stores numbers as text.
   const cleaned = String(val).replace(/[^0-9.-]/g, '');
-  const num = Number(cleaned);
+  num = Number(cleaned);
   return isNaN(num) ? 0 : num;
 }
 


### PR DESCRIPTION
## Summary
- handle scientific notation in `parseCoupangExcel` when extracting numbers

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a696e5dd08329b4be6cb39ae94ca4