### PR TITLE
Improve stock table UI

### DIFF
--- a/public/js/stock.js
+++ b/public/js/stock.js
@@ -7,6 +7,7 @@ $(document).ready(function () {
   const table = createDataTable('#stockTable', {
     serverSide: true,
     processing: true,
+    ordering: true,
     paging: true,
     searching: false,
     dom: 'lrtip',

--- a/public/main.css
+++ b/public/main.css
@@ -297,8 +297,13 @@ td:nth-child(3) {
 }
 
 /* Low stock row highlight */
+/* Low stock row highlight */
+.table-danger {
+  background-color: #fff1f1;
+}
+
 .table-danger .low-stock {
-  color: #842029;
+  color: #b94a48;
 }
 
 /* Stock table subtle shadow and rounded corners */
@@ -306,4 +311,10 @@ td:nth-child(3) {
   border-radius: 0.5rem;
   overflow: hidden;
   box-shadow: 0 0.25rem 0.75rem rgba(0, 0, 0, 0.05);
+  border-collapse: separate;
+}
+
+#stockTable th,
+#stockTable td {
+  padding: 0.75rem 1rem;
 }

--- a/views/stock.ejs
+++ b/views/stock.ejs
@@ -49,7 +49,7 @@
 
     <!-- 테이블 -->
     <div class="table-responsive table-container">
-      <table id="stockTable" class="table table-striped table-hover shadow-sm rounded table-sm bg-white align-middle text-center auto-width">
+      <table id="stockTable" class="table table-striped table-hover table-bordered shadow-sm rounded bg-white align-middle text-center auto-width">
         <thead class="table-light">
           <tr>
             <th>#</th>


### PR DESCRIPTION
## Summary
- keep DataTable ordering on for stock list
- add table borders and remove condensed rows in stock page
- soften low stock highlight colors and expand cell padding

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a6a219c8c8329baee3e8f85d4023e