### PR TITLE
Fix Coupang Excel header parsing

### DIFF
--- a/lib/parseCoupangExcel.js
+++ b/lib/parseCoupangExcel.js
@@ -34,12 +34,18 @@ function parseCoupangExcel(filePath) {
 
   const headers = rows[headerRowIdx].map((h) => String(h).trim());
 
+  // 헤더명 정규화 함수: 공백과 괄호(단위)를 제거하고 소문자로 변환
+  const normalize = (str) =>
+    String(str)
+      .replace(/\s+/g, '')
+      .replace(/\(.*?\)/g, '')
+      .toLowerCase();
+
   // 헤더명 검색 함수
   const findIndex = (names) =>
-    headers.findIndex((h) => {
-      const normalized = String(h).replace(/\s+/g, '').toLowerCase();
-      return names.some((n) => normalized.includes(String(n).replace(/\s+/g, '').toLowerCase()));
-    });
+    headers.findIndex((h) =>
+      names.some((n) => normalize(h) === normalize(n))
+    );
 
   // 주요 열 인덱스
   const optionIdIdx = findIndex(['Option ID', '옵션ID']);


### PR DESCRIPTION
## Summary
- handle parentheses and units in header names when parsing Coupang Excel files

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a7cc109888329bd3834170539ffcb