### PR TITLE
Fix Coupang Excel header detection

### DIFF
--- a/lib/parseCoupangExcel.js
+++ b/lib/parseCoupangExcel.js
@@ -24,11 +24,19 @@ function parseCoupangExcel(filePath) {
 
   if (rows.length < 2) return [];
 
+  // 문자열 정규화 함수: 공백과 괄호(단위)를 제거하고 소문자로 변환
+  const normalize = (str) =>
+    String(str)
+      .replace(/\s+/g, '')
+      .replace(/\(.*?\)/g, '')
+      .toLowerCase();
+
   // 헤더 행 인덱스 탐색
   const headerRowIdx = rows.findIndex((r) =>
-    r.some((c) =>
-      String(c).replace(/\s+/g, '').toLowerCase().includes('optionid')
-    )
+    r.some((c) => {
+      const text = normalize(c);
+      return text.includes('optionid') || text.includes('옵션id');
+    })
   );
   if (headerRowIdx === -1) return [];
 
@@ -36,10 +44,9 @@ function parseCoupangExcel(filePath) {
 
   // 헤더명 검색 함수
   const findIndex = (names) =>
-    headers.findIndex((h) => {
-      const normalized = String(h).replace(/\s+/g, '').toLowerCase();
-      return names.some((n) => normalized.includes(String(n).replace(/\s+/g, '').toLowerCase()));
-    });
+    headers.findIndex((h) =>
+      names.some((n) => normalize(h) === normalize(n))
+    );
 
   // 주요 열 인덱스
   const optionIdIdx = findIndex(['Option ID', '옵션ID']);
@@ -50,12 +57,14 @@ function parseCoupangExcel(filePath) {
   const salesAmountIdx = findIndex([
     'Sales amount on the last 30 days',
     '30일 판매금액',
+    '30일 판매금액(원)',
     '최근 30일 판매금액',
     '최근30일판매금액'
   ]);
   const salesCountIdx = findIndex([
     'Sales in the last 30 days',
     '30일 판매량',
+    '30일 판매량(개)',
     '최근 30일 판매량',
     '최근30일판매량'
   ]);


### PR DESCRIPTION
## Summary
- improve header row detection to match Korean "옵션ID"
- normalize headers before searching for indices
- add parentheses variants for sales columns

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a7cc109888329bd3834170539ffcb