### PR TITLE
Implement daily ad cost summary

### DIFF
--- a/public/js/coupangAddDaily.js
+++ b/public/js/coupangAddDaily.js
@@ -1,0 +1,14 @@
+$(function () {
+  const table = '#dailyTable';
+  if (!$(table).length) return;
+  createDataTable(table, {
+    ordering: true,
+    order: [[0, 'asc']],
+    paging: false,
+    searching: false,
+    info: false,
+    lengthChange: false,
+    responsive: true,
+    columnDefs: [{ targets: '_all', className: 'text-center' }],
+  });
+});

--- a/views/coupang-add-daily.ejs
+++ b/views/coupang-add-daily.ejs
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+  <meta charset="UTF-8">
+  <title>일별 광고 소진 비용</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.6/dist/css/bootstrap.min.css" rel="stylesheet">
+  <link rel="stylesheet" href="/main.css">
+  <link rel="stylesheet" href="https://cdn.datatables.net/1.13.6/css/dataTables.bootstrap5.min.css">
+  <link rel="stylesheet" href="https://cdn.datatables.net/fixedheader/3.4.0/css/fixedHeader.bootstrap5.min.css">
+</head>
+<body class="bg-light">
+  <%- include('nav.ejs') %>
+
+  <div class="container my-5">
+    <h2 class="mb-4 fw-bold">🛒 일별 광고 소진 비용</h2>
+
+    <div class="mb-3">
+      <a href="/coupang/add?mode=detail" class="btn <%= mode === 'detail' ? 'btn-primary' : 'btn-outline-primary' %>">전체 보기</a>
+      <a href="/coupang/add?mode=summary" class="btn <%= mode === 'summary' ? 'btn-success' : 'btn-outline-success' %>">상품명 통합 보기</a>
+      <a href="/coupang/add?mode=daily" class="btn <%= mode === 'daily' ? 'btn-warning' : 'btn-outline-warning' %>">일별 광고소진 비용</a>
+    </div>
+
+    <div class="table-responsive table-container">
+      <table id="dailyTable" class="table table-bordered table-hover table-striped bg-white align-middle text-center auto-width">
+        <thead class="table-light">
+          <tr>
+            <th>날짜</th>
+            <th>광고비 합</th>
+          </tr>
+        </thead>
+        <tbody>
+          <% list.forEach(item => { %>
+            <tr>
+              <td><%= item.date %></td>
+              <td><%= item.adCost.toLocaleString() %></td>
+            </tr>
+          <% }) %>
+        </tbody>
+      </table>
+    </div>
+  </div>
+
+  <script src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
+  <script src="https://cdn.datatables.net/1.13.6/js/jquery.dataTables.min.js"></script>
+  <script src="https://cdn.datatables.net/1.13.6/js/dataTables.bootstrap5.min.js"></script>
+  <script src="https://cdn.datatables.net/fixedheader/3.4.0/js/dataTables.fixedHeader.min.js"></script>
+  <script src="/js/common-dt.js"></script>
+  <script src="/js/coupangAddDaily.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.6/dist/js/bootstrap.bundle.min.js"></script>
+</body>
+</html>

--- a/views/coupang-add-summary.ejs
+++ b/views/coupang-add-summary.ejs
@@ -18,6 +18,7 @@
     <div class="mb-3">
       <a href="/coupang/add?mode=detail" class="btn <%= mode === 'detail' ? 'btn-primary' : 'btn-outline-primary' %>">전체 보기</a>
       <a href="/coupang/add?mode=summary" class="btn <%= mode === 'summary' ? 'btn-success' : 'btn-outline-success' %>">상품명 통합 보기</a>
+      <a href="/coupang/add?mode=daily" class="btn <%= mode === 'daily' ? 'btn-warning' : 'btn-outline-warning' %>">일별 광고소진 비용</a>
     </div>
 
     <div id="search-form" class="d-flex align-items-center mb-3">

--- a/views/coupangAdd.ejs
+++ b/views/coupangAdd.ejs
@@ -19,6 +19,7 @@
     <div class="mb-3">
       <a href="/coupang/add?mode=detail" class="btn <%= mode === 'detail' ? 'btn-primary' : 'btn-outline-primary' %>">전체 보기</a>
       <a href="/coupang/add?mode=summary" class="btn <%= mode === 'summary' ? 'btn-success' : 'btn-outline-success' %>">상품명 통합 보기</a>
+      <a href="/coupang/add?mode=daily" class="btn <%= mode === 'daily' ? 'btn-warning' : 'btn-outline-warning' %>">일별 광고소진 비용</a>
     </div>
 
     <div class="alert alert-info mb-4">


### PR DESCRIPTION
## Summary
- add daily mode to CoupangAdd controller
- show daily ad cost table via new view
- add button for daily cost view in existing pages
- include DataTables script for the daily table

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a8ebf50cc8329a155be06e4c05d9e