### PR TITLE
Fix parse error in Coupang Excel parser

### DIFF
--- a/lib/parseCoupangExcel.js
+++ b/lib/parseCoupangExcel.js
@@ -35,7 +35,7 @@ function parseCoupangExcel(filePath) {
   const headers = rows[headerRowIdx].map((h) => String(h).trim());
 
   // 헤더명 정규화 함수: 공백과 괄호(단위)를 제거하고 소문자로 변환
-  const normalize = (str) =>
+  const normalizeHeader = (str) =>
     String(str)
       .replace(/\s+/g, '')
       .replace(/\(.*?\)/g, '')
@@ -44,7 +44,7 @@ function parseCoupangExcel(filePath) {
   // 헤더명 검색 함수
   const findIndex = (names) =>
     headers.findIndex((h) =>
-      names.some((n) => normalize(h) === normalize(n))
+      names.some((n) => normalizeHeader(h) === normalizeHeader(n))
     );
 
   // 주요 열 인덱스


### PR DESCRIPTION
## Summary
- avoid duplicate identifier `normalize` by renaming to `normalizeHeader`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a96b5cce88329ae19a7f84d0c570f