### PR TITLE
Fix header normalization variable

### DIFF
--- a/lib/parseCoupangExcel.js
+++ b/lib/parseCoupangExcel.js
@@ -35,7 +35,7 @@ function parseCoupangExcel(filePath) {
   const headers = rows[headerRowIdx].map((h) => String(h).trim());
 
   // 헤더명 정규화 함수: 공백과 괄호(단위)를 제거하고 소문자로 변환
-  const normalizeHeader = (str) =>
+  const normalizeHeaderName = (str) =>
     String(str)
       .replace(/\s+/g, '')
       .replace(/\(.*?\)/g, '')
@@ -44,7 +44,7 @@ function parseCoupangExcel(filePath) {
   // 헤더명 검색 함수
   const findIndex = (names) =>
     headers.findIndex((h) =>
-      names.some((n) => normalizeHeader(h) === normalizeHeader(n))
+      names.some((n) => normalizeHeaderName(h) === normalizeHeaderName(n))
     );
 
   // 주요 열 인덱스


### PR DESCRIPTION
## Summary
- avoid variable clash by renaming `normalizeHeader`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a992a3e108329ae2a541990009759