### PR TITLE
Add JWT login endpoint

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,7 @@
 MONGO_URI=mongodb://127.0.0.1:27017
 DB_NAME=forum
 SESSION_SECRET=changeme
+JWT_SECRET=your-jwt-secret
 S3_KEY=your-s3-key
 S3_SECRET=your-s3-secret
 S3_REGION=your-s3-region

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ This project requires several environment variables to run:
 - `MONGO_URI` – MongoDB connection string
 - `DB_NAME` – MongoDB database name used by the application
 - `SESSION_SECRET` – Secret string used to sign session cookies
+- `JWT_SECRET` – Secret key used to sign JWTs for the API
 - `S3_KEY` – AWS S3 access key
 - `S3_SECRET` – AWS S3 secret key
 - `S3_REGION` – AWS S3 region where the bucket resides
@@ -53,6 +54,13 @@ Routes are organized under the `routes/` directory. `server.js` mounts two route
 `routes/web/index.js` automatically reads every `.js` file in the same folder and mounts it. Some routes like `post` or `admin` are guarded with an auth check. `routes/api/index.js` currently exposes `/stock` endpoints through `stockApi.js`.
 
 This layout keeps API and web routes separate while avoiding an extra routing layer.
+
+## JWT authentication
+
+`/api/auth/login` issues a JSON Web Token for API clients. Send `username` and
+`password` in the request body and the server returns `{ "token": "..." }` if the
+credentials are valid. Include this token in the `Authorization` header as
+`Bearer <token>` when accessing protected endpoints.
 
 ## Coupang product endpoint
 

--- a/middlewares/jwtAuth.js
+++ b/middlewares/jwtAuth.js
@@ -1,0 +1,16 @@
+const jwt = require('jsonwebtoken');
+
+function authenticateToken(req, res, next) {
+  const authHeader = req.headers['authorization'];
+  const token = authHeader && authHeader.split(' ')[1];
+
+  if (!token) return res.status(401).json({ message: '토큰 없음' });
+
+  jwt.verify(token, process.env.JWT_SECRET || 'secret', (err, decoded) => {
+    if (err) return res.status(401).json({ message: '토큰 오류' });
+    req.user = decoded;
+    next();
+  });
+}
+
+module.exports = { authenticateToken };

--- a/routes/api/authApi.js
+++ b/routes/api/authApi.js
@@ -1,0 +1,7 @@
+const express = require('express');
+const router = express.Router();
+const controller = require('../../controllers/authController');
+
+router.post('/login', controller.loginJwt);
+
+module.exports = router;

--- a/routes/api/index.js
+++ b/routes/api/index.js
@@ -8,6 +8,8 @@
 const express = require("express");
 const router = express.Router();
 
+// 인증 API
+router.use("/auth", require("./authApi"));
 // 재고(Stock) API
 router.use("/stock", require("./stockApi"));
 // 쿠팡 재고 API


### PR DESCRIPTION
## Summary
- implement new `loginJwt` function in controller for JWT issuance
- add `/api/auth/login` route
- include JWT auth middleware
- document new `JWT_SECRET` env variable and JWT login usage

## Testing
- `npm test` *(fails: jest not found)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'scripts')*

------
https://chatgpt.com/codex/tasks/task_e_685a9ae3a68c8329a6129e1886928d1d