### PR TITLE
Fix Heroku push for shallow clone

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,11 @@ jobs:
         with:
           fetch-depth: 0
 
+      # Ensure repository is not shallow (Heroku rejects shallow pushes)
+      - name: Unshallow repository
+        run: |
+          git fetch --all --unshallow
+
       # 2) Node + 캐시
       - uses: actions/setup-node@v3
         with:


### PR DESCRIPTION
## Summary
- ensure repo is not shallow before pushing to Heroku

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a9cb7cfa08329bc85f84a912c34e8