### PR TITLE
Add Meteostat-based weather route

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,14 @@ The project exposes `/api/weather/daily` which fetches forecast data from the
 Korean Meteorological Administration using `WEATHER_API_KEY`. An accompanying
 `/weather` page displays the information via AJAX.
 
+Additionally `/api/weather/meteostat` runs a Python helper script using the
+[`meteostat`](https://github.com/meteostat/meteostat-python) library to return
+historical climate data. Example usage:
+
+```bash
+curl "http://localhost:3000/api/weather/meteostat?start=2024-01-01&end=2024-03-31"
+```
+
 
 Server-side requests use `node-fetch`, which is listed in `package.json`.
 =======

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ pandas
 openpyxl
 
 requests
+meteostat

--- a/routes/api/weatherApi.js
+++ b/routes/api/weatherApi.js
@@ -3,5 +3,6 @@ const router = express.Router();
 const ctrl = require('../../controllers/weatherController');
 
 router.get('/daily', ctrl.getDailyWeather);
+router.get('/meteostat', ctrl.getMeteostatWeather);
 
 module.exports = router;

--- a/scripts/meteostat_weather.py
+++ b/scripts/meteostat_weather.py
@@ -1,0 +1,26 @@
+import sys
+import json
+from datetime import datetime
+from meteostat import Point, Daily
+
+
+def main():
+    lat = float(sys.argv[1]) if len(sys.argv) > 1 else 37.5665
+    lon = float(sys.argv[2]) if len(sys.argv) > 2 else 126.9780
+    start_str = sys.argv[3] if len(sys.argv) > 3 else "2024-01-01"
+    end_str = sys.argv[4] if len(sys.argv) > 4 else "2024-03-31"
+
+    start = datetime.strptime(start_str, "%Y-%m-%d")
+    end = datetime.strptime(end_str, "%Y-%m-%d")
+
+    location = Point(lat, lon)
+    data = Daily(location, start=start, end=end)
+    df = data.fetch()
+
+    out = df[["tavg", "tmin", "tmax", "prcp"]].reset_index()
+    out["time"] = out["time"].dt.strftime("%Y-%m-%d")
+    print(out.to_json(orient="records"))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add helper script using Meteostat
- expose `/api/weather/meteostat` in the API router
- implement controller to run the python script
- document new endpoint
- add unit test for the new route

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685aa4fec4808329a2ad31bd41d30db4