### PR TITLE
Integrate DataTables into admin users page

### DIFF
--- a/public/js/admin-users.js
+++ b/public/js/admin-users.js
@@ -1,0 +1,6 @@
+$(function(){
+  const table = createDataTable('#usersTable');
+  $('#usersTable tbody').on('change', 'input[name="userId"]', function(){
+    $('#deleteBtn').prop('disabled', false);
+  });
+});

--- a/views/admin/users.ejs
+++ b/views/admin/users.ejs
@@ -6,7 +6,7 @@
   </div>
 </form>
 <form method="post" action="/admin/users/delete" onsubmit="return confirm('선택한 사용자를 삭제하시겠습니까?');">
-  <table class="table table-striped align-middle">
+  <table id="usersTable" class="table table-striped align-middle">
     <thead>
       <tr>
         <th style="width: 1%;"></th>
@@ -24,10 +24,3 @@
   </table>
   <button type="submit" id="deleteBtn" class="btn btn-danger" disabled>삭제</button>
 </form>
-<script>
-  document.querySelectorAll('input[name="userId"]').forEach(function(radio){
-    radio.addEventListener('change', function(){
-      document.getElementById('deleteBtn').disabled = false;
-    });
-  });
-</script>

--- a/views/layouts/admin.ejs
+++ b/views/layouts/admin.ejs
@@ -5,7 +5,8 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title><%= typeof title !== 'undefined' ? title : '관리자' %></title>
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.6/dist/css/bootstrap.min.css" rel="stylesheet">
-  <link rel="stylesheet" href="/css/admin.css">
+  <link href="https://cdn.datatables.net/1.13.6/css/dataTables.bootstrap5.min.css" rel="stylesheet">
+  <link href="/css/admin.css" rel="stylesheet">
 </head>
 <body>
   <%- include('../nav.ejs') %>
@@ -23,6 +24,13 @@
       <%- include('../' + body) %>
     </main>
   </div>
+  <script src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
+  <script src="https://cdn.datatables.net/1.13.6/js/jquery.dataTables.min.js"></script>
+  <script src="https://cdn.datatables.net/1.13.6/js/dataTables.bootstrap5.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.6/dist/js/bootstrap.bundle.min.js"></script>
-</body>
+    <script src="/js/common-dt.js"></script>
+    <% if (currentUrl.startsWith('/admin/users')) { %>
+    <script src="/js/admin-users.js"></script>
+    <% } %>
+  </body>
 </html>


### PR DESCRIPTION
## Summary
- enable DataTables on admin user management
- include DataTables assets in admin layout
- add client script for DataTables initialization

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b497988248329a70070f0f03f9c1c