### PR TITLE
Add default DataTable sorting via data attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,3 +160,17 @@ The algorithm derives average daily sales from recent conversions, applies an
 ad spend multiplier, and subtracts current stock to determine how many units
 to reorder.
 
+## DataTable helper
+
+Client pages use a helper `createDataTable()` located in `public/js/common-dt.js`.
+Tables can specify the default sort column via `data-order-col` and
+`data-order-dir` attributes:
+
+```html
+<table id="stockTable" data-order-col="1" data-order-dir="asc"></table>
+```
+
+These values are passed to DataTables when initializing so you can control the
+initial ordering without writing extra JavaScript.
+
+

--- a/public/js/common-dt.js
+++ b/public/js/common-dt.js
@@ -1,19 +1,24 @@
 function createDataTable(selector, opts = {}) {
-  return $(selector).DataTable(
-    Object.assign(
-      {
-        lengthChange: false,
-        pagingType: 'simple_numbers',
-        responsive: true,
-        fixedHeader: true,
-        language: {
-          paginate: { previous: '이전', next: '다음' },
-          info: '총 _TOTAL_건 중 _START_ ~ _END_',
-          infoEmpty: '데이터가 없습니다',
-          emptyTable: '데이터가 없습니다.'
-        }
-      },
-      opts
-    )
-  );
+  const $table = $(selector);
+  const orderCol = Number($table.data('order-col'));
+  const orderDir = $table.data('order-dir') || 'asc';
+
+  const options = {
+    lengthChange: false,
+    pagingType: 'simple_numbers',
+    responsive: true,
+    fixedHeader: true,
+    language: {
+      paginate: { previous: '이전', next: '다음' },
+      info: '총 _TOTAL_건 중 _START_ ~ _END_',
+      infoEmpty: '데이터가 없습니다',
+      emptyTable: '데이터가 없습니다.'
+    }
+  };
+
+  if (!isNaN(orderCol)) {
+    options.order = [[orderCol, orderDir]];
+  }
+
+  return $table.DataTable(Object.assign(options, opts));
 }

--- a/public/js/coupangAdd.js
+++ b/public/js/coupangAdd.js
@@ -11,7 +11,6 @@ $(function () {
     searching: false,
     info: true,
     pageLength: 50,
-    order: [[0, 'asc']],
     columnDefs: [
       { targets: '_all', className: 'text-center' },
       // 텍스트 컬러는 기본 색상 사용

--- a/public/js/coupangAddSummary.js
+++ b/public/js/coupangAddSummary.js
@@ -3,7 +3,6 @@ $(function () {
   if (!$(table).length) return;
   createDataTable(table, {
     ordering: true,
-    order: [[1, 'asc']],
     paging: false,
     searching: false,
     info: false,

--- a/public/js/stock.js
+++ b/public/js/stock.js
@@ -13,7 +13,6 @@ $(document).ready(function () {
     dom: 'lrtip',
     info: true,
     pageLength: 50,
-    order: [[1, "asc"]],
     columnDefs: [
       { targets: "_all", className: "text-center" },
       {

--- a/views/coupang-add-summary.ejs
+++ b/views/coupang-add-summary.ejs
@@ -35,7 +35,7 @@
     </div>
 
     <div class="table-responsive table-container">
-      <table id="summaryTable" class="table table-bordered table-hover table-striped bg-white align-middle text-center auto-width">
+      <table id="summaryTable" data-order-col="1" data-order-dir="asc" class="table table-bordered table-hover table-striped bg-white align-middle text-center auto-width">
         <thead class="table-light text-center">
           <tr>
             <th>번호</th>

--- a/views/coupang.ejs
+++ b/views/coupang.ejs
@@ -109,7 +109,7 @@
     <% } %>
 
     <div class="table-responsive table-container">
-      <table id="coupangTable" class="table table-bordered table-hover table-striped bg-white align-middle text-center auto-width coupang-table">
+      <table id="coupangTable" data-order-col="1" data-order-dir="asc" class="table table-bordered table-hover table-striped bg-white align-middle text-center auto-width coupang-table">
         <thead class="table-light text-center">
           <% if (필드 && 필드.length > 0) { %>
             <tr>

--- a/views/coupangAdd.ejs
+++ b/views/coupangAdd.ejs
@@ -109,7 +109,7 @@
 
     <div class="table-responsive table-container">
 
-      <table id="coupangAddTable" data-mode="<%= mode %>" class="table table-bordered table-hover table-striped bg-white align-middle text-center auto-width">
+      <table id="coupangAddTable" data-mode="<%= mode %>" data-order-col="<%= mode === 'summary' ? 1 : 0 %>" data-order-dir="asc" class="table table-bordered table-hover table-striped bg-white align-middle text-center auto-width">
         <thead class="table-light">
 
           <% if (mode === 'summary') { %>

--- a/views/stock.ejs
+++ b/views/stock.ejs
@@ -56,7 +56,7 @@
 
     <!-- 테이블 -->
     <div class="table-responsive table-container">
-      <table id="stockTable" class="table table-striped table-hover table-bordered shadow-sm rounded bg-white align-middle text-center auto-width">
+      <table id="stockTable" data-order-col="1" data-order-dir="asc" class="table table-striped table-hover table-bordered shadow-sm rounded bg-white align-middle text-center auto-width">
         <thead class="table-light">
           <tr>
             <th>번호</th>


### PR DESCRIPTION
## Summary
- allow `createDataTable` to read `data-order-col` and `data-order-dir` attributes
- rely on those attributes for default ordering on inventory and Coupang tables
- update README with usage notes

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: @eslint/js missing)*

------
https://chatgpt.com/codex/tasks/task_e_685b4c51f7388329a42d46d8b0063b7a