### PR TITLE
Implement auth checks and add tests

### DIFF
--- a/controllers/authController.js
+++ b/controllers/authController.js
@@ -71,6 +71,7 @@ exports.register = async (req, res) => {
       name,
       email,
       password: hashedPassword,
+      role: 'user',
       createdAt: new Date(),
     });
 

--- a/middlewares/auth.js
+++ b/middlewares/auth.js
@@ -1,16 +1,29 @@
-// Permission checks have been disabled to allow access to all routes.
-// These middleware functions now simply pass control to the next handler.
 function checkLogin(req, res, next) {
-  next();
+  if (req.isAuthenticated && req.isAuthenticated()) {
+    return next();
+  }
+  if (typeof req.flash === 'function') {
+    req.flash('error', '로그인이 필요합니다.');
+  }
+  return res.redirect('/login');
 }
 
 // Alias used by routers that require authentication
 function checkAuth(req, res, next) {
-  checkLogin(req, res, next);
+  return checkLogin(req, res, next);
 }
 
 function checkAdmin(req, res, next) {
-  next();
+  if (req.isAuthenticated && req.isAuthenticated()) {
+    if (req.user && req.user.role === 'admin') {
+      return next();
+    }
+    return res.status(403).send('Forbidden');
+  }
+  if (typeof req.flash === 'function') {
+    req.flash('error', '로그인이 필요합니다.');
+  }
+  return res.redirect('/login');
 }
 
 module.exports = { checkLogin, checkAdmin, checkAuth };

--- a/tests/accessControl.test.js
+++ b/tests/accessControl.test.js
@@ -1,0 +1,46 @@
+jest.setTimeout(60000);
+
+const { checkLogin, checkAdmin } = require('../middlewares/auth');
+
+describe('access control middlewares', () => {
+  let req;
+  let res;
+  let next;
+
+  beforeEach(() => {
+    req = { isAuthenticated: jest.fn(), flash: jest.fn(), user: null };
+    res = {
+      redirect: jest.fn(),
+      status: jest.fn(function () { return this; }),
+      send: jest.fn(),
+    };
+    next = jest.fn();
+  });
+
+  test('checkLogin allows authenticated user', () => {
+    req.isAuthenticated.mockReturnValue(true);
+    checkLogin(req, res, next);
+    expect(next).toHaveBeenCalled();
+  });
+
+  test('checkLogin redirects unauthenticated user', () => {
+    req.isAuthenticated.mockReturnValue(false);
+    checkLogin(req, res, next);
+    expect(res.redirect).toHaveBeenCalledWith('/login');
+  });
+
+  test('checkAdmin allows admin user', () => {
+    req.isAuthenticated.mockReturnValue(true);
+    req.user = { role: 'admin' };
+    checkAdmin(req, res, next);
+    expect(next).toHaveBeenCalled();
+  });
+
+  test('checkAdmin rejects non-admin user', () => {
+    req.isAuthenticated.mockReturnValue(true);
+    req.user = { role: 'user' };
+    checkAdmin(req, res, next);
+    expect(res.status).toHaveBeenCalledWith(403);
+    expect(res.send).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- validate login status and admin role in auth middleware
- set default `role` when registering users
- test access control middleware

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b51090e30832996bb08012a91b455