### PR TITLE
Add stock row expansion

### DIFF
--- a/controllers/stockController.js
+++ b/controllers/stockController.js
@@ -69,6 +69,26 @@ exports.getStockData = asyncHandler(async (req, res) => {
   });
 });
 
+// 상세 데이터 조회 API
+exports.getStockDetail = asyncHandler(async (req, res) => {
+  const db = req.app.locals.db;
+  const { item_code: itemCode, color } = req.query;
+
+  if (!itemCode || !color) {
+    return res
+      .status(400)
+      .json({ error: "item_code and color are required" });
+  }
+
+  const rows = await db
+    .collection("stock")
+    .find({ item_code: itemCode, color })
+    .sort({ size: 1 })
+    .toArray();
+
+  res.json({ data: rows });
+});
+
 // Excel upload API
 exports.uploadExcel = asyncHandler(async (req, res) => {
   console.log("✅ POST /stock/upload controller");

--- a/public/js/stock.js
+++ b/public/js/stock.js
@@ -22,9 +22,11 @@ $(document).ready(function () {
         },
       },
       {
-        targets: 1,
+        targets: [1, 3],
+        createdCell: function (td) {
+          $(td).addClass("dt-toggle").css("cursor", "pointer");
+        },
         render: function (data) {
-          // 품번 옆 배지를 제거하여 보다 깔끔한 출력
           return data;
         },
       },
@@ -85,6 +87,33 @@ $(document).ready(function () {
         $(row).addClass("table-danger");
       }
     },
+  });
+
+  // 품번 또는 색상 클릭 시 상세 정보 로딩
+  $('#stockTable tbody').on('click', 'td.dt-toggle', function () {
+    const tr = $(this).closest('tr');
+    const row = table.row(tr);
+
+    if (row.child.isShown()) {
+      row.child.hide();
+      tr.removeClass('shown');
+      return;
+    }
+
+    const data = row.data();
+
+    $.get('/api/stock/detail', { item_code: data.item_code, color: data.color })
+      .done(function (res) {
+        let html =
+          '<table class="table table-sm mb-0"><thead><tr><th>사이즈</th><th>수량</th><th>할당</th></tr></thead><tbody>';
+        res.data.forEach(function (d) {
+          html += `<tr><td>${d.size}</td><td>${d.qty}</td><td>${d.allocation || ''}</td></tr>`;
+        });
+        html += '</tbody></table>';
+
+        row.child(html).show();
+        tr.addClass('shown');
+      });
   });
 
   // 검색 버튼

--- a/public/main.css
+++ b/public/main.css
@@ -317,5 +317,9 @@ td:nth-child(3) {
     <col style="width: 8%">   <!-- 수량 -->
     <col style="width: 10%">  <!-- 할당 -->
     <col style="width: 12%">  <!-- 업로드 사용자 -->
-    <col style="width: 19%">  <!-- 업로드 시각 -->
+  <col style="width: 19%">  <!-- 업로드 시각 -->
   </colgroup>
+
+.dt-toggle {
+  cursor: pointer;
+}

--- a/routes/api/stockApi.js
+++ b/routes/api/stockApi.js
@@ -4,6 +4,7 @@ const router = express.Router();
 const stockCtrl = require("../../controllers/stockController");
 
 router.get("/", stockCtrl.getStockData);
+router.get("/detail", stockCtrl.getStockDetail);
 router.post("/upload", stockCtrl.upload, stockCtrl.uploadExcelApi);
 router.delete("/", async (req, res) => {
   const db = req.app.locals.db;

--- a/tests/stockApi.test.js
+++ b/tests/stockApi.test.js
@@ -79,3 +79,22 @@ describe("DELETE /api/stock", () => {
     expect(mockColl.deleteMany).toHaveBeenCalledWith({});
   });
 });
+
+describe("GET /api/stock/detail", () => {
+  it("should return detail rows", async () => {
+    mockCollection.toArray.mockResolvedValueOnce([{ size: "S", qty: 3 }]);
+
+    const res = await request(app)
+      .get("/api/stock/detail")
+      .query({ item_code: "ABC", color: "RED" });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toEqual({ data: [{ size: "S", qty: 3 }] });
+
+    expect(mockCollection.find).toHaveBeenCalledWith({
+      item_code: "ABC",
+      color: "RED",
+    });
+    expect(mockCollection.sort).toHaveBeenCalledWith({ size: 1 });
+  });
+});


### PR DESCRIPTION
## Summary
- load detailed stock rows via `/api/stock/detail`
- show sizes and quantities on click in stock table
- style clickable cells
- test stock detail API

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b54cb5e0c832983dff8e090601716