### PR TITLE
Fix jest hanging

### DIFF
--- a/server.js
+++ b/server.js
@@ -23,7 +23,9 @@ async function initApp() {
   const db = await connectDB();
   await initIndexes(db);
   app.locals.db = db;
-  startCronJobs(db);
+  if (process.env.NODE_ENV !== 'test') {
+    startCronJobs(db);
+  }
 
   require("./config/passport")(passport, db);
 


### PR DESCRIPTION
## Summary
- skip cronjobs when running in the test environment

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b915c0cec8329966290056b890670