### PR TITLE
Handle alternate sales amount header

### DIFF
--- a/lib/parseCoupangExcel.js
+++ b/lib/parseCoupangExcel.js
@@ -53,8 +53,10 @@ function parseCoupangExcel(filePath) {
   const optionNameIdx = findIndex(['Option name', '옵션명']);
   const offerCondIdx = findIndex(['Offer condition', '상품상태', '판매상태']);
   const inventoryIdx = findIndex(['Orderable quantity (real-time)', '재고량']);
+  // “on the last 30 days” 와 “in the last 30 days” 두 표현 모두 인식
   const salesAmountIdx = findIndex([
     'Sales amount on the last 30 days',
+    'Sales amount in the last 30 days',
     '30일 판매금액',
     '최근 30일 판매금액',
     '최근30일판매금액'


### PR DESCRIPTION
## Summary
- support "Sales amount in the last 30 days" header when parsing Coupang Excel files

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685b9a199a248329b371c72c31d79520