### PR TITLE
Add Python script for settlement payouts

### DIFF
--- a/scripts/settlement_api.py
+++ b/scripts/settlement_api.py
@@ -1,0 +1,54 @@
+from coupang_api import coupang_request
+
+
+def list_payouts(
+    page: int = 0,
+    size: int = 20,
+    start_date: str | None = None,   # 형식: 'YYYY-MM-DD'
+    end_date: str | None = None      # 형식: 'YYYY-MM-DD'
+):
+    """
+    정산(매출) 리스트 조회
+    - page, size: 페이지네이션 파라미터
+    - start_date, end_date: 조회 기간 (선택)
+    """
+    path = "/v2/providers/seller_api/apis/api/v1/settlement/payouts"
+    query = {
+        "page": page,
+        "size": size,
+    }
+    if start_date:
+        query["startDate"] = start_date
+    if end_date:
+        query["endDate"] = end_date
+
+    return coupang_request("GET", path, query=query)
+
+
+def get_payout_detail(settlement_id: str | int):
+    """
+    특정 정산 ID 의 상세 리포트 조회
+    """
+    path = f"/v2/providers/seller_api/apis/api/v1/settlement/payouts/{settlement_id}"
+    return coupang_request("GET", path)
+
+
+# 사용 예시 -------------------------------------------------------------------
+if __name__ == "__main__":
+    # 1) 최근 30일 정산 내역 첫 페이지(20건) 조회
+    payouts = list_payouts(
+        page=0,
+        size=20,
+        start_date="2025-05-28",
+        end_date="2025-06-27",
+    )
+    print("=== Payout List ===")
+    for p in payouts.get("content", []):
+        print(p["settlementId"], p["payoutAmount"])
+
+    # 2) 특정 정산 ID 상세 조회
+    if payouts.get("content"):
+        settlement_id = payouts["content"][0]["settlementId"]
+        detail = get_payout_detail(settlement_id)
+        print("\n=== Payout Detail ===")
+        print(detail)


### PR DESCRIPTION
## Summary
- add `scripts/settlement_api.py` module using existing `coupang_request`

## Testing
- `python -m py_compile scripts/settlement_api.py`
- `npm test` *(fails: `jest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e37d579d88329b2c78cb1ceafbe11