### PR TITLE
Add settlement API unit tests

### DIFF
--- a/scripts/settlement_api.py
+++ b/scripts/settlement_api.py
@@ -1,0 +1,15 @@
+from .coupang_api import coupang_request
+
+
+def list_payouts():
+    """Return payout list using Coupang settlement API."""
+    return coupang_request(
+        "GET",
+        "/v2/providers/settlement-openapi/apis/api/v1/payouts",
+    )
+
+
+def get_payout_detail(payout_id: str):
+    """Return payout detail for the given payout_id."""
+    path = f"/v2/providers/settlement-openapi/apis/api/v1/payouts/{payout_id}"
+    return coupang_request("GET", path)

--- a/tests/test_settlement_api.py
+++ b/tests/test_settlement_api.py
@@ -1,0 +1,29 @@
+import unittest
+from unittest.mock import patch, Mock
+
+from scripts.settlement_api import list_payouts, get_payout_detail
+
+
+class SettlementApiTests(unittest.TestCase):
+    @patch("scripts.settlement_api.coupang_request")
+    def test_list_payouts_calls_coupang_request(self, mock_request):
+        mock_request.return_value = {"foo": "bar"}
+        data = list_payouts()
+        mock_request.assert_called_with(
+            "GET", "/v2/providers/settlement-openapi/apis/api/v1/payouts"
+        )
+        self.assertEqual(data, {"foo": "bar"})
+
+    @patch("scripts.settlement_api.coupang_request")
+    def test_get_payout_detail_calls_coupang_request(self, mock_request):
+        mock_request.return_value = {"baz": "qux"}
+        data = get_payout_detail("123")
+        mock_request.assert_called_with(
+            "GET",
+            "/v2/providers/settlement-openapi/apis/api/v1/payouts/123",
+        )
+        self.assertEqual(data, {"baz": "qux"})
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- cover new settlement API helper with unit tests
- implement simple wrapper functions for Coupang settlement endpoints

## Testing
- `npm test` *(fails: jest not found)*
- `python -m pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_685e396284d8832986283220aa803654