### PR TITLE
Fix weather same-day test

### DIFF
--- a/tests/weatherApi.test.js
+++ b/tests/weatherApi.test.js
@@ -2,6 +2,7 @@ jest.setTimeout(60000);
 
 // Mock MongoDB config
 const mockCollection = {
+  findOne: jest.fn().mockResolvedValue(null),
   find: jest.fn().mockReturnThis(),
   project: jest.fn().mockReturnThis(),
   sort: jest.fn().mockReturnThis(),
@@ -49,6 +50,13 @@ beforeAll(async () => {
   });
 
   app = await initApp();
+});
+
+beforeEach(() => {
+  mockCollection.find.mockClear();
+  mockCollection.project.mockClear();
+  mockCollection.sort.mockClear();
+  mockCollection.toArray.mockReset();
 });
 
 afterAll(async () => {


### PR DESCRIPTION
## Summary
- mock `findOne` for homepage queries
- reset DB mocks before each weather API test to avoid leftover calls

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e45637b0c8329b58d7b75a491f294