### PR TITLE
Fix banner middleware and update mocks

### DIFF
--- a/server.js
+++ b/server.js
@@ -77,12 +77,21 @@ async function initApp() {
   app.use(async (req, res, next) => {
     try {
       const db = req.app.locals.db;
-      const logoDoc = await db.collection("homepage").findOne({ key: "logo" });
-      const bannerDocs = await db
-        .collection("homepage")
-        .find({ key: /^banner/ })
-        .sort({ key: 1 })
-        .toArray();
+      const homepageColl = db?.collection?.("homepage");
+
+      const logoDoc = await homepageColl?.findOne?.({ key: "logo" });
+
+      let bannerDocs = [];
+      if (typeof homepageColl?.find === "function") {
+        let cursor = homepageColl.find({ key: /^banner/ });
+        if (typeof cursor.sort === "function") {
+          cursor = cursor.sort({ key: 1 });
+        }
+        if (typeof cursor.toArray === "function") {
+          bannerDocs = await cursor.toArray();
+        }
+      }
+
       res.locals.logo = logoDoc?.img || "";
       res.locals.banners = bannerDocs.map((b) => b.img);
     } catch (err) {

--- a/tests/coupangApi.test.js
+++ b/tests/coupangApi.test.js
@@ -6,6 +6,7 @@ const mockCollection = {
   find: jest.fn().mockReturnThis(),
   sort: jest.fn().mockReturnThis(),
   toArray: jest.fn().mockResolvedValue([]),
+  findOne: jest.fn().mockResolvedValue(null),
 };
 jest.mock("../config/db", () => {
   const mockDb = { collection: jest.fn(() => mockCollection) };

--- a/tests/coupangOpenApi.test.js
+++ b/tests/coupangOpenApi.test.js
@@ -1,7 +1,13 @@
 jest.setTimeout(60000);
 
 jest.mock('../config/db', () => {
-  const mockDb = { collection: jest.fn() };
+  const mockCollection = {
+    findOne: jest.fn().mockResolvedValue(null),
+    find: jest.fn().mockReturnThis(),
+    sort: jest.fn().mockReturnThis(),
+    toArray: jest.fn().mockResolvedValue([]),
+  };
+  const mockDb = { collection: jest.fn(() => mockCollection) };
   const mockConnect = jest.fn().mockResolvedValue(mockDb);
   mockConnect.then = (fn) => fn(mockDb);
   return { connectDB: mockConnect, closeDB: jest.fn().mockResolvedValue() };

--- a/tests/coupangOpenCreate.test.js
+++ b/tests/coupangOpenCreate.test.js
@@ -1,7 +1,13 @@
 jest.setTimeout(60000);
 
 jest.mock('../config/db', () => {
-  const mockDb = { collection: jest.fn() };
+  const mockCollection = {
+    findOne: jest.fn().mockResolvedValue(null),
+    find: jest.fn().mockReturnThis(),
+    sort: jest.fn().mockReturnThis(),
+    toArray: jest.fn().mockResolvedValue([]),
+  };
+  const mockDb = { collection: jest.fn(() => mockCollection) };
   const mockConnect = jest.fn().mockResolvedValue(mockDb);
   mockConnect.then = (fn) => fn(mockDb);
   return { connectDB: mockConnect, closeDB: jest.fn().mockResolvedValue() };

--- a/tests/weatherApi.test.js
+++ b/tests/weatherApi.test.js
@@ -6,6 +6,7 @@ const mockCollection = {
   project: jest.fn().mockReturnThis(),
   sort: jest.fn().mockReturnThis(),
   toArray: jest.fn().mockResolvedValue([]),
+  findOne: jest.fn().mockResolvedValue(null),
 };
 jest.mock('../config/db', () => {
   const mockDb = { collection: jest.fn(() => mockCollection) };
@@ -66,10 +67,12 @@ test('GET /api/weather/daily returns parsed weather data', async () => {
 });
 
 test('GET /api/weather/same-day returns past years data', async () => {
-  mockCollection.toArray.mockResolvedValueOnce([
-    { _id: '20240627' },
-    { _id: '20230627' },
-  ]);
+  mockCollection.toArray
+    .mockResolvedValueOnce([])
+    .mockResolvedValueOnce([
+      { _id: '20240627' },
+      { _id: '20230627' },
+    ]);
 
   const res = await request(app).get(
     '/api/weather/same-day?date=2024-06-27&years=2'


### PR DESCRIPTION
## Summary
- guard optional Mongo collection functions in banner middleware
- update DB mocks across tests for banner lookup
- handle multiple calls to toArray in weather API test

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e4bd6637483298e64bfd3b23bd474