### PR TITLE
Fix deterministic ordering in weather same-day results

### DIFF
--- a/controllers/weatherController.js
+++ b/controllers/weatherController.js
@@ -70,5 +70,8 @@ exports.getSameDay = asyncHandler(async (req, res) => {
     .sort({ _id: -1 })
     .toArray();
 
+  // Ensure deterministic order
+  docs.sort((a, b) => b._id.localeCompare(a._id));
+
   res.json(docs);
 });


### PR DESCRIPTION
## Summary
- guarantee deterministically sorted weather results

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e57a09b948329b1b1904ae63181a1