### PR TITLE
Switch Python scripts to logging

### DIFF
--- a/scripts/coupang_api.py
+++ b/scripts/coupang_api.py
@@ -4,6 +4,12 @@ import hashlib
 import time
 from urllib.parse import urlencode
 import requests
+import logging
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s - %(levelname)s - %(message)s",
+)
 
 
 def sign(method: str, url_path: str, secret_key: str, timestamp: str) -> str:
@@ -50,4 +56,4 @@ if __name__ == "__main__":
 
     q = dict(pair.split("=", 1) for pair in args.query.split("&")) if args.query else None
     data = coupang_request(args.method.upper(), args.path, query=q)
-    print(json.dumps(data, ensure_ascii=False, indent=2))
+    logging.info(json.dumps(data, ensure_ascii=False, indent=2))

--- a/scripts/excel_to_json.py
+++ b/scripts/excel_to_json.py
@@ -2,9 +2,15 @@ import sys
 import pandas as pd
 import json
 import re
+import logging
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s - %(levelname)s - %(message)s",
+)
 
 if len(sys.argv) < 3:
-    print('Usage: python excel_to_json.py <excel_path> <output_path>')
+    logging.error('Usage: python excel_to_json.py <excel_path> <output_path>')
     sys.exit(1)
 
 excel_path = sys.argv[1]
@@ -14,7 +20,7 @@ output_path = sys.argv[2]
 try:
     df = pd.read_excel(excel_path, header=0)
 except Exception as e:
-    print(f'Error reading Excel: {e}', file=sys.stderr)
+    logging.error('Error reading Excel: %s', e)
     sys.exit(2)
 
 # Sanitize column names: remove whitespace and newlines using regex
@@ -26,5 +32,5 @@ records = df.to_dict(orient='records')
 with open(output_path, 'w', encoding='utf-8') as f:
     json.dump(records, f, ensure_ascii=False)
 
-print(f'JSON saved to {output_path} with {len(records)} records')
+logging.info('JSON saved to %s with %d records', output_path, len(records))
 

--- a/scripts/excel_to_mongo.py
+++ b/scripts/excel_to_mongo.py
@@ -7,6 +7,12 @@ from pathlib import Path
 import re
 from dotenv import load_dotenv
 from typing import Union, IO
+import logging
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s - %(levelname)s - %(message)s",
+)
 
 # ─────────────────────────────────────────────
 # ① .env 파일에서 환경변수 불러오기 (MONGO_URI 포함)
@@ -155,20 +161,22 @@ def transform_file(path: Union[str, Path, IO]) -> list[dict]:
 # ─────────────────────────────────────────────
 def main():
     if len(sys.argv) < 4:
-        print("❌ 사용법: python file_to_mongo.py <file_path> <db_name> <collection_name>")
+        logging.error(
+            "❌ 사용법: python file_to_mongo.py <file_path> <db_name> <collection_name>"
+        )
         sys.exit(1)
 
     file_path, db_name, collection_name = sys.argv[1:4]
     mongo_uri = os.getenv("MONGO_URI")
     if not mongo_uri:
-        print("❌ 환경 변수 MONGO_URI이 설정되지 않았습니다.")
+        logging.error("❌ 환경 변수 MONGO_URI이 설정되지 않았습니다.")
         sys.exit(1)
 
     try:
         # 🔧 수정 내용: 확장자에 따라 엑셀/CSV를 자동 판단하여 처리
         docs = transform_file(file_path)
     except Exception as e:
-        print("❌ Transform error:", e, file=sys.stderr)
+        logging.error("❌ Transform error: %s", e)
         traceback.print_exc()
         sys.exit(2)
 
@@ -178,11 +186,11 @@ def main():
             if docs:
                 col.delete_many({})  # 기존 데이터 전체 삭제
                 col.insert_many(docs)
-                print(f"✅ MongoDB 저장 완료: {len(docs)}건")
+                logging.info("✅ MongoDB 저장 완료: %d건", len(docs))
             else:
-                print("⚠️ 변환된 데이터가 없습니다.")
+                logging.info("⚠️ 변환된 데이터가 없습니다.")
     except Exception as e:
-        print("❌ MongoDB 저장 실패:", e, file=sys.stderr)
+        logging.error("❌ MongoDB 저장 실패: %s", e)
         traceback.print_exc()
         sys.exit(3)
 

--- a/scripts/settlement_api.py
+++ b/scripts/settlement_api.py
@@ -1,4 +1,10 @@
 from coupang_api import coupang_request
+import logging
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s - %(levelname)s - %(message)s",
+)
 
 
 def list_payouts(
@@ -42,13 +48,13 @@ if __name__ == "__main__":
         start_date="2025-05-28",
         end_date="2025-06-27",
     )
-    print("=== Payout List ===")
+    logging.info("=== Payout List ===")
     for p in payouts.get("content", []):
-        print(p["settlementId"], p["payoutAmount"])
+        logging.info("%s %s", p["settlementId"], p["payoutAmount"])
 
     # 2) 특정 정산 ID 상세 조회
     if payouts.get("content"):
         settlement_id = payouts["content"][0]["settlementId"]
         detail = get_payout_detail(settlement_id)
-        print("\n=== Payout Detail ===")
-        print(detail)
+        logging.info("\n=== Payout Detail ===")
+        logging.info("%s", detail)


### PR DESCRIPTION
## Summary
- replace `print` with `logging` in Python helper scripts
- configure logging output for timestamped messages

## Testing
- `npm test` *(fails: jest not found)*
- `python -m pytest` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_685e57ac92848329bb7e756df581e0b0