### PR TITLE
Update README with Node install notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,18 @@ This project requires several environment variables to run:
 - `CP_RG_AUTH_TOKEN` – Token for RocketGross API calls (enable the feature in WING first)
 
 
+
 Copy `.env.example` to `.env` in the project root and define these values before starting the server. Make sure the file is saved as **UTF-8 without BOM** so that `dotenv` can read it correctly.
+
+## Node packages
+
+`node_modules` is excluded from version control. Install the dependencies before running the server or any tests:
+
+```bash
+npm ci # or `npm install`
+```
+
+After the packages are installed you can run `npm test` or start `server.js`.
 
 ## Python scripts
 


### PR DESCRIPTION
## Summary
- document that `node_modules` is not committed
- instruct to run `npm ci` or `npm install` before running tests or server

## Testing
- `npm test` *(fails: jest not found)*
- `npm ci` *(fails: network access disabled)*

------
https://chatgpt.com/codex/tasks/task_e_685f6bd970f883298996c14b4910a5b4