### PR TITLE
Drop deprecated mongoose options in tests

### DIFF
--- a/tests/setup.js
+++ b/tests/setup.js
@@ -17,10 +17,7 @@ beforeAll(async () => {
   process.env.NODE_ENV = "test";
   process.env.SESSION_SECRET = "testsecret";
 
-  await mongoose.connect(uri, {
-    useNewUrlParser: true,
-    useUnifiedTopology: true,
-  });
+  await mongoose.connect(uri);
 
   // Express 앱 불러오기 및 listen
   const { app } = require("../server");


### PR DESCRIPTION
## Summary
- modernize mongoose connect call in tests by dropping deprecated `useNewUrlParser` and `useUnifiedTopology`

## Testing
- `npm test` *(fails: `jest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f6bdcbec883299c9c341c477d4354