### PR TITLE
Update client root and stock pages

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -1,14 +1,16 @@
 import './App.css';
-import Weather from './Weather';
+import { BrowserRouter, Routes, Route } from 'react-router-dom';
+import Home from './pages/Home';
+import Stock from './pages/Stock';
 
 function App() {
   return (
-    <div className="App">
-      <header className="App-header">
-        <h1>날씨 정보</h1>
-        <Weather />
-      </header>
-    </div>
+    <BrowserRouter>
+      <Routes>
+        <Route path="/" element={<Home />} />
+        <Route path="/stock" element={<Stock />} />
+      </Routes>
+    </BrowserRouter>
   );
 }
 

--- a/client/src/App.test.js
+++ b/client/src/App.test.js
@@ -1,8 +1,8 @@
 import { render, screen } from '@testing-library/react';
 import App from './App';
 
-test('renders weather header', () => {
+test('renders home heading', () => {
   render(<App />);
-  const heading = screen.getByText('날씨 정보');
+  const heading = screen.getByText('재고관리 시스템');
   expect(heading).toBeInTheDocument();
 });

--- a/client/src/pages/Home.js
+++ b/client/src/pages/Home.js
@@ -1,0 +1,14 @@
+import { Link } from 'react-router-dom';
+
+function Home() {
+  return (
+    <div className="container">
+      <h1>재고관리 시스템</h1>
+      <p>
+        <Link to="/stock">재고 페이지로 이동</Link>
+      </p>
+    </div>
+  );
+}
+
+export default Home;

--- a/client/src/pages/Stock.js
+++ b/client/src/pages/Stock.js
@@ -1,0 +1,97 @@
+import { useEffect, useState } from 'react';
+
+function Stock() {
+  const [rows, setRows] = useState([]);
+  const [form, setForm] = useState({ itemCode: '', color: '', size: '' });
+
+  const loadData = async () => {
+    const params = new URLSearchParams({
+      start: '0',
+      length: '100',
+      item_code: form.itemCode,
+      color: form.color,
+      size: form.size,
+    });
+    const res = await fetch(`/api/stock?${params.toString()}`);
+    if (res.ok) {
+      const data = await res.json();
+      setRows(data.data || []);
+    }
+  };
+
+  useEffect(() => {
+    loadData();
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+
+  const onChange = (e) => {
+    setForm({ ...form, [e.target.name]: e.target.value });
+  };
+
+  return (
+    <div className="container">
+      <h2>재고 관리</h2>
+      <div className="row g-2 mb-3">
+        <div className="col">
+          <input
+            type="text"
+            name="itemCode"
+            className="form-control"
+            placeholder="품번"
+            value={form.itemCode}
+            onChange={onChange}
+          />
+        </div>
+        <div className="col">
+          <input
+            type="text"
+            name="color"
+            className="form-control"
+            placeholder="색상"
+            value={form.color}
+            onChange={onChange}
+          />
+        </div>
+        <div className="col">
+          <input
+            type="text"
+            name="size"
+            className="form-control"
+            placeholder="사이즈"
+            value={form.size}
+            onChange={onChange}
+          />
+        </div>
+        <div className="col">
+          <button className="btn btn-outline-primary w-100" onClick={loadData}>
+            검색
+          </button>
+        </div>
+      </div>
+
+      <table className="table table-bordered text-center">
+        <thead>
+          <tr>
+            <th>품번</th>
+            <th>품명</th>
+            <th>색상</th>
+            <th>사이즈</th>
+            <th>수량</th>
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map((row) => (
+            <tr key={row._id}>
+              <td>{row.item_code}</td>
+              <td>{row.item_name}</td>
+              <td>{row.color}</td>
+              <td>{row.size}</td>
+              <td>{row.qty}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+export default Stock;


### PR DESCRIPTION
## Summary
- add React Router with Home and Stock pages
- show stock items from `/api/stock` in Stock page
- update tests for new home page heading

## Testing
- `npm test` *(fails: jest not found)*
- `cd client && npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f768c397883299be11461c492735d