### PR TITLE
Add react-hooks ESLint plugin

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,6 +1,7 @@
 import js from "@eslint/js";
 import globals from "globals";
 import pluginReact from "eslint-plugin-react";
+import pluginReactHooks from "eslint-plugin-react-hooks";
 import pluginPrettier from "eslint-plugin-prettier";
 import airbnb from "eslint-config-airbnb-base";
 import { defineConfig } from "eslint/config";
@@ -12,6 +13,7 @@ export default defineConfig([
       js,
       react: pluginReact,
       prettier: pluginPrettier,
+      "react-hooks": pluginReactHooks,
     },
     languageOptions: {
       ecmaVersion: 2022,
@@ -28,6 +30,7 @@ export default defineConfig([
       "js/recommended",
       airbnb,
       pluginPrettier.configs.recommended,
+      "plugin:react-hooks/recommended",
     ],
     rules: {
       "no-console": "off",

--- a/package-lock.json
+++ b/package-lock.json
@@ -51,6 +51,7 @@
         "eslint-plugin-import": "^2.32.0",
         "eslint-plugin-prettier": "^5.1.3",
         "eslint-plugin-react": "^7.37.5",
+        "eslint-plugin-react-hooks": "^4.6.0",
         "globals": "^16.2.0",
         "husky": "^9.1.7",
         "jest": "^30.0.3",

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "eslint-plugin-import": "^2.32.0",
     "eslint-plugin-prettier": "^5.1.3",
     "eslint-plugin-react": "^7.37.5",
+    "eslint-plugin-react-hooks": "^4.6.0",
     "globals": "^16.2.0",
     "husky": "^9.1.7",
     "jest": "^30.0.3",


### PR DESCRIPTION
## Summary
- install eslint-plugin-react-hooks as a dev dependency
- enable react-hooks lint rules

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685f8f6427e883298ace50290e463225