### PR TITLE
Update root page and weather

### DIFF
--- a/server.js
+++ b/server.js
@@ -117,7 +117,12 @@ async function initApp() {
   }
 
   app.get("/", (req, res) => {
-    res.redirect(302, "/stock");
+    const routes = webRouter.stack
+      .filter((layer) => layer.route)
+      .map((layer) => layer.route.path)
+      .filter((p, idx, arr) => arr.indexOf(p) === idx)
+      .sort();
+    res.render("routes.ejs", { routes });
   });
   app.use(express.static(path.join(__dirname, "public")));
   app.get("/dashboard", checkAuth, (req, res) => {

--- a/views/routes.ejs
+++ b/views/routes.ejs
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+  <meta charset="UTF-8">
+  <title>라우터 목록</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.6/dist/css/bootstrap.min.css" rel="stylesheet">
+  <link rel="stylesheet" href="/main.css">
+</head>
+<body class="bg-light">
+  <%- include('nav.ejs') %>
+  <div class="container my-5">
+    <h2 class="fw-bold mb-4">📌 사용 가능한 페이지</h2>
+    <ul class="list-group">
+      <% routes.forEach(function(p){ %>
+        <li class="list-group-item">
+          <a href="<%= p %>"><%= p %></a>
+        </li>
+      <% }) %>
+    </ul>
+  </div>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.6/dist/js/bootstrap.bundle.min.js"></script>
+</body>
+</html>

--- a/views/weather.ejs
+++ b/views/weather.ejs
@@ -11,7 +11,7 @@
   <%- include('nav.ejs') %>
 
   <div class="container my-5">
-    <h2 class="fw-bold mb-4">🌤️ 날씨 정보</h2>
+    <h2 class="fw-bold mb-4">🌤️ 서울의 날씨 정보</h2>
     <div id="weather-root"></div>
   </div>
 
@@ -27,7 +27,7 @@
       React.useEffect(() => {
         async function fetchWeather() {
           try {
-            const res = await fetch('/api/weather/daily');
+            const res = await fetch('/api/weather/daily?nx=60&ny=127');
             if (!res.ok) throw new Error('Failed to fetch');
             const data = await res.json();
             setWeather(data);


### PR DESCRIPTION
## Summary
- render a page that lists all available routes at the root URL
- fetch Seoul weather and show heading

## Testing
- `npm run lint`
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f96ef63cc8329ab62ea5265526eed