### PR TITLE
Implement route list page and update weather view

### DIFF
--- a/routes/api/index.js
+++ b/routes/api/index.js
@@ -18,6 +18,8 @@ router.use("/coupang-add", require("./coupangAddApi"));
 router.use("/coupang-open", require("./coupangOpenApi"));
 // 날씨 API
 router.use("/weather", require("./weatherApi"));
+// Express routes info
+router.use("/routes", require("./routesInfo"));
 // 광고 성과 API
 router.use("/analytics", require("./analytics"));
 

--- a/routes/api/routesInfo.js
+++ b/routes/api/routesInfo.js
@@ -1,0 +1,20 @@
+const express = require('express');
+const router = express.Router();
+
+// Return a list of all registered routes on the app
+router.get('/', (req, res) => {
+  const routes = [];
+  req.app._router.stack.forEach((r) => {
+    if (r.route && r.route.path) {
+      routes.push({
+        path: r.route.path,
+        methods: Object.keys(r.route.methods)
+          .map((m) => m.toUpperCase())
+          .join(', '),
+      });
+    }
+  });
+  res.json(routes);
+});
+
+module.exports = router;

--- a/server.js
+++ b/server.js
@@ -117,7 +117,7 @@ async function initApp() {
   }
 
   app.get("/", (req, res) => {
-    res.redirect(302, "/stock");
+    res.render("routes");
   });
   app.use(express.static(path.join(__dirname, "public")));
   app.get("/dashboard", checkAuth, (req, res) => {

--- a/views/routes.ejs
+++ b/views/routes.ejs
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+  <meta charset="UTF-8">
+  <title>라우터 목록</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.6/dist/css/bootstrap.min.css" rel="stylesheet">
+  <link rel="stylesheet" href="/main.css">
+</head>
+<body class="bg-light">
+  <%- include('nav.ejs') %>
+  <div class="container my-5">
+    <h2 class="fw-bold mb-4">📑 라우터 목록</h2>
+    <div id="route-root"></div>
+  </div>
+
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.6/dist/js/bootstrap.bundle.min.js"></script>
+  <script crossorigin src="https://unpkg.com/react@18/umd/react.development.js"></script>
+  <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"></script>
+  <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
+  <script type="text/babel">
+    function RouteList() {
+      const [routes, setRoutes] = React.useState(null);
+      React.useEffect(() => {
+        fetch('/api/routes')
+          .then(res => res.json())
+          .then(setRoutes)
+          .catch(() => setRoutes([]));
+      }, []);
+      if (!routes) {
+        return <p>Loading...</p>;
+      }
+      return (
+        <table className="table table-bordered bg-white text-center">
+          <thead className="table-light">
+            <tr>
+              <th>METHODS</th>
+              <th>PATH</th>
+            </tr>
+          </thead>
+          <tbody>
+            {routes.map((r, idx) => (
+              <tr key={idx}>
+                <td>{r.methods}</td>
+                <td><a href={r.path}>{r.path}</a></td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      );
+    }
+    ReactDOM.createRoot(document.getElementById('route-root')).render(<RouteList />);
+  </script>
+</body>
+</html>

--- a/views/weather.ejs
+++ b/views/weather.ejs
@@ -11,7 +11,7 @@
   <%- include('nav.ejs') %>
 
   <div class="container my-5">
-    <h2 class="fw-bold mb-4">🌤️ 날씨 정보</h2>
+    <h2 class="fw-bold mb-4">🌤️ 서울 날씨 정보</h2>
     <div id="weather-root"></div>
   </div>
 


### PR DESCRIPTION
## Summary
- show Express routes via new `/` view with React
- expose `/api/routes` endpoint to serve route data
- update weather page heading to show Seoul

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f9ba5ebe08329835f6b45e66aaa9b