### PR TITLE
Fix root route to serve React index

### DIFF
--- a/server.js
+++ b/server.js
@@ -116,10 +116,11 @@ async function initApp() {
       );
   }
 
-  app.get("/", (req, res) => {
-    res.redirect(302, "/stock");
-  });
+  app.use(express.static(path.join(__dirname, "client", "public")));
   app.use(express.static(path.join(__dirname, "public")));
+  app.get("/", (req, res) => {
+    res.sendFile(path.join(__dirname, "client", "public", "index.html"));
+  });
   app.get("/dashboard", checkAuth, (req, res) => {
     const menus = ["/stock", "/list", "/write"];
     const menuIcons = {

--- a/tests/health.test.js
+++ b/tests/health.test.js
@@ -45,12 +45,12 @@ afterAll(async () => {
   await closeDB(); // 모킹된 closeDB 호출
 });
 
-describe("GET /stock", () => {
+describe("GET /", () => {
   it(
-    "should return 302 redirect (CI 환경)",
+    "should return 200 with React index",
     async () => {
-      const res = await request(app).get("/").redirects(0);
-      expect(res.statusCode).toBe(302);
+      const res = await request(app).get("/");
+      expect(res.statusCode).toBe(200);
     },
     60000 // 개별 테스트 타임아웃 (60초)
   );


### PR DESCRIPTION
## Summary
- serve React index.html at the root path
- adjust health test to expect HTTP 200

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f9dba983c8329a64e94c14436b853