### PR TITLE
Fix root route to serve React index

### DIFF
--- a/server.js
+++ b/server.js
@@ -116,8 +116,10 @@ async function initApp() {
       );
   }
 
+  // 기본 경로에서 React 정적 페이지 제공
   app.get("/", (req, res) => {
-    res.redirect(302, "/stock");
+    const reactIndex = path.join(__dirname, "client", "public", "index.html");
+    res.sendFile(reactIndex);
   });
   app.use(express.static(path.join(__dirname, "public")));
   app.get("/dashboard", checkAuth, (req, res) => {

--- a/tests/health.test.js
+++ b/tests/health.test.js
@@ -45,12 +45,12 @@ afterAll(async () => {
   await closeDB(); // 모킹된 closeDB 호출
 });
 
-describe("GET /stock", () => {
+describe("GET /", () => {
   it(
-    "should return 302 redirect (CI 환경)",
+    "should return 200 with React index",
     async () => {
-      const res = await request(app).get("/").redirects(0);
-      expect(res.statusCode).toBe(302);
+      const res = await request(app).get("/");
+      expect(res.statusCode).toBe(200);
     },
     60000 // 개별 테스트 타임아웃 (60초)
   );


### PR DESCRIPTION
## Summary
- serve React client static index.html at the root path
- update health test to expect HTTP 200 for the root

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f9eca10f0832993e79f570d3669a6