### PR TITLE
Implement monthly weather chart in React

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -8,7 +8,9 @@
     "react-dom": "^19.1.0",
     "react-router-dom": "^6.30.1",
     "react-scripts": "^5.0.1",
-    "web-vitals": "^2.1.4"
+    "web-vitals": "^2.1.4",
+    "chart.js": "^4.4.1",
+    "react-chartjs-2": "^5.2.0"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -5,6 +5,7 @@ import { BrowserRouter, Routes, Route } from 'react-router-dom';
 import Home from './pages/Home';
 import Stock from './pages/Stock';
 import Login from './pages/Login';
+import Weather from './pages/Weather';
 
 function App() {
   return (
@@ -13,6 +14,7 @@ function App() {
         <Route path="/" element={<Home />} />
         <Route path="/login" element={<Login />} />
         <Route path="/stock" element={<Stock />} />
+        <Route path="/weather" element={<Weather />} />
       </Routes>
     </BrowserRouter>
   );

--- a/client/src/MonthlyWeatherChart.js
+++ b/client/src/MonthlyWeatherChart.js
@@ -1,0 +1,66 @@
+import { useEffect, useState } from 'react';
+import { Line } from 'react-chartjs-2';
+import {
+  Chart as ChartJS,
+  CategoryScale,
+  LinearScale,
+  PointElement,
+  LineElement,
+  Title,
+  Tooltip,
+  Legend,
+} from 'chart.js';
+
+ChartJS.register(
+  CategoryScale,
+  LinearScale,
+  PointElement,
+  LineElement,
+  Title,
+  Tooltip,
+  Legend
+);
+
+function MonthlyWeatherChart({ year, month }) {
+  const [data, setData] = useState([]);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    async function fetchData() {
+      try {
+        const res = await fetch(`/api/weather/monthly?year=${year}&month=${month}`);
+        if (!res.ok) throw new Error('Failed to fetch');
+        const json = await res.json();
+        setData(json.filter((d) => !d.error));
+      } catch (e) {
+        setError('데이터 없음');
+      }
+    }
+    fetchData();
+  }, [year, month]);
+
+  if (error) {
+    return <p>{error}</p>;
+  }
+
+  if (!data.length) {
+    return <p>Loading...</p>;
+  }
+
+  const chartData = {
+    labels: data.map((d) => d.date.slice(-2)),
+    datasets: [
+      {
+        label: '기온(℃)',
+        data: data.map((d) => d.temperature),
+        borderColor: 'rgba(75,192,192,1)',
+        backgroundColor: 'rgba(75,192,192,0.2)',
+        tension: 0.1,
+      },
+    ],
+  };
+
+  return <Line data={chartData} />;
+}
+
+export default MonthlyWeatherChart;

--- a/client/src/pages/Weather.js
+++ b/client/src/pages/Weather.js
@@ -1,0 +1,37 @@
+import { useState } from 'react';
+import MonthlyWeatherChart from '../MonthlyWeatherChart';
+
+function Weather() {
+  const now = new Date();
+  const [year, setYear] = useState(now.getFullYear());
+  const [month, setMonth] = useState(now.getMonth() + 1);
+
+  return (
+    <div className="container">
+      <h2>월별 날씨</h2>
+      <div className="row g-2 mb-3">
+        <div className="col">
+          <input
+            type="number"
+            className="form-control"
+            value={year}
+            onChange={(e) => setYear(e.target.value)}
+          />
+        </div>
+        <div className="col">
+          <input
+            type="number"
+            min="1"
+            max="12"
+            className="form-control"
+            value={month}
+            onChange={(e) => setMonth(e.target.value)}
+          />
+        </div>
+      </div>
+      <MonthlyWeatherChart year={year} month={month} />
+    </div>
+  );
+}
+
+export default Weather;

--- a/routes/api/weatherApi.js
+++ b/routes/api/weatherApi.js
@@ -4,5 +4,6 @@ const ctrl = require('../../controllers/weatherController');
 
 router.get('/daily', ctrl.getDailyWeather);
 router.get('/same-day', ctrl.getSameDay);
+router.get('/monthly', ctrl.getMonthlyWeather);
 
 module.exports = router;

--- a/routes/web/weather.js
+++ b/routes/web/weather.js
@@ -1,9 +1,11 @@
 const express = require('express');
 const router = express.Router();
 const { checkAuth } = require('../../middlewares/auth');
+const path = require('path');
 
 router.get('/', checkAuth, (req, res) => {
-  res.render('weather');
+  const indexPath = path.join(__dirname, '../../client/public', 'index.html');
+  res.sendFile(indexPath);
 });
 
 module.exports = router;

--- a/server.js
+++ b/server.js
@@ -121,6 +121,7 @@ async function initApp() {
     const reactIndex = path.join(__dirname, "client", "public", "index.html");
     res.sendFile(reactIndex);
   });
+  app.use(express.static(path.join(__dirname, "client", "public")));
   app.use(express.static(path.join(__dirname, "public")));
   app.get("/dashboard", checkAuth, (req, res) => {
     const menus = ["/stock", "/list", "/write"];

--- a/tests/weatherApi.test.js
+++ b/tests/weatherApi.test.js
@@ -89,3 +89,10 @@ test('GET /api/weather/same-day returns past years data', async () => {
   expect(mockCollection.project).toHaveBeenCalledWith({ _id: 1 });
   expect(mockCollection.sort).toHaveBeenCalledWith({ _id: -1 });
 });
+
+test('GET /api/weather/monthly returns array of daily data', async () => {
+  const res = await request(app).get('/api/weather/monthly?year=2024&month=06');
+  expect(res.statusCode).toBe(200);
+  expect(Array.isArray(res.body)).toBe(true);
+  expect(res.body.length).toBeGreaterThan(0);
+});


### PR DESCRIPTION
## Summary
- add helper to fetch daily weather data
- create monthly weather API
- serve React index for weather route
- expose weather monthly endpoint
- display monthly weather in React with chart.js

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685fa0fcd32083298af022ff0c7e4c5f