### PR TITLE
Fix missing React imports in weather components

### DIFF
--- a/client/src/MonthlyWeatherChart.js
+++ b/client/src/MonthlyWeatherChart.js
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { Line } from 'react-chartjs-2';
 import {
   Chart as ChartJS,

--- a/client/src/Weather.js
+++ b/client/src/Weather.js
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import React, { useEffect, useState } from 'react';
 
 function Weather() {
   const [weather, setWeather] = useState(null);

--- a/client/src/pages/Weather.js
+++ b/client/src/pages/Weather.js
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import React, { useState } from 'react';
 import MonthlyWeatherChart from '../MonthlyWeatherChart';
 
 function Weather() {


### PR DESCRIPTION
## Summary
- import React in Weather components to satisfy eslint rule

## Testing
- `npm run lint`
- `npm test --silent -- -w 2` *(fails: react-scripts not found)*
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685fa315b9ec832986e234520ac005fe