### PR TITLE
Fix React prop validation and doc install step

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,4 +194,18 @@ Tables can specify the default sort column via `data-order-col` and
 These values are passed to DataTables when initializing so you can control the
 initial ordering without writing extra JavaScript.
 
+## React client
+
+The project includes a React frontend under `client/`. Install its dependencies
+separately before starting the development server:
+
+```bash
+cd client
+npm install
+npm start
+```
+
+The React client relies on `chart.js` and `react-chartjs-2` for visualizations,
+so a successful install is required before `npm start` will compile.
+
 

--- a/client/src/MonthlyWeatherChart.js
+++ b/client/src/MonthlyWeatherChart.js
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from 'react';
+import PropTypes from 'prop-types';
 import { Line } from 'react-chartjs-2';
 import {
   Chart as ChartJS,
@@ -64,3 +65,8 @@ function MonthlyWeatherChart({ year, month }) {
 }
 
 export default MonthlyWeatherChart;
+
+MonthlyWeatherChart.propTypes = {
+  year: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
+  month: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
+};


### PR DESCRIPTION
## Summary
- add prop-type checks for MonthlyWeatherChart
- document installing the React client in README

## Testing
- `npm test` *(fails: jest not found)*
- `npm ci` *(fails: blocked by network)*


------
https://chatgpt.com/codex/tasks/task_e_685fa476d5f483298fcbdeef6d8a6ed5