### PR TITLE
Add average weather endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,9 @@ createProduct({ name: 'Sample' });
 
 The project exposes `/api/weather/daily` which fetches forecast data from the
 Korean Meteorological Administration using `WEATHER_API_KEY`. An accompanying
-`/weather` page displays the information via AJAX.
+`/weather` page displays the information via AJAX. A new endpoint
+`/api/weather/average` calculates the average temperature for a given
+`date` by sampling multiple times throughout the day.
 
 
 Server-side requests use `node-fetch`, which is listed in `package.json`.

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -6,6 +6,7 @@ import Home from './pages/Home';
 import Stock from './pages/Stock';
 import Login from './pages/Login';
 import Weather from './pages/Weather';
+import AverageWeather from './pages/AverageWeather';
 
 function App() {
   return (
@@ -15,6 +16,7 @@ function App() {
         <Route path="/login" element={<Login />} />
         <Route path="/stock" element={<Stock />} />
         <Route path="/weather" element={<Weather />} />
+        <Route path="/weather/average" element={<AverageWeather />} />
       </Routes>
     </BrowserRouter>
   );

--- a/client/src/pages/AverageWeather.js
+++ b/client/src/pages/AverageWeather.js
@@ -1,0 +1,58 @@
+import React, { useState } from 'react';
+
+function AverageWeather() {
+  const [date, setDate] = useState(new Date().toISOString().slice(0, 10));
+  const [data, setData] = useState(null);
+  const [error, setError] = useState(null);
+
+  const fetchData = async () => {
+    try {
+      const res = await fetch(`/api/weather/average?date=${date.replace(/-/g, '')}`);
+      if (!res.ok) throw new Error('Failed');
+      const json = await res.json();
+      setData(json);
+      setError(null);
+    } catch (e) {
+      setError('데이터 없음');
+      setData(null);
+    }
+  };
+
+  return (
+    <div className="container">
+      <h2>일 평균 기온</h2>
+      <div className="row g-2 mb-3">
+        <div className="col">
+          <input
+            type="date"
+            className="form-control"
+            value={date}
+            onChange={(e) => setDate(e.target.value)}
+          />
+        </div>
+        <div className="col-auto">
+          <button className="btn btn-primary" onClick={fetchData}>
+            조회
+          </button>
+        </div>
+      </div>
+      {error && <p>{error}</p>}
+      {data && (
+        <table className="table">
+          <thead>
+            <tr>
+              <th>평균 기온(℃)</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>{data.averageTemperature}</td>
+            </tr>
+          </tbody>
+        </table>
+      )}
+    </div>
+  );
+}
+
+export default AverageWeather;

--- a/routes/api/weatherApi.js
+++ b/routes/api/weatherApi.js
@@ -5,5 +5,6 @@ const ctrl = require('../../controllers/weatherController');
 router.get('/daily', ctrl.getDailyWeather);
 router.get('/same-day', ctrl.getSameDay);
 router.get('/monthly', ctrl.getMonthlyWeather);
+router.get('/average', ctrl.getAverageTemperature);
 
 module.exports = router;

--- a/tests/weatherApi.test.js
+++ b/tests/weatherApi.test.js
@@ -96,3 +96,20 @@ test('GET /api/weather/monthly returns array of daily data', async () => {
   expect(Array.isArray(res.body)).toBe(true);
   expect(res.body.length).toBeGreaterThan(0);
 });
+
+test('GET /api/weather/average returns average temperature', async () => {
+  mockFetch.mockResolvedValue({
+    ok: true,
+    json: async () => ({
+      response: {
+        body: { items: { item: [{ category: 'T1H', fcstValue: '15' }] } },
+      },
+    }),
+  });
+
+  const res = await request(app).get('/api/weather/average?date=20240627');
+
+  expect(res.statusCode).toBe(200);
+  expect(res.body).toEqual({ date: '20240627', averageTemperature: 15 });
+  expect(mockFetch).toHaveBeenCalledTimes(8);
+});


### PR DESCRIPTION
## Summary
- add new `/api/weather/average` endpoint calculating average temperature by sampling multiple times in a day
- document new endpoint in README
- expose new AverageWeather page in React client
- add tests for new route

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685fb16624cc8329970f5cfd77365175