### PR TITLE
Implement React dashboard layout

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -6,6 +6,8 @@ import Home from './pages/Home';
 import Stock from './pages/Stock';
 import Login from './pages/Login';
 import Weather from './pages/Weather';
+import Dashboard from './pages/Dashboard';
+import DashboardLayout from './pages/DashboardLayout';
 
 function App() {
   return (
@@ -13,8 +15,11 @@ function App() {
       <Routes>
         <Route path="/" element={<Home />} />
         <Route path="/login" element={<Login />} />
-        <Route path="/stock" element={<Stock />} />
-        <Route path="/weather" element={<Weather />} />
+        <Route element={<DashboardLayout />}>
+          <Route path="/dashboard" element={<Dashboard />} />
+          <Route path="/stock" element={<Stock />} />
+          <Route path="/weather" element={<Weather />} />
+        </Route>
       </Routes>
     </BrowserRouter>
   );

--- a/client/src/components/Sidebar.css
+++ b/client/src/components/Sidebar.css
@@ -1,0 +1,23 @@
+.sidebar {
+  width: 180px;
+  background: #f8f9fa;
+  padding: 1rem;
+  position: fixed;
+  top: 0;
+  bottom: 0;
+  overflow-y: auto;
+}
+.nav-group {
+  margin-bottom: 1rem;
+}
+.nav-category {
+  font-weight: bold;
+  margin-bottom: 0.25rem;
+}
+.nav-link {
+  text-decoration: none;
+  color: #333;
+}
+.nav-link:hover {
+  text-decoration: underline;
+}

--- a/client/src/components/Sidebar.js
+++ b/client/src/components/Sidebar.js
@@ -1,0 +1,33 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+import './Sidebar.css';
+
+const navData = [
+  { category: '내의미', items: ['게시판', '재고관리', '매출금액', '판매량', '관리자'] },
+  { category: 'TRY', items: ['게시판', '재고관리', '매출금액', '판매량', '입고요청'] },
+  { category: 'BYC', items: ['게시판', '재고관리', '매출금액', '판매량', '입고요청'] },
+  { category: '제임스딘', items: ['게시판', '재고관리', '매출금액', '판매량', '입고요청'] },
+  { category: '쿠팡', items: ['게시판', '재고관리', '매출금액', '판매량', '입고요청'] },
+  { category: '네이버', items: ['게시판', '재고관리', '매출금액', '판매량', '입고요청'] }
+];
+
+function Sidebar() {
+  return (
+    <nav className="sidebar">
+      {navData.map((group) => (
+        <div key={group.category} className="nav-group">
+          <div className="nav-category">{group.category}</div>
+          <ul>
+            {group.items.map((item) => (
+              <li key={item}>
+                <Link to="#" className="nav-link">{item}</Link>
+              </li>
+            ))}
+          </ul>
+        </div>
+      ))}
+    </nav>
+  );
+}
+
+export default Sidebar;

--- a/client/src/pages/Dashboard.js
+++ b/client/src/pages/Dashboard.js
@@ -1,0 +1,12 @@
+import React from 'react';
+
+function Dashboard() {
+  return (
+    <div>
+      <h1>대시보드</h1>
+      <p>환영합니다. 원하는 메뉴를 선택하세요.</p>
+    </div>
+  );
+}
+
+export default Dashboard;

--- a/client/src/pages/DashboardLayout.css
+++ b/client/src/pages/DashboardLayout.css
@@ -1,0 +1,9 @@
+.dashboard-layout {
+  display: flex;
+  min-height: 100vh;
+}
+.dashboard-main {
+  flex: 1;
+  margin-left: 180px;
+  padding: 1rem;
+}

--- a/client/src/pages/DashboardLayout.js
+++ b/client/src/pages/DashboardLayout.js
@@ -1,0 +1,17 @@
+import React from 'react';
+import { Outlet } from 'react-router-dom';
+import Sidebar from '../components/Sidebar';
+import './DashboardLayout.css';
+
+function DashboardLayout() {
+  return (
+    <div className="dashboard-layout">
+      <Sidebar />
+      <main className="dashboard-main">
+        <Outlet />
+      </main>
+    </div>
+  );
+}
+
+export default DashboardLayout;

--- a/routes/web/stock.js
+++ b/routes/web/stock.js
@@ -6,11 +6,9 @@ const stockCtrl = require("../../controllers/stockController");
 // 0. GET /stock (페이지 표시)
 // ───────────────────────────────────────────
 router.get("/", (req, res) => {
-  // stock.ejs를 렌더링
-  res.render("stock", {
-    title: "재고 관리",
-    user: req.user, // 필요 시 전달
-  });
+  const path = require("path");
+  const reactIndex = path.join(__dirname, "..", "..", "client", "public", "index.html");
+  res.sendFile(reactIndex);
 });
 // ───────────────────────────────────────────
 // 2. POST /stock/upload (엑셀 업로드)

--- a/server.js
+++ b/server.js
@@ -124,23 +124,8 @@ async function initApp() {
   app.use(express.static(path.join(__dirname, "client", "public")));
   app.use(express.static(path.join(__dirname, "public")));
   app.get("/dashboard", checkAuth, (req, res) => {
-    const menus = ["/stock", "/list", "/write"];
-    const menuIcons = {
-      "/stock": "📦",
-      "/list": "📋",
-      "/write": "✍️",
-    };
-    const menuLabels = {
-      "/stock": "재고 관리",
-      "/list": "게시글 목록",
-      "/write": "글 작성",
-    };
-    res.render("dashboard.ejs", {
-      menus,
-      menuIcons,
-      menuLabels,
-      banners: res.locals.banners,
-    });
+    const reactIndex = path.join(__dirname, "client", "public", "index.html");
+    res.sendFile(reactIndex);
   });
 
   app.use(errorHandler);


### PR DESCRIPTION
## Summary
- switch `/dashboard` endpoint to serve the React app
- convert `/stock` page to React entry
- add sidebar navigation component
- create dashboard layout and page
- register routes with the new layout

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685fb98077fc8329ac978193087c7df1