### PR TITLE
Add React dashboard navigation and API login

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -20,6 +20,7 @@ function App() {
           <Route path="/stock" element={<Stock />} />
           <Route path="/weather" element={<Weather />} />
         </Route>
+      </Routes>
     </BrowserRouter>
   );
 }

--- a/client/src/components/Header.css
+++ b/client/src/components/Header.css
@@ -1,0 +1,16 @@
+.app-header {
+  background: #fff;
+  padding: 0.5rem 1rem;
+  display: flex;
+  align-items: center;
+  border-bottom: 1px solid #dee2e6;
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 3rem;
+  z-index: 1000;
+}
+.app-header .btn {
+  font-size: 1.25rem;
+}

--- a/client/src/components/Header.js
+++ b/client/src/components/Header.js
@@ -1,0 +1,15 @@
+import React from 'react';
+import './Header.css';
+
+function Header({ onToggleSidebar }) {
+  return (
+    <header className="app-header shadow-sm">
+      <button type="button" className="btn btn-link" onClick={onToggleSidebar}>
+        ☰
+      </button>
+      <span className="ms-2 fw-bold">내의미</span>
+    </header>
+  );
+}
+
+export default Header;

--- a/client/src/components/Sidebar.css
+++ b/client/src/components/Sidebar.css
@@ -3,7 +3,7 @@
   background: #f8f9fa;
   padding: 1rem;
   position: fixed;
-  top: 0;
+  top: 3rem;
   bottom: 0;
   overflow-y: auto;
 }

--- a/client/src/pages/DashboardLayout.css
+++ b/client/src/pages/DashboardLayout.css
@@ -1,9 +1,16 @@
 .dashboard-layout {
   display: flex;
+  flex-direction: column;
   min-height: 100vh;
 }
+
 .dashboard-main {
   flex: 1;
-  margin-left: 180px;
   padding: 1rem;
+  padding-top: 4rem;
+  transition: margin-left 0.3s ease;
+}
+
+.dashboard-main.with-sidebar {
+  margin-left: 180px;
 }

--- a/client/src/pages/DashboardLayout.js
+++ b/client/src/pages/DashboardLayout.js
@@ -1,13 +1,21 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { Outlet } from 'react-router-dom';
 import Sidebar from '../components/Sidebar';
+import Header from '../components/Header';
 import './DashboardLayout.css';
 
 function DashboardLayout() {
+  const [showSidebar, setShowSidebar] = useState(false);
+
+  const handleToggle = () => {
+    setShowSidebar((prev) => !prev);
+  };
+
   return (
     <div className="dashboard-layout">
-      <Sidebar />
-      <main className="dashboard-main">
+      <Header onToggleSidebar={handleToggle} />
+      {showSidebar && <Sidebar />}
+      <main className={`dashboard-main ${showSidebar ? 'with-sidebar' : ''}`}>
         <Outlet />
       </main>
     </div>

--- a/client/src/pages/Login.js
+++ b/client/src/pages/Login.js
@@ -1,4 +1,5 @@
-import React from 'react';
+import React, { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 import './Login.css';
 
 /**
@@ -7,12 +8,42 @@ import './Login.css';
  */
 
 function Login() {
+  const navigate = useNavigate();
+  const [form, setForm] = useState({ username: '', password: '' });
+  const [error, setError] = useState('');
+
+  const handleChange = (e) => {
+    const { name, value } = e.target;
+    setForm((prev) => ({ ...prev, [name]: value }));
+  };
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    setError('');
+    try {
+      const res = await fetch('/api/auth/login', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(form),
+      });
+      const data = await res.json();
+      if (data.success) {
+        navigate('/dashboard');
+      } else {
+        setError(data.message || '로그인 실패');
+      }
+    } catch (err) {
+      setError('서버 오류');
+    }
+  };
+
   return (
     <div className="login-container">
       <div className="card shadow-sm login-card">
         <div className="card-body">
           <h5 className="card-title mb-4 text-center">로그인</h5>
-          <form action="/login" method="POST">
+          {error && <div className="alert alert-danger">{error}</div>}
+          <form onSubmit={handleSubmit}>
             <div className="mb-3">
               <label htmlFor="username" className="form-label">
                 아이디
@@ -22,6 +53,8 @@ function Login() {
                 name="username"
                 id="username"
                 className="form-control"
+                value={form.username}
+                onChange={handleChange}
                 required
               />
             </div>
@@ -34,6 +67,8 @@ function Login() {
                 name="password"
                 id="password"
                 className="form-control"
+                value={form.password}
+                onChange={handleChange}
                 required
               />
             </div>

--- a/controllers/apiAuthController.js
+++ b/controllers/apiAuthController.js
@@ -1,0 +1,38 @@
+const bcrypt = require('bcrypt');
+
+exports.login = async (req, res, next) => {
+  const db = req.app.locals.db;
+  const { username, password } = req.body;
+  try {
+    const user = await db
+      .collection('user')
+      .findOne({ username: new RegExp(`^${username}$`, 'i') });
+
+    if (!user) {
+      return res.status(401).json({ success: false, message: '아이디 없음' });
+    }
+
+    const match = await bcrypt.compare(password, user.password);
+    if (!match) {
+      return res.status(401).json({ success: false, message: '비밀번호 불일치' });
+    }
+
+    req.login(user, (err) => {
+      if (err) return next(err);
+      const { password: _pw, ...safeUser } = user;
+      return res.json({ success: true, user: safeUser });
+    });
+  } catch (err) {
+    next(err);
+  }
+};
+
+exports.logout = (req, res) => {
+  req.logout(() => res.json({ success: true }));
+};
+
+exports.getUser = (req, res) => {
+  if (!req.user) return res.status(401).json({ user: null });
+  const { password, ...safeUser } = req.user;
+  res.json({ user: safeUser });
+};

--- a/routes/api/authApi.js
+++ b/routes/api/authApi.js
@@ -1,0 +1,9 @@
+const express = require('express');
+const router = express.Router();
+const controller = require('../../controllers/apiAuthController');
+
+router.post('/login', controller.login);
+router.post('/logout', controller.logout);
+router.get('/user', controller.getUser);
+
+module.exports = router;

--- a/routes/api/index.js
+++ b/routes/api/index.js
@@ -8,6 +8,9 @@
 const express = require("express");
 const router = express.Router();
 
+// 인증 API
+router.use('/auth', require('./authApi'));
+
 // 재고(Stock) API
 router.use("/stock", require("./stockApi"));
 // 쿠팡 재고 API


### PR DESCRIPTION
## Summary
- implement API-based login endpoints
- create React header and toggleable sidebar
- update dashboard layout to use header toggle
- use fetch login in React client

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685fbec07c38832993890fc5530bc82a