### PR TITLE
Store weather data in DB

### DIFF
--- a/controllers/weatherController.js
+++ b/controllers/weatherController.js
@@ -44,6 +44,18 @@ const getDailyWeather = asyncHandler(async (req, res) => {
   const ny = req.query.ny || '127';
 
   const data = await fetchDaily(baseDate, baseTime, nx, ny);
+
+  try {
+    const db = req.app.locals.db;
+    await db.collection('weather').updateOne(
+      { _id: baseDate },
+      { $set: { ...data, updatedAt: new Date() } },
+      { upsert: true },
+    );
+  } catch (err) {
+    console.error('❌ Weather DB update failed:', err.message);
+  }
+
   res.json(data);
 });
 
@@ -141,6 +153,7 @@ const getAverageTemperature = asyncHandler(async (req, res) => {
 });
 
 module.exports = {
+  fetchDaily,
   getDailyWeather,
   getSameDay,
   getMonthlyWeather,


### PR DESCRIPTION
## Summary
- store daily weather data in MongoDB when API is called
- export `fetchDaily` helper
- save today's weather via cron job

## Testing
- `npm test` *(fails: jest not found)*
- `npm install` *(fails: network access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_685fc01757088329b60d39ca3e67fdf4