### PR TITLE
Switch login route to React

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,4 +216,9 @@ so start React on a different port to avoid conflicts:
 PORT=3001 npm start
 ```
 
+The login page was migrated from an EJS template to a React component. The
+client authenticates by sending credentials to the Express endpoint
+`/api/auth/login`. In production the server serves `client/public/index.html` for
+`/login`, so navigating directly to `/login` loads the React app.
+
 

--- a/controllers/authController.js
+++ b/controllers/authController.js
@@ -1,8 +1,10 @@
+const path = require('path');
 const bcrypt = require('bcrypt');
 const passport = require('passport');
 
 exports.renderLoginPage = (req, res) => {
-  res.render('login');
+  const reactIndex = path.join(__dirname, '..', 'client', 'public', 'index.html');
+  res.sendFile(reactIndex);
 };
 
 exports.login = async (req, res, next) => {


### PR DESCRIPTION
## Summary
- serve React app for `/login`
- document API-based login

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685fc16128988329ba609fc38611fdbb