### PR TITLE
Convert signup to SPA workflow

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -5,6 +5,7 @@ import { BrowserRouter, Routes, Route } from 'react-router-dom';
 import Home from './pages/Home';
 import Stock from './pages/Stock';
 import Login from './pages/Login';
+import Register from './pages/Register';
 import Weather from './pages/Weather';
 import Dashboard from './pages/Dashboard';
 import DashboardLayout from './pages/DashboardLayout';
@@ -15,6 +16,7 @@ function App() {
       <Routes>
         <Route path="/" element={<Home />} />
         <Route path="/login" element={<Login />} />
+        <Route path="/register" element={<Register />} />
         <Route element={<DashboardLayout />}>
           <Route path="/dashboard" element={<Dashboard />} />
           <Route path="/stock" element={<Stock />} />

--- a/client/src/pages/Register.css
+++ b/client/src/pages/Register.css
@@ -1,0 +1,12 @@
+.register-container {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  min-height: 100vh;
+  background-color: #f8f9fa;
+}
+
+.register-card {
+  width: 100%;
+  max-width: 500px;
+}

--- a/client/src/pages/Register.js
+++ b/client/src/pages/Register.js
@@ -1,0 +1,132 @@
+import React, { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import './Register.css';
+
+function Register() {
+  const navigate = useNavigate();
+  const [form, setForm] = useState({
+    username: '',
+    name: '',
+    email: '',
+    password: '',
+    password2: '',
+  });
+  const [error, setError] = useState('');
+  const [success, setSuccess] = useState('');
+
+  const handleChange = (e) => {
+    const { name, value } = e.target;
+    setForm((prev) => ({ ...prev, [name]: value }));
+  };
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    setError('');
+    setSuccess('');
+    try {
+      const res = await fetch('/api/auth/register', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(form),
+      });
+      const data = await res.json();
+      if (data.success) {
+        setSuccess('회원가입이 완료되었습니다.');
+        setTimeout(() => navigate('/login'), 1000);
+      } else {
+        setError(data.message || '회원가입 실패');
+      }
+    } catch (err) {
+      setError('서버 오류');
+    }
+  };
+
+  return (
+    <div className="register-container">
+      <div className="card shadow-sm register-card">
+        <div className="card-body">
+          <h5 className="card-title mb-4 text-center">회원가입</h5>
+          {error && <div className="alert alert-danger">{error}</div>}
+          {success && <div className="alert alert-success">{success}</div>}
+          <form onSubmit={handleSubmit}>
+            <div className="mb-3">
+              <label htmlFor="username" className="form-label">
+                아이디
+              </label>
+              <input
+                type="text"
+                className="form-control"
+                id="username"
+                name="username"
+                value={form.username}
+                onChange={handleChange}
+                required
+              />
+            </div>
+            <div className="mb-3">
+              <label htmlFor="name" className="form-label">
+                이름
+              </label>
+              <input
+                type="text"
+                className="form-control"
+                id="name"
+                name="name"
+                value={form.name}
+                onChange={handleChange}
+                required
+              />
+            </div>
+            <div className="mb-3">
+              <label htmlFor="email" className="form-label">
+                이메일
+              </label>
+              <input
+                type="email"
+                className="form-control"
+                id="email"
+                name="email"
+                value={form.email}
+                onChange={handleChange}
+                required
+              />
+            </div>
+            <div className="mb-3">
+              <label htmlFor="password" className="form-label">
+                비밀번호
+              </label>
+              <input
+                type="password"
+                className="form-control"
+                id="password"
+                name="password"
+                value={form.password}
+                onChange={handleChange}
+                required
+              />
+            </div>
+            <div className="mb-4">
+              <label htmlFor="password2" className="form-label">
+                비밀번호 확인
+              </label>
+              <input
+                type="password"
+                className="form-control"
+                id="password2"
+                name="password2"
+                value={form.password2}
+                onChange={handleChange}
+                required
+              />
+            </div>
+            <button type="submit" className="btn btn-primary w-100">
+              가입하기
+            </button>
+          </form>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default Register;

--- a/controllers/authController.js
+++ b/controllers/authController.js
@@ -40,7 +40,8 @@ exports.logout = (req, res) => {
 };
 
 exports.renderRegisterPage = (req, res) => {
-  res.render('register');
+  const reactIndex = path.join(__dirname, '..', 'client', 'public', 'index.html');
+  res.sendFile(reactIndex);
 };
 
 exports.register = async (req, res) => {

--- a/routes/api/authApi.js
+++ b/routes/api/authApi.js
@@ -3,6 +3,7 @@ const router = express.Router();
 const controller = require('../../controllers/apiAuthController');
 
 router.post('/login', controller.login);
+router.post('/register', controller.register);
 router.post('/logout', controller.logout);
 router.get('/user', controller.getUser);
 


### PR DESCRIPTION
## Summary
- serve React app for `/register`
- add register endpoint to auth API
- expose controller logic for registration via JSON
- add Register page and route in React app

## Testing
- `npm run lint`
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685fc300e0f88329895819087da3ade3