### PR TITLE
Fix login page test

### DIFF
--- a/client/src/pages/Login.test.js
+++ b/client/src/pages/Login.test.js
@@ -1,8 +1,13 @@
 import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
 import Login from './Login';
 
 test('renders login form', () => {
-  render(<Login />);
+  render(
+    <MemoryRouter>
+      <Login />
+    </MemoryRouter>
+  );
   expect(screen.getByRole('heading', { name: '로그인' })).toBeInTheDocument();
   expect(screen.getByLabelText('아이디')).toBeInTheDocument();
   expect(screen.getByLabelText('비밀번호')).toBeInTheDocument();


### PR DESCRIPTION
## Summary
- wrap Login in a router context for tests

## Testing
- `npm ci --prefix client` *(fails: registry access blocked)*
- `npm test --silent --prefix client` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_685fc38c5818832995917b4c59712996