### PR TITLE
Add credentialed fetch and user nav

### DIFF
--- a/client/src/MonthlyWeatherChart.js
+++ b/client/src/MonthlyWeatherChart.js
@@ -29,7 +29,9 @@ function MonthlyWeatherChart({ year, month }) {
   useEffect(() => {
     async function fetchData() {
       try {
-        const res = await fetch(`/api/weather/monthly?year=${year}&month=${month}`);
+        const res = await fetch(`/api/weather/monthly?year=${year}&month=${month}`, {
+          credentials: 'include',
+        });
         if (!res.ok) throw new Error('Failed to fetch');
         const json = await res.json();
         setData(json.filter((d) => !d.error));

--- a/client/src/Weather.js
+++ b/client/src/Weather.js
@@ -7,7 +7,7 @@ function Weather() {
   useEffect(() => {
     async function fetchWeather() {
       try {
-        const res = await fetch('/api/weather/daily');
+        const res = await fetch('/api/weather/daily', { credentials: 'include' });
         if (!res.ok) {
           throw new Error('Failed to fetch');
         }

--- a/client/src/components/Header.css
+++ b/client/src/components/Header.css
@@ -14,3 +14,9 @@
 .app-header .btn {
   font-size: 1.25rem;
 }
+
+.user-info {
+  margin-left: auto;
+  display: flex;
+  align-items: center;
+}

--- a/client/src/components/Header.js
+++ b/client/src/components/Header.js
@@ -1,13 +1,35 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import './Header.css';
 
 function Header({ onToggleSidebar }) {
+  const [user, setUser] = useState(null);
+
+  useEffect(() => {
+    fetch('/api/auth/user', { credentials: 'include' })
+      .then((res) => res.json())
+      .then((data) => {
+        setUser(data.user);
+      })
+      .catch(() => {});
+  }, []);
+
+  const handleLogout = async () => {
+    await fetch('/api/auth/logout', { method: 'POST', credentials: 'include' });
+    window.location.href = '/login';
+  };
+
   return (
     <header className="app-header shadow-sm">
       <button type="button" className="btn btn-link" onClick={onToggleSidebar}>
         ☰
       </button>
       <span className="ms-2 fw-bold">내의미</span>
+      <div className="user-info ms-auto">
+        {user && <span className="me-3">{user.name || user.username}</span>}
+        <button type="button" className="btn btn-link" onClick={handleLogout}>
+          로그아웃
+        </button>
+      </div>
     </header>
   );
 }

--- a/client/src/pages/AverageTemp.js
+++ b/client/src/pages/AverageTemp.js
@@ -12,7 +12,8 @@ function AverageTemp() {
     try {
       const [year, month, day] = date.split('-');
       const res = await fetch(
-        `/api/weather/average?year=${year}&month=${month}&day=${day}`
+        `/api/weather/average?year=${year}&month=${month}&day=${day}`,
+        { credentials: 'include' }
       );
       if (!res.ok) throw new Error('Failed to fetch');
       const data = await res.json();

--- a/client/src/pages/Login.js
+++ b/client/src/pages/Login.js
@@ -24,6 +24,7 @@ function Login() {
       const res = await fetch('/api/auth/login', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
+        credentials: 'include',
         body: JSON.stringify(form),
       });
       const data = await res.json();

--- a/client/src/pages/Register.js
+++ b/client/src/pages/Register.js
@@ -27,6 +27,7 @@ function Register() {
       const res = await fetch('/api/auth/register', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
+        credentials: 'include',
         body: JSON.stringify(form),
       });
       const data = await res.json();

--- a/client/src/pages/Stock.js
+++ b/client/src/pages/Stock.js
@@ -12,7 +12,9 @@ function Stock() {
       color: form.color,
       size: form.size,
     });
-    const res = await fetch(`/api/stock?${params.toString()}`);
+    const res = await fetch(`/api/stock?${params.toString()}`, {
+      credentials: 'include',
+    });
     if (res.ok) {
       const data = await res.json();
       setRows(data.data || []);


### PR DESCRIPTION
## Summary
- show logged-in user info in header and add logout
- include credentials on API fetches for auth/session

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685fcf9d5a188329b593c00430a460fe