### PR TITLE
Implement collapsible sidebar and dashboard link

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -9,6 +9,11 @@ import Register from './pages/Register';
 import Weather from './pages/Weather';
 import Dashboard from './pages/Dashboard';
 import DashboardLayout from './pages/DashboardLayout';
+import Board from './pages/Board';
+import SalesAmount from './pages/SalesAmount';
+import SalesVolume from './pages/SalesVolume';
+import Admin from './pages/Admin';
+import Placeholder from './pages/Placeholder';
 
 function App() {
   return (
@@ -19,8 +24,13 @@ function App() {
         <Route path="/register" element={<Register />} />
         <Route element={<DashboardLayout />}>
           <Route path="/dashboard" element={<Dashboard />} />
+          <Route path="/board" element={<Board />} />
+          <Route path="/sales-amount" element={<SalesAmount />} />
+          <Route path="/sales-volume" element={<SalesVolume />} />
+          <Route path="/admin" element={<Admin />} />
           <Route path="/stock" element={<Stock />} />
           <Route path="/weather" element={<Weather />} />
+          <Route path="/:shop/:section" element={<Placeholder />} />
         </Route>
       </Routes>
     </BrowserRouter>

--- a/client/src/components/Header.css
+++ b/client/src/components/Header.css
@@ -11,8 +11,15 @@
   height: 3rem;
   z-index: 1000;
 }
-.app-header .btn {
+.app-header .menu-btn {
   font-size: 1.25rem;
+  border: none;
+  background: transparent;
+}
+
+.brand-link {
+  text-decoration: none;
+  color: #333;
 }
 
 .user-info {

--- a/client/src/components/Header.js
+++ b/client/src/components/Header.js
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from 'react';
+import { Link } from 'react-router-dom';
 import './Header.css';
 
 function Header({ onToggleSidebar }) {
@@ -20,10 +21,12 @@ function Header({ onToggleSidebar }) {
 
   return (
     <header className="app-header shadow-sm">
-      <button type="button" className="btn btn-link" onClick={onToggleSidebar}>
+      <button type="button" className="btn menu-btn" onClick={onToggleSidebar}>
         ☰
       </button>
-      <span className="ms-2 fw-bold">내의미</span>
+      <Link to="/dashboard" className="ms-2 fw-bold brand-link">
+        내의미
+      </Link>
       <div className="user-info ms-auto">
         {user && <span className="me-3">{user.name || user.username}</span>}
         <button type="button" className="btn btn-link" onClick={handleLogout}>

--- a/client/src/components/Sidebar.css
+++ b/client/src/components/Sidebar.css
@@ -13,6 +13,15 @@
 .nav-category {
   font-weight: bold;
   margin-bottom: 0.25rem;
+  cursor: pointer;
+}
+.nav-group ul {
+  list-style: none;
+  padding-left: 0;
+}
+
+.nav-group li {
+  margin: 0.25rem 0;
 }
 .nav-link {
   text-decoration: none;

--- a/client/src/components/Sidebar.js
+++ b/client/src/components/Sidebar.js
@@ -1,29 +1,98 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { Link } from 'react-router-dom';
 import './Sidebar.css';
 
 const navData = [
-  { category: '내의미', items: ['게시판', '재고관리', '매출금액', '판매량', '관리자'] },
-  { category: 'TRY', items: ['게시판', '재고관리', '매출금액', '판매량', '입고요청'] },
-  { category: 'BYC', items: ['게시판', '재고관리', '매출금액', '판매량', '입고요청'] },
-  { category: '제임스딘', items: ['게시판', '재고관리', '매출금액', '판매량', '입고요청'] },
-  { category: '쿠팡', items: ['게시판', '재고관리', '매출금액', '판매량', '입고요청'] },
-  { category: '네이버', items: ['게시판', '재고관리', '매출금액', '판매량', '입고요청'] }
+  {
+    category: '내의미',
+    items: [
+      { label: '게시판', path: '/board' },
+      { label: '재고관리', path: '/stock' },
+      { label: '매출금액', path: '/sales-amount' },
+      { label: '판매량', path: '/sales-volume' },
+      { label: '관리자', path: '/admin' }
+    ]
+  },
+  {
+    category: 'TRY',
+    items: [
+      { label: '게시판', path: '/try/board' },
+      { label: '재고관리', path: '/try/stock' },
+      { label: '매출금액', path: '/try/sales-amount' },
+      { label: '판매량', path: '/try/sales-volume' },
+      { label: '입고요청', path: '/try/inbound-request' }
+    ]
+  },
+  {
+    category: 'BYC',
+    items: [
+      { label: '게시판', path: '/byc/board' },
+      { label: '재고관리', path: '/byc/stock' },
+      { label: '매출금액', path: '/byc/sales-amount' },
+      { label: '판매량', path: '/byc/sales-volume' },
+      { label: '입고요청', path: '/byc/inbound-request' }
+    ]
+  },
+  {
+    category: '제임스딘',
+    items: [
+      { label: '게시판', path: '/james-dean/board' },
+      { label: '재고관리', path: '/james-dean/stock' },
+      { label: '매출금액', path: '/james-dean/sales-amount' },
+      { label: '판매량', path: '/james-dean/sales-volume' },
+      { label: '입고요청', path: '/james-dean/inbound-request' }
+    ]
+  },
+  {
+    category: '쿠팡',
+    items: [
+      { label: '게시판', path: '/coupang/board' },
+      { label: '재고관리', path: '/coupang/stock' },
+      { label: '매출금액', path: '/coupang/sales-amount' },
+      { label: '판매량', path: '/coupang/sales-volume' },
+      { label: '입고요청', path: '/coupang/inbound-request' }
+    ]
+  },
+  {
+    category: '네이버',
+    items: [
+      { label: '게시판', path: '/naver/board' },
+      { label: '재고관리', path: '/naver/stock' },
+      { label: '매출금액', path: '/naver/sales-amount' },
+      { label: '판매량', path: '/naver/sales-volume' },
+      { label: '입고요청', path: '/naver/inbound-request' }
+    ]
+  }
 ];
 
 function Sidebar() {
+  const [openCategory, setOpenCategory] = useState(null);
+
+  const handleToggle = (category) => {
+    setOpenCategory((prev) => (prev === category ? null : category));
+  };
+
   return (
     <nav className="sidebar">
       {navData.map((group) => (
         <div key={group.category} className="nav-group">
-          <div className="nav-category">{group.category}</div>
-          <ul>
-            {group.items.map((item) => (
-              <li key={item}>
-                <Link to="#" className="nav-link">{item}</Link>
-              </li>
-            ))}
-          </ul>
+          <div
+            className="nav-category"
+            onClick={() => handleToggle(group.category)}
+          >
+            {group.category}
+          </div>
+          {openCategory === group.category && (
+            <ul>
+              {group.items.map((item) => (
+                <li key={item.label}>
+                  <Link to={item.path} className="nav-link">
+                    {item.label}
+                  </Link>
+                </li>
+              ))}
+            </ul>
+          )}
         </div>
       ))}
     </nav>

--- a/client/src/pages/Admin.js
+++ b/client/src/pages/Admin.js
@@ -1,0 +1,12 @@
+import React from 'react';
+
+function Admin() {
+  return (
+    <div>
+      <h2>관리자</h2>
+      <p>콘텐츠를 준비 중입니다.</p>
+    </div>
+  );
+}
+
+export default Admin;

--- a/client/src/pages/Board.js
+++ b/client/src/pages/Board.js
@@ -1,0 +1,12 @@
+import React from 'react';
+
+function Board() {
+  return (
+    <div>
+      <h2>게시판</h2>
+      <p>콘텐츠를 준비 중입니다.</p>
+    </div>
+  );
+}
+
+export default Board;

--- a/client/src/pages/Placeholder.js
+++ b/client/src/pages/Placeholder.js
@@ -1,0 +1,14 @@
+import React from 'react';
+import { useLocation } from 'react-router-dom';
+
+function Placeholder() {
+  const location = useLocation();
+  return (
+    <div>
+      <h2>{location.pathname}</h2>
+      <p>준비 중인 페이지입니다.</p>
+    </div>
+  );
+}
+
+export default Placeholder;

--- a/client/src/pages/SalesAmount.js
+++ b/client/src/pages/SalesAmount.js
@@ -1,0 +1,12 @@
+import React from 'react';
+
+function SalesAmount() {
+  return (
+    <div>
+      <h2>매출금액</h2>
+      <p>콘텐츠를 준비 중입니다.</p>
+    </div>
+  );
+}
+
+export default SalesAmount;

--- a/client/src/pages/SalesVolume.js
+++ b/client/src/pages/SalesVolume.js
@@ -1,0 +1,12 @@
+import React from 'react';
+
+function SalesVolume() {
+  return (
+    <div>
+      <h2>판매량</h2>
+      <p>콘텐츠를 준비 중입니다.</p>
+    </div>
+  );
+}
+
+export default SalesVolume;


### PR DESCRIPTION
## Summary
- simplify header design and link brand to dashboard
- update sidebar to show sub items only after clicking each header
- add placeholder pages and routes for future sections

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685fd2e467148329a050542ea03abc84