### PR TITLE
Enable React Weather Page

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -7,6 +7,7 @@ import Stock from './pages/Stock';
 import Login from './pages/Login';
 import Register from './pages/Register';
 import Weather from './pages/Weather';
+import MonthlyWeather from './pages/MonthlyWeather';
 import Dashboard from './pages/Dashboard';
 import DashboardLayout from './pages/DashboardLayout';
 
@@ -21,6 +22,7 @@ function App() {
           <Route path="/dashboard" element={<Dashboard />} />
           <Route path="/stock" element={<Stock />} />
           <Route path="/weather" element={<Weather />} />
+          <Route path="/weather/monthly" element={<MonthlyWeather />} />
         </Route>
       </Routes>
     </BrowserRouter>

--- a/client/src/pages/MonthlyWeather.js
+++ b/client/src/pages/MonthlyWeather.js
@@ -1,0 +1,37 @@
+import React, { useState } from 'react';
+import MonthlyWeatherChart from '../MonthlyWeatherChart';
+
+function MonthlyWeather() {
+  const now = new Date();
+  const [year, setYear] = useState(now.getFullYear());
+  const [month, setMonth] = useState(now.getMonth() + 1);
+
+  return (
+    <div className="container">
+      <h2>월별 날씨</h2>
+      <div className="row g-2 mb-3">
+        <div className="col">
+          <input
+            type="number"
+            className="form-control"
+            value={year}
+            onChange={(e) => setYear(e.target.value)}
+          />
+        </div>
+        <div className="col">
+          <input
+            type="number"
+            min="1"
+            max="12"
+            className="form-control"
+            value={month}
+            onChange={(e) => setMonth(e.target.value)}
+          />
+        </div>
+      </div>
+      <MonthlyWeatherChart year={year} month={month} />
+    </div>
+  );
+}
+
+export default MonthlyWeather;

--- a/client/src/pages/Weather.js
+++ b/client/src/pages/Weather.js
@@ -1,35 +1,11 @@
-import React, { useState } from 'react';
-import MonthlyWeatherChart from '../MonthlyWeatherChart';
+import React from 'react';
+import WeatherTable from '../Weather';
 
 function Weather() {
-  const now = new Date();
-  const [year, setYear] = useState(now.getFullYear());
-  const [month, setMonth] = useState(now.getMonth() + 1);
-
   return (
-    <div className="container">
-      <h2>월별 날씨</h2>
-      <div className="row g-2 mb-3">
-        <div className="col">
-          <input
-            type="number"
-            className="form-control"
-            value={year}
-            onChange={(e) => setYear(e.target.value)}
-          />
-        </div>
-        <div className="col">
-          <input
-            type="number"
-            min="1"
-            max="12"
-            className="form-control"
-            value={month}
-            onChange={(e) => setMonth(e.target.value)}
-          />
-        </div>
-      </div>
-      <MonthlyWeatherChart year={year} month={month} />
+    <div className="container my-4">
+      <h2 className="mb-3">🌤️ 오늘 날씨</h2>
+      <WeatherTable />
     </div>
   );
 }

--- a/routes/web/weather.js
+++ b/routes/web/weather.js
@@ -2,9 +2,12 @@ const express = require('express');
 const router = express.Router();
 const { checkAuth } = require('../../middlewares/auth');
 const path = require('path');
+const fs = require('fs');
 
 router.get('/*', checkAuth, (req, res) => {
-  const indexPath = path.join(__dirname, '../../client/public', 'index.html');
+  const buildPath = path.join(__dirname, '../../client/build', 'index.html');
+  const publicPath = path.join(__dirname, '../../client/public', 'index.html');
+  const indexPath = fs.existsSync(buildPath) ? buildPath : publicPath;
   res.sendFile(indexPath);
 });
 

--- a/server.js
+++ b/server.js
@@ -9,6 +9,7 @@ const morgan = require("morgan");
 const helmet = require("helmet");
 const compression = require("compression");
 const flash = require("connect-flash");
+const fs = require("fs");
 const { connectDB } = require("./config/db");
 const { initIndexes } = require("./config/initIndexes");
 const webRouter = require("./routes/web");
@@ -117,14 +118,18 @@ async function initApp() {
   }
 
   // 기본 경로에서 React 정적 페이지 제공
+  const reactRoot = fs.existsSync(path.join(__dirname, 'client', 'build'))
+    ? path.join(__dirname, 'client', 'build')
+    : path.join(__dirname, 'client', 'public');
+
   app.get("/", (req, res) => {
-    const reactIndex = path.join(__dirname, "client", "public", "index.html");
+    const reactIndex = path.join(reactRoot, "index.html");
     res.sendFile(reactIndex);
   });
-  app.use(express.static(path.join(__dirname, "client", "public")));
+  app.use(express.static(reactRoot));
   app.use(express.static(path.join(__dirname, "public")));
   app.get("/dashboard", checkAuth, (req, res) => {
-    const reactIndex = path.join(__dirname, "client", "public", "index.html");
+    const reactIndex = path.join(reactRoot, "index.html");
     res.sendFile(reactIndex);
   });
 


### PR DESCRIPTION
## Summary
- move monthly weather chart page and add new daily weather page
- mount both Weather pages in React router
- serve React index from `client/build` when available
- update weather route to handle build path

## Testing
- `npm install` *(fails: network access blocked)*
- `npm test` *(fails: jest not found due to failed install)*

------
https://chatgpt.com/codex/tasks/task_e_685fd4d9bc148329b7d2c1426efde53d