### PR TITLE
Migrate admin routes to React

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -15,6 +15,10 @@ import Board from './pages/Board';
 import SalesAmount from './pages/SalesAmount';
 import SalesVolume from './pages/SalesVolume';
 import Admin from './pages/Admin';
+import AdminBanner from './pages/admin/Banner';
+import AdminLogo from './pages/admin/Logo';
+import AdminUsers from './pages/admin/Users';
+import AdminPermissions from './pages/admin/Permissions';
 import Placeholder from './pages/Placeholder';
 
 function App() {
@@ -30,6 +34,10 @@ function App() {
           <Route path="/sales-amount" element={<SalesAmount />} />
           <Route path="/sales-volume" element={<SalesVolume />} />
           <Route path="/admin" element={<Admin />} />
+          <Route path="/admin/banner" element={<AdminBanner />} />
+          <Route path="/admin/logo" element={<AdminLogo />} />
+          <Route path="/admin/users" element={<AdminUsers />} />
+          <Route path="/admin/permissions" element={<AdminPermissions />} />
           <Route path="/stock" element={<Stock />} />
           <Route path="/coupang" element={<Coupang />} />
           <Route path="/coupang-add" element={<CoupangAdd />} />

--- a/client/src/pages/Admin.css
+++ b/client/src/pages/Admin.css
@@ -1,0 +1,9 @@
+.admin-page {
+  padding: 1rem;
+}
+
+.admin-menu {
+  max-width: 400px;
+  margin: 0;
+  padding: 0;
+}

--- a/client/src/pages/Admin.js
+++ b/client/src/pages/Admin.js
@@ -1,10 +1,25 @@
 import React from 'react';
+import { Link } from 'react-router-dom';
+import './Admin.css';
 
 function Admin() {
   return (
-    <div>
-      <h2>관리자</h2>
-      <p>콘텐츠를 준비 중입니다.</p>
+    <div className="admin-page">
+      <h1 className="mb-3">관리자 메뉴</h1>
+      <ul className="admin-menu list-group">
+        <li className="list-group-item">
+          <Link to="/admin/users">사용자 관리</Link>
+        </li>
+        <li className="list-group-item">
+          <Link to="/admin/permissions">접근 권한 설정</Link>
+        </li>
+        <li className="list-group-item">
+          <Link to="/admin/banner">배너 이미지 관리</Link>
+        </li>
+        <li className="list-group-item">
+          <Link to="/admin/logo">브랜드 로고 관리</Link>
+        </li>
+      </ul>
     </div>
   );
 }

--- a/client/src/pages/admin/Banner.js
+++ b/client/src/pages/admin/Banner.js
@@ -1,0 +1,12 @@
+import React from 'react';
+
+function Banner() {
+  return (
+    <div>
+      <h2>배너 이미지 관리</h2>
+      <p>React 기반의 배너 관리 페이지입니다.</p>
+    </div>
+  );
+}
+
+export default Banner;

--- a/client/src/pages/admin/Logo.js
+++ b/client/src/pages/admin/Logo.js
@@ -1,0 +1,12 @@
+import React from 'react';
+
+function Logo() {
+  return (
+    <div>
+      <h2>브랜드 로고 관리</h2>
+      <p>React 기반의 로고 관리 페이지입니다.</p>
+    </div>
+  );
+}
+
+export default Logo;

--- a/client/src/pages/admin/Permissions.js
+++ b/client/src/pages/admin/Permissions.js
@@ -1,0 +1,12 @@
+import React from 'react';
+
+function Permissions() {
+  return (
+    <div>
+      <h2>접근 권한 설정</h2>
+      <p>React 기반의 권한 설정 페이지입니다.</p>
+    </div>
+  );
+}
+
+export default Permissions;

--- a/client/src/pages/admin/Users.js
+++ b/client/src/pages/admin/Users.js
@@ -1,0 +1,12 @@
+import React from 'react';
+
+function Users() {
+  return (
+    <div>
+      <h2>사용자 관리</h2>
+      <p>React 기반의 사용자 관리 페이지입니다.</p>
+    </div>
+  );
+}
+
+export default Users;


### PR DESCRIPTION
## Summary
- convert placeholder Admin page to show links
- add basic pages for banner, logo, users and permissions
- wire new admin subroutes in React app

## Testing
- `npm test` *(fails: jest not found)*
- `npm --prefix client test -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_685fd6c263548329946300002243774c