### PR TITLE
Add React board API and UI

### DIFF
--- a/client/src/pages/Board.js
+++ b/client/src/pages/Board.js
@@ -1,10 +1,123 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 
 function Board() {
+  const [posts, setPosts] = useState([]);
+  const [form, setForm] = useState({ title: '', content: '' });
+  const [editingId, setEditingId] = useState(null);
+
+  const loadPosts = async () => {
+    const res = await fetch('/api/posts', { credentials: 'include' });
+    if (res.ok) {
+      const data = await res.json();
+      setPosts(data.data || []);
+    }
+  };
+
+  useEffect(() => {
+    loadPosts();
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+
+  const onChange = (e) => {
+    setForm({ ...form, [e.target.name]: e.target.value });
+  };
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    const method = editingId ? 'PUT' : 'POST';
+    const url = editingId ? `/api/posts/${editingId}` : '/api/posts';
+    await fetch(url, {
+      method,
+      headers: { 'Content-Type': 'application/json' },
+      credentials: 'include',
+      body: JSON.stringify(form),
+    });
+    setForm({ title: '', content: '' });
+    setEditingId(null);
+    loadPosts();
+  };
+
+  const startEdit = (post) => {
+    setEditingId(post._id);
+    setForm({ title: post.title, content: post.content });
+  };
+
+  const handleDelete = async (id) => {
+    if (!window.confirm('삭제하시겠습니까?')) return;
+    await fetch(`/api/posts/${id}`, { method: 'DELETE', credentials: 'include' });
+    loadPosts();
+  };
+
+  const cancelEdit = () => {
+    setEditingId(null);
+    setForm({ title: '', content: '' });
+  };
+
   return (
-    <div>
+    <div className="container">
       <h2>게시판</h2>
-      <p>콘텐츠를 준비 중입니다.</p>
+      <form onSubmit={handleSubmit} className="mb-3">
+        <input
+          type="text"
+          name="title"
+          value={form.title}
+          onChange={onChange}
+          className="form-control mb-2"
+          placeholder="제목"
+          required
+        />
+        <textarea
+          name="content"
+          value={form.content}
+          onChange={onChange}
+          className="form-control mb-2"
+          rows="3"
+          placeholder="내용"
+          required
+        />
+        <button type="submit" className="btn btn-primary">
+          {editingId ? '수정' : '등록'}
+        </button>
+        {editingId && (
+          <button type="button" className="btn btn-secondary ms-2" onClick={cancelEdit}>
+            취소
+          </button>
+        )}
+      </form>
+      <table className="table table-bordered">
+        <thead>
+          <tr>
+            <th>제목</th>
+            <th>작성자</th>
+            <th>작성일</th>
+            <th>관리</th>
+          </tr>
+        </thead>
+        <tbody>
+          {posts.map((post) => (
+            <tr key={post._id}>
+              <td className="text-start">{post.title}</td>
+              <td>{post.username}</td>
+              <td>{new Date(post.createdAt).toLocaleString()}</td>
+              <td>
+                <button
+                  type="button"
+                  className="btn btn-sm btn-outline-secondary me-2"
+                  onClick={() => startEdit(post)}
+                >
+                  수정
+                </button>
+                <button
+                  type="button"
+                  className="btn btn-sm btn-outline-danger"
+                  onClick={() => handleDelete(post._id)}
+                >
+                  삭제
+                </button>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
     </div>
   );
 }

--- a/controllers/postApiController.js
+++ b/controllers/postApiController.js
@@ -1,0 +1,87 @@
+const { ObjectId } = require('mongodb');
+const asyncHandler = require('../middlewares/asyncHandler');
+
+// 게시글 목록 조회
+exports.list = asyncHandler(async (req, res) => {
+  const db = req.app.locals.db;
+  const page = parseInt(req.query.page, 10) || 1;
+  const limit = parseInt(req.query.limit, 10) || 10;
+  const skip = (page - 1) * limit;
+  const search = req.query.search;
+  const query = search
+    ? {
+        $or: [
+          { title: { $regex: search, $options: 'i' } },
+          { content: { $regex: search, $options: 'i' } },
+        ],
+      }
+    : {};
+  const [posts, total] = await Promise.all([
+    db
+      .collection('post')
+      .find(query)
+      .sort({ createdAt: -1 })
+      .skip(skip)
+      .limit(limit)
+      .toArray(),
+    db.collection('post').countDocuments(query),
+  ]);
+  res.json({ data: posts, total });
+});
+
+// 게시글 작성
+exports.create = asyncHandler(async (req, res) => {
+  if (!req.user) {
+    return res.status(401).json({ message: '로그인이 필요합니다.' });
+  }
+  const db = req.app.locals.db;
+  const doc = {
+    title: req.body.title,
+    content: req.body.content,
+    user: req.user._id,
+    username: req.user.username,
+    createdAt: new Date(),
+  };
+  await db.collection('post').insertOne(doc);
+  res.json({ success: true });
+});
+
+// 게시글 상세 조회
+exports.detail = asyncHandler(async (req, res) => {
+  const db = req.app.locals.db;
+  const post = await db
+    .collection('post')
+    .findOne({ _id: new ObjectId(req.params.id) });
+  if (!post) return res.status(404).json({ message: '존재하지 않는 게시글입니다.' });
+  res.json(post);
+});
+
+// 게시글 수정
+exports.update = asyncHandler(async (req, res) => {
+  if (!req.user) {
+    return res.status(401).json({ message: '로그인이 필요합니다.' });
+  }
+  const db = req.app.locals.db;
+  const result = await db.collection('post').updateOne(
+    { _id: new ObjectId(req.params.id), user: req.user._id },
+    { $set: { title: req.body.title, content: req.body.content } },
+  );
+  if (result.matchedCount === 0)
+    return res.status(403).json({ message: '수정 권한이 없습니다.' });
+  res.json({ success: true });
+});
+
+// 게시글 삭제
+exports.remove = asyncHandler(async (req, res) => {
+  if (!req.user) {
+    return res.status(401).json({ message: '로그인이 필요합니다.' });
+  }
+  const db = req.app.locals.db;
+  const result = await db.collection('post').deleteOne({
+    _id: new ObjectId(req.params.id),
+    user: req.user._id,
+  });
+  if (result.deletedCount === 0)
+    return res.status(403).json({ message: '삭제 권한이 없거나 존재하지 않습니다.' });
+  res.json({ success: true });
+});

--- a/routes/api/index.js
+++ b/routes/api/index.js
@@ -23,6 +23,8 @@ router.use("/coupang-open", require("./coupangOpenApi"));
 router.use("/weather", require("./weatherApi"));
 // 광고 성과 API
 router.use("/analytics", require("./analytics"));
+// 게시판 API
+router.use("/posts", require("./postApi"));
 
 // TODO: 다른 API 라우터 추가 시 아래와 같이 등록
 // router.use("/user", require("./userApi"));

--- a/routes/api/postApi.js
+++ b/routes/api/postApi.js
@@ -1,0 +1,11 @@
+const express = require('express');
+const router = express.Router();
+const ctrl = require('../../controllers/postApiController');
+
+router.get('/', ctrl.list);
+router.post('/', ctrl.create);
+router.get('/:id', ctrl.detail);
+router.put('/:id', ctrl.update);
+router.delete('/:id', ctrl.remove);
+
+module.exports = router;

--- a/routes/web/board.js
+++ b/routes/web/board.js
@@ -1,11 +1,10 @@
-const router = require("express").Router();
+const path = require('path');
+const router = require('express').Router();
 
-router.get("/sports", (요청, 응답) => {
-  응답.send("스포츠 게시판");
-});
-
-router.get("/game", (요청, 응답) => {
-  응답.send("게임 게시판");
+// React 페이지 제공
+router.get('/', (req, res) => {
+  const reactIndex = path.join(__dirname, '..', '..', 'client', 'public', 'index.html');
+  res.sendFile(reactIndex);
 });
 
 module.exports = router;


### PR DESCRIPTION
## Summary
- create `postApiController` for JSON-based board operations
- expose board REST routes under `/api/posts`
- serve React board page from `/board`
- implement React board page with list, write, edit, delete features

## Testing
- `npm test` *(fails: `jest: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_685fd7785c9c8329a74236d60a10d4a0