### PR TITLE
Add weather info in React header

### DIFF
--- a/client/src/components/Header.css
+++ b/client/src/components/Header.css
@@ -27,3 +27,8 @@
   display: flex;
   align-items: center;
 }
+
+.weather-info {
+  margin-left: 1rem;
+  font-size: 0.9rem;
+}

--- a/client/src/components/Header.js
+++ b/client/src/components/Header.js
@@ -4,12 +4,23 @@ import './Header.css';
 
 function Header({ onToggleSidebar }) {
   const [user, setUser] = useState(null);
+  const [weather, setWeather] = useState(null);
+
+  const skyMap = { '1': '맑음', '3': '구름많음', '4': '흐림' };
+  const ptyMap = { '0': '없음', '1': '비', '2': '비/눈', '3': '눈', '4': '소나기' };
 
   useEffect(() => {
     fetch('/api/auth/user', { credentials: 'include' })
       .then((res) => res.json())
       .then((data) => {
         setUser(data.user);
+      })
+      .catch(() => {});
+
+    fetch('/api/weather/daily', { credentials: 'include' })
+      .then((res) => (res.ok ? res.json() : Promise.reject()))
+      .then((data) => {
+        setWeather(data);
       })
       .catch(() => {});
   }, []);
@@ -27,6 +38,14 @@ function Header({ onToggleSidebar }) {
       <Link to="/dashboard" className="ms-2 fw-bold brand-link">
         내의미
       </Link>
+      {weather && (
+        <div className="weather-info ms-3">
+          <span>
+            {weather.temperature ?? '-'}℃ {skyMap[weather.sky] ?? weather.sky ?? '-'}{' '}
+            {ptyMap[weather.precipitationType] ?? weather.precipitationType ?? '-'}
+          </span>
+        </div>
+      )}
       <div className="user-info ms-auto">
         {user && <span className="me-3">{user.name || user.username}</span>}
         <button type="button" className="btn btn-link" onClick={handleLogout}>

--- a/client/src/components/Header.test.js
+++ b/client/src/components/Header.test.js
@@ -1,0 +1,36 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import Header from './Header';
+
+beforeEach(() => {
+  global.fetch = jest.fn((url) => {
+    if (url.includes('/api/auth/user')) {
+      return Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve({ user: { name: 'Tester' } }),
+      });
+    }
+    if (url.includes('/api/weather/daily')) {
+      return Promise.resolve({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            temperature: '20',
+            sky: '1',
+            precipitationType: '0',
+          }),
+      });
+    }
+    return Promise.reject(new Error('Unknown endpoint'));
+  });
+});
+
+afterEach(() => {
+  jest.resetAllMocks();
+});
+
+test('displays weather info in header', async () => {
+  render(<Header onToggleSidebar={() => {}} />);
+  await waitFor(() => screen.getByText(/맑음/));
+  expect(screen.getByText('맑음')).toBeInTheDocument();
+  expect(screen.getByText('20℃ 맑음 없음')).toBeInTheDocument();
+});


### PR DESCRIPTION
## Summary
- show weather data in dashboard header
- add styles for new weather section
- test header weather output

## Testing
- `npm test` *(fails: jest not found)*
- `cd client && npm test -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_685fd8949c648329843e8029099626e1