### PR TITLE
Add brand boards and React page

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,4 +224,18 @@ client authenticates by sending credentials to the Express endpoint
 `/api/auth/login`. In production the server serves `client/public/index.html` for
 `/login`, so navigating directly to `/login` loads the React app.
 
+### Board API
+
+Each brand has its own board managed through `/api/board/:name`. Supported
+names are `내의미`, `TRY`, `BYC`, `제임스딘`, `쿠팡` and `네이버`. Posts can be read
+with a GET request and created with a POST request:
+
+```bash
+curl http://localhost:3000/api/board/TRY/posts
+
+curl -X POST http://localhost:3000/api/board/TRY/posts \
+  -H 'Content-Type: application/json' \
+  -d '{"title":"hello","content":"world"}'
+```
+
 

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -31,6 +31,7 @@ function App() {
         <Route element={<DashboardLayout />}>
           <Route path="/dashboard" element={<Dashboard />} />
           <Route path="/board" element={<Board />} />
+          <Route path="/:brand/board" element={<Board />} />
           <Route path="/sales-amount" element={<SalesAmount />} />
           <Route path="/sales-volume" element={<SalesVolume />} />
           <Route path="/admin" element={<Admin />} />

--- a/client/src/pages/Board.js
+++ b/client/src/pages/Board.js
@@ -1,10 +1,71 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
+import { useParams } from 'react-router-dom';
+
+const boardMap = {
+  try: 'TRY',
+  byc: 'BYC',
+  'james-dean': '제임스딘',
+  coupang: '쿠팡',
+  naver: '네이버',
+};
 
 function Board() {
+  const { brand } = useParams();
+  const boardName = brand ? boardMap[brand] : '내의미';
+  const [posts, setPosts] = useState([]);
+  const [title, setTitle] = useState('');
+  const [content, setContent] = useState('');
+
+  const loadPosts = async () => {
+    const res = await fetch(`/api/board/${boardName}/posts`);
+    if (res.ok) {
+      const data = await res.json();
+      setPosts(data);
+    }
+  };
+
+  useEffect(() => {
+    loadPosts();
+  }, [boardName]);
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    await fetch(`/api/board/${boardName}/posts`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ title, content }),
+    });
+    setTitle('');
+    setContent('');
+    loadPosts();
+  };
+
   return (
     <div>
-      <h2>게시판</h2>
-      <p>콘텐츠를 준비 중입니다.</p>
+      <h2>{boardName} 게시판</h2>
+      <form onSubmit={handleSubmit}>
+        <input
+          value={title}
+          onChange={(e) => setTitle(e.target.value)}
+          placeholder="제목"
+        />
+        <br />
+        <textarea
+          value={content}
+          onChange={(e) => setContent(e.target.value)}
+          placeholder="내용"
+        />
+        <br />
+        <button type="submit">등록</button>
+      </form>
+      <ul>
+        {posts.map((p) => (
+          <li key={p._id}>
+            <strong>{p.title}</strong>
+            <p>{p.content}</p>
+          </li>
+        ))}
+      </ul>
     </div>
   );
 }

--- a/client/src/pages/Coupang.js
+++ b/client/src/pages/Coupang.js
@@ -15,7 +15,7 @@ function Coupang() {
 
   useEffect(() => {
     loadData();
-  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+  }, []);
 
   return (
     <div className="container">

--- a/client/src/pages/CoupangAdd.js
+++ b/client/src/pages/CoupangAdd.js
@@ -15,7 +15,7 @@ function CoupangAdd() {
 
   useEffect(() => {
     loadData();
-  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+  }, []);
 
   return (
     <div className="container">

--- a/config/initBoards.js
+++ b/config/initBoards.js
@@ -1,0 +1,18 @@
+const boards = ['내의미', 'TRY', 'BYC', '제임스딘', '쿠팡', '네이버'];
+
+async function initBoards(db) {
+  try {
+    const coll = db.collection('boards');
+    for (const name of boards) {
+      const exists = await coll.findOne({ name });
+      if (!exists) {
+        await coll.insertOne({ name });
+      }
+    }
+    console.log('📢 게시판 초기화 완료');
+  } catch (err) {
+    console.error('게시판 초기화 실패:', err.message);
+  }
+}
+
+module.exports = { initBoards, boards };

--- a/controllers/boardApiController.js
+++ b/controllers/boardApiController.js
@@ -1,0 +1,37 @@
+const { ObjectId } = require('mongodb');
+
+const getPosts = async (req, res) => {
+  const db = req.app.locals.db;
+  const board = req.params.board;
+  try {
+    const posts = await db
+      .collection('board_posts')
+      .find({ board })
+      .sort({ createdAt: -1 })
+      .toArray();
+    res.json(posts);
+  } catch (err) {
+    console.error('게시글 조회 실패:', err.message);
+    res.status(500).json({ error: 'failed' });
+  }
+};
+
+const addPost = async (req, res) => {
+  const db = req.app.locals.db;
+  const board = req.params.board;
+  const { title, content } = req.body;
+  try {
+    const result = await db.collection('board_posts').insertOne({
+      board,
+      title,
+      content,
+      createdAt: new Date(),
+    });
+    res.status(201).json({ id: result.insertedId });
+  } catch (err) {
+    console.error('게시글 추가 실패:', err.message);
+    res.status(500).json({ error: 'failed' });
+  }
+};
+
+module.exports = { getPosts, addPost };

--- a/routes/api/boardApi.js
+++ b/routes/api/boardApi.js
@@ -1,0 +1,7 @@
+const router = require('express').Router();
+const boardController = require('../../controllers/boardApiController');
+
+router.get('/:board/posts', boardController.getPosts);
+router.post('/:board/posts', boardController.addPost);
+
+module.exports = router;

--- a/routes/api/index.js
+++ b/routes/api/index.js
@@ -23,6 +23,8 @@ router.use("/coupang-open", require("./coupangOpenApi"));
 router.use("/weather", require("./weatherApi"));
 // 광고 성과 API
 router.use("/analytics", require("./analytics"));
+// 게시판 API
+router.use("/board", require("./boardApi"));
 
 // TODO: 다른 API 라우터 추가 시 아래와 같이 등록
 // router.use("/user", require("./userApi"));

--- a/server.js
+++ b/server.js
@@ -11,6 +11,7 @@ const compression = require("compression");
 const flash = require("connect-flash");
 const { connectDB } = require("./config/db");
 const { initIndexes } = require("./config/initIndexes");
+const { initBoards } = require("./config/initBoards");
 const webRouter = require("./routes/web");
 const apiRouter = require("./routes/api");
 const { checkAuth } = require("./middlewares/auth");
@@ -22,6 +23,7 @@ const app = express();
 async function initApp() {
   const db = await connectDB();
   await initIndexes(db);
+  await initBoards(db);
   app.locals.db = db;
   if (process.env.NODE_ENV !== 'test') {
     startCronJobs(db);


### PR DESCRIPTION
## Summary
- initialize brand boards in MongoDB
- expose `/api/board` endpoints
- add React Board page and dynamic route
- remove unused ESLint overrides
- document board API in README

## Testing
- `npm run lint`
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685fd9c49e9083299fb60eb988029e16