### PR TITLE
Add nested admin routes

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -15,11 +15,7 @@ import Board from './pages/Board';
 import SalesAmount from './pages/SalesAmount';
 import SalesVolume from './pages/SalesVolume';
 import Help from './pages/Help';
-import Admin from './pages/Admin';
-import AdminBanner from './pages/admin/Banner';
-import AdminLogo from './pages/admin/Logo';
-import AdminUsers from './pages/admin/Users';
-import AdminPermissions from './pages/admin/Permissions';
+import AdminRoutes from './routes/AdminRoutes';
 import Placeholder from './pages/Placeholder';
 
 function App() {
@@ -35,11 +31,7 @@ function App() {
           <Route path="/board" element={<Board />} />
           <Route path="/sales-amount" element={<SalesAmount />} />
           <Route path="/sales-volume" element={<SalesVolume />} />
-          <Route path="/admin" element={<Admin />} />
-          <Route path="/admin/banner" element={<AdminBanner />} />
-          <Route path="/admin/logo" element={<AdminLogo />} />
-          <Route path="/admin/users" element={<AdminUsers />} />
-          <Route path="/admin/permissions" element={<AdminPermissions />} />
+          <Route path="/admin/*" element={<AdminRoutes />} />
           <Route path="/stock" element={<Stock />} />
           <Route path="/coupang" element={<Coupang />} />
           <Route path="/coupang-add" element={<CoupangAdd />} />

--- a/client/src/routes/AdminRoutes.js
+++ b/client/src/routes/AdminRoutes.js
@@ -1,0 +1,27 @@
+import React from 'react';
+import { Routes, Route, Navigate } from 'react-router-dom';
+import Admin from '../pages/Admin';
+import AdminBanner from '../pages/admin/Banner';
+import AdminLogo from '../pages/admin/Logo';
+import AdminUsers from '../pages/admin/Users';
+import AdminPermissions from '../pages/admin/Permissions';
+
+/**
+ * Router for admin pages. This nested router keeps admin related
+ * paths grouped together and makes it easy to add new admin pages
+ * without touching the top-level App router.
+ */
+function AdminRoutes() {
+  return (
+    <Routes>
+      <Route index element={<Admin />} />
+      <Route path="banner" element={<AdminBanner />} />
+      <Route path="logo" element={<AdminLogo />} />
+      <Route path="users" element={<AdminUsers />} />
+      <Route path="permissions" element={<AdminPermissions />} />
+      <Route path="*" element={<Navigate to="." />} />
+    </Routes>
+  );
+}
+
+export default AdminRoutes;


### PR DESCRIPTION
## Summary
- route admin pages through a dedicated router
- organize admin-specific pages under `client/src/routes/AdminRoutes`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685fe0d3d22483298aa42a8bc168d5f1