### PR TITLE
Add advanced DataTable and CRUD endpoints

### DIFF
--- a/client/public/index.html
+++ b/client/public/index.html
@@ -20,6 +20,18 @@
       href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.6/dist/css/bootstrap.min.css"
       rel="stylesheet"
     />
+    <link
+      href="https://cdn.datatables.net/1.13.6/css/dataTables.bootstrap5.min.css"
+      rel="stylesheet"
+    />
+    <link
+      href="https://cdn.datatables.net/fixedheader/3.4.0/css/fixedHeader.bootstrap5.min.css"
+      rel="stylesheet"
+    />
+    <link
+      href="https://cdn.datatables.net/buttons/2.4.2/css/buttons.bootstrap5.min.css"
+      rel="stylesheet"
+    />
     <!--
       Notice the use of %PUBLIC_URL% in the tags above.
       It will be replaced with the URL of the `public` folder during the build.
@@ -36,5 +48,17 @@
     <div id="root"></div>
     <!-- Bootstrap JS -->
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.6/dist/js/bootstrap.bundle.min.js"></script>
+    <script src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
+    <script src="https://cdn.datatables.net/1.13.6/js/jquery.dataTables.min.js"></script>
+    <script src="https://cdn.datatables.net/1.13.6/js/dataTables.bootstrap5.min.js"></script>
+    <script src="https://cdn.datatables.net/fixedheader/3.4.0/js/dataTables.fixedHeader.min.js"></script>
+    <script src="https://cdn.datatables.net/buttons/2.4.2/js/dataTables.buttons.min.js"></script>
+    <script src="https://cdn.datatables.net/buttons/2.4.2/js/buttons.bootstrap5.min.js"></script>
+    <script src="https://cdn.datatables.net/buttons/2.4.2/js/buttons.html5.min.js"></script>
+    <script src="https://cdn.datatables.net/buttons/2.4.2/js/buttons.print.min.js"></script>
+    <script src="https://cdn.datatables.net/buttons/2.4.2/js/buttons.colVis.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/jszip/3.10.1/jszip.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/pdfmake/0.2.7/pdfmake.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/pdfmake/0.2.7/vfs_fonts.js"></script>
   </body>
 </html>

--- a/client/src/pages/Stock.js
+++ b/client/src/pages/Stock.js
@@ -1,135 +1,170 @@
-import React, { useEffect, useState, useCallback } from 'react';
+import React, { useEffect, useRef } from 'react';
 
 function Stock() {
-  const [rows, setRows] = useState([]);
-  const [form, setForm] = useState({ itemCode: '', color: '', size: '' });
-  const [excelFile, setExcelFile] = useState(null);
-
-  const loadData = useCallback(async () => {
-    const params = new URLSearchParams({
-      start: '0',
-      length: '100',
-      item_code: form.itemCode,
-      color: form.color,
-      size: form.size,
-    });
-    const res = await fetch(`/api/stock?${params.toString()}`, {
-      credentials: 'include',
-    });
-    if (res.ok) {
-      const data = await res.json();
-      setRows(data.data || []);
-    }
-  }, [form]);
+  const itemCodeRef = useRef(null);
+  const colorRef = useRef(null);
+  const sizeRef = useRef(null);
+  const formRef = useRef(null);
 
   useEffect(() => {
-    loadData();
-  }, [loadData]);
-
-  const onChange = (e) => {
-    setForm({ ...form, [e.target.name]: e.target.value });
-  };
-
-  const handleFileChange = (e) => {
-    setExcelFile(e.target.files[0] || null);
-  };
-
-  const handleUpload = async (e) => {
-    e.preventDefault();
-    if (!excelFile) return;
-    const fd = new FormData();
-    fd.append('excelFile', excelFile);
-    await fetch('/api/stock/upload', {
-      method: 'POST',
-      body: fd,
-      credentials: 'include',
+    const $ = window.$;
+    const table = $('#stockTable').DataTable({
+      serverSide: true,
+      processing: true,
+      ordering: true,
+      paging: true,
+      searching: false,
+      dom: 'Bfrtip',
+      buttons: ['copy', 'csv', 'excel', 'pdf', 'print', 'colvis'],
+      fixedHeader: true,
+      lengthChange: true,
+      pageLength: 50,
+      columnDefs: [
+        { targets: '_all', className: 'text-center' },
+        {
+          targets: 0,
+          render: function (data, type, row, meta) {
+            return meta.row + meta.settings._iDisplayStart + 1;
+          },
+        },
+        {
+          targets: 5,
+          createdCell: function (td, cellData) {
+            $(td).addClass(cellData < 10 ? 'low-stock' : 'high-stock');
+          },
+        },
+        {
+          targets: 8,
+          render: function (data) {
+            if (!data) return '';
+            const d = new Date(data);
+            return d.toLocaleString('ko-KR', {
+              year: 'numeric',
+              month: '2-digit',
+              day: '2-digit',
+              hour: '2-digit',
+              minute: '2-digit',
+              hour12: false,
+            });
+          },
+        },
+      ],
+      language: {
+        paginate: { previous: '이전', next: '다음' },
+        info: '총 _TOTAL_건 중 _START_ ~ _END_',
+        infoEmpty: '데이터가 없습니다',
+      },
+      ajax: {
+        url: '/api/stock',
+        type: 'GET',
+        data: function (d) {
+          d.item_code = itemCodeRef.current.value.trim();
+          d.color = colorRef.current.value.trim();
+          d.size = sizeRef.current.value.trim();
+        },
+        dataSrc: 'data',
+      },
+      columns: [
+        { data: null },
+        { data: 'item_code' },
+        { data: 'item_name' },
+        { data: 'color' },
+        { data: 'size' },
+        { data: 'qty' },
+        { data: 'allocation' },
+        { data: 'uploadedBy' },
+        { data: 'createdAt' },
+      ],
+      createdRow: function (row, data) {
+        if (data.qty < 10) {
+          $(row).addClass('table-danger');
+        }
+      },
     });
-    setExcelFile(null);
-    loadData();
-  };
 
-  const handleReset = async () => {
-    if (!window.confirm('모든 데이터를 삭제하시겠습니까?')) return;
-    await fetch('/api/stock', { method: 'DELETE', credentials: 'include' });
-    loadData();
-  };
+    $('#btnSearch').on('click', function () {
+      table.ajax.reload();
+    });
+
+    $('#btnRefresh').on('click', function () {
+      itemCodeRef.current.value = '';
+      colorRef.current.value = '';
+      sizeRef.current.value = '';
+      table.ajax.reload();
+    });
+
+    $(formRef.current).on('submit', function (e) {
+      e.preventDefault();
+      const formData = new FormData(formRef.current);
+      $.ajax({
+        url: '/stock/upload',
+        type: 'POST',
+        data: formData,
+        processData: false,
+        contentType: false,
+        success: () => {
+          alert('업로드 성공!');
+          table.ajax.reload(null, false);
+        },
+        error: (xhr) => {
+          alert('업로드 실패: ' + xhr.responseText);
+        },
+      });
+    });
+
+    return () => {
+      table.destroy();
+    };
+  }, []);
 
   return (
-    <div className="container">
-      <h2>재고 관리</h2>
-      <form onSubmit={handleUpload} className="mb-3 d-flex gap-2">
-        <input type="file" accept=".xlsx,.xls" onChange={handleFileChange} />
-        <button type="submit" className="btn btn-success">
-          엑셀 업로드
-        </button>
-        <button
-          type="button"
-          className="btn btn-danger"
-          onClick={handleReset}
-        >
-          데이터 초기화
-        </button>
-      </form>
-      <div className="row g-2 mb-3">
-        <div className="col">
-          <input
-            type="text"
-            name="itemCode"
-            className="form-control"
-            placeholder="품번"
-            value={form.itemCode}
-            onChange={onChange}
-          />
+    <div className="container my-5">
+      <h2 className="fw-bold mb-4">재고 관리</h2>
+
+      <div className="action-form mb-4">
+        <form ref={formRef} className="d-flex gap-2 flex-nowrap" encType="multipart/form-data">
+          <input type="file" name="excelFile" accept=".xlsx,.xls" className="form-control" required />
+          <button type="submit" className="btn btn-success btn-upload">엑셀 업로드</button>
+        </form>
+        <button id="btnRefresh" className="btn btn-danger btn-reset ms-2">데이터 초기화</button>
+      </div>
+
+      <div className="row g-3 align-items-end mb-4 stock-search">
+        <div className="col-md-3">
+          <label htmlFor="itemCode" className="form-label">품번</label>
+          <input ref={itemCodeRef} type="text" id="itemCode" className="form-control" placeholder="품번 입력" />
         </div>
-        <div className="col">
-          <input
-            type="text"
-            name="color"
-            className="form-control"
-            placeholder="색상"
-            value={form.color}
-            onChange={onChange}
-          />
+        <div className="col-md-3">
+          <label htmlFor="color" className="form-label">색상</label>
+          <input ref={colorRef} type="text" id="color" className="form-control" placeholder="색상 입력" />
         </div>
-        <div className="col">
-          <input
-            type="text"
-            name="size"
-            className="form-control"
-            placeholder="사이즈"
-            value={form.size}
-            onChange={onChange}
-          />
+        <div className="col-md-3">
+          <label htmlFor="size" className="form-label">사이즈</label>
+          <input ref={sizeRef} type="text" id="size" className="form-control" placeholder="사이즈 입력" />
         </div>
-        <div className="col">
-          <button className="btn btn-outline-primary w-100" onClick={loadData}>
-            검색
-          </button>
+        <div className="col-md-3 d-flex gap-2">
+          <button id="btnSearch" className="btn btn-outline-primary w-100">검색</button>
         </div>
       </div>
 
-      <table className="table table-bordered text-center">
-        <thead>
-          <tr>
-            <th>품번</th>
-            <th>품명</th>
-            <th>색상</th>
-            <th>사이즈</th>
-            <th>수량</th>
-          </tr>
-        </thead>
-        <tbody>
-          {rows.map((row) => (
-            <tr key={row._id}>
-              <td>{row.item_code}</td>
-              <td>{row.item_name}</td>
-              <td>{row.color}</td>
-              <td>{row.size}</td>
-              <td>{Number(row.qty || 0).toLocaleString()}</td>
+      <div className="table-responsive table-container">
+        <table id="stockTable" data-order-col="1" data-order-dir="asc" className="table table-striped table-hover table-bordered shadow-sm rounded bg-white align-middle text-center auto-width">
+          <thead className="table-light">
+            <tr>
+              <th>번호</th>
+              <th>품번</th>
+              <th>품명</th>
+              <th>색상</th>
+              <th>사이즈</th>
+              <th>수량</th>
+              <th>할당</th>
+              <th>업로드 사용자</th>
+              <th>업로드 시각</th>
             </tr>
-          ))}
-        </tbody>
-      </table>
+          </thead>
+          <tbody></tbody>
+        </table>
+      </div>
     </div>
   );
 }

--- a/routes/api/stockApi.js
+++ b/routes/api/stockApi.js
@@ -4,11 +4,14 @@ const router = express.Router();
 const stockCtrl = require("../../controllers/stockController");
 
 router.get("/", stockCtrl.getStockData);
+router.get("/:id", stockCtrl.getStockItem);
+router.post("/", stockCtrl.addStockItem);
 router.post("/upload", stockCtrl.upload, stockCtrl.uploadExcelApi);
 router.delete("/", async (req, res) => {
   const db = req.app.locals.db;
   await db.collection("stock").deleteMany({});
   res.json({ message: "삭제 완료" });
 });
+router.put("/:id", stockCtrl.updateStockItem);
 
 module.exports = router;

--- a/tests/stockApi.test.js
+++ b/tests/stockApi.test.js
@@ -79,3 +79,33 @@ describe("DELETE /api/stock", () => {
     expect(mockColl.deleteMany).toHaveBeenCalledWith({});
   });
 });
+
+describe("POST /api/stock", () => {
+  it("should insert a new item", async () => {
+    mockCollection.insertOne = jest
+      .fn()
+      .mockResolvedValue({ insertedId: "507f1f77bcf86cd799439011" });
+
+    const res = await request(app)
+      .post("/api/stock")
+      .send({ item_code: "A1", qty: 1 });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toEqual({ insertedId: "507f1f77bcf86cd799439011" });
+    expect(mockCollection.insertOne).toHaveBeenCalled();
+  });
+});
+
+describe("PUT /api/stock/:id", () => {
+  it("should update an item", async () => {
+    mockCollection.updateOne = jest.fn().mockResolvedValue({ matchedCount: 1 });
+
+    const res = await request(app)
+      .put("/api/stock/507f1f77bcf86cd799439011")
+      .send({ qty: 2 });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toEqual({ message: "updated" });
+    expect(mockCollection.updateOne).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- enhance stock DataTable React page using jQuery DataTables with Buttons
- expose CRUD API for stock collection
- support stock CRUD handlers in controller
- extend test coverage for new routes
- include DataTables assets in React index.html

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685fe359b4e0832997e8a157c1a96ee1