### PR TITLE
Add board management API with React admin page

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,5 +232,10 @@ client authenticates by sending credentials to the Express endpoint
 
 The Help page has also been converted to React and is accessible at `/help`.
 
+### Board management API
+Boards are stored in the `board` collection. CRUD operations are available via
+`/api/boards`. A simple management page is located at `/admin/boards` in the
+React client.
+
 
 

--- a/client/src/pages/Admin.js
+++ b/client/src/pages/Admin.js
@@ -19,6 +19,9 @@ function Admin() {
         <li className="list-group-item">
           <Link to="/admin/logo">브랜드 로고 관리</Link>
         </li>
+        <li className="list-group-item">
+          <Link to="/admin/boards">게시판 관리</Link>
+        </li>
       </ul>
     </div>
   );

--- a/client/src/pages/admin/Boards.js
+++ b/client/src/pages/admin/Boards.js
@@ -1,0 +1,133 @@
+import React, { useEffect, useState } from 'react';
+
+function Boards() {
+  const [boards, setBoards] = useState([]);
+  const [form, setForm] = useState({ name: '', slug: '', description: '' });
+  const [editingId, setEditingId] = useState(null);
+
+  const loadBoards = async () => {
+    const res = await fetch('/api/boards', { credentials: 'include' });
+    if (res.ok) {
+      const data = await res.json();
+      setBoards(data);
+    }
+  };
+
+  useEffect(() => {
+    loadBoards();
+  }, []);
+
+  const onChange = (e) => {
+    setForm({ ...form, [e.target.name]: e.target.value });
+  };
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    const method = editingId ? 'PUT' : 'POST';
+    const url = editingId ? `/api/boards/${editingId}` : '/api/boards';
+    await fetch(url, {
+      method,
+      headers: { 'Content-Type': 'application/json' },
+      credentials: 'include',
+      body: JSON.stringify(form),
+    });
+    setForm({ name: '', slug: '', description: '' });
+    setEditingId(null);
+    loadBoards();
+  };
+
+  const startEdit = (board) => {
+    setEditingId(board._id);
+    setForm({ name: board.name, slug: board.slug, description: board.description || '' });
+  };
+
+  const cancelEdit = () => {
+    setEditingId(null);
+    setForm({ name: '', slug: '', description: '' });
+  };
+
+  const handleDelete = async (id) => {
+    if (!window.confirm('삭제하시겠습니까?')) return;
+    await fetch(`/api/boards/${id}`, { method: 'DELETE', credentials: 'include' });
+    loadBoards();
+  };
+
+  return (
+    <div className="container">
+      <h2>게시판 관리</h2>
+      <form onSubmit={handleSubmit} className="mb-3">
+        <input
+          type="text"
+          name="name"
+          value={form.name}
+          onChange={onChange}
+          className="form-control mb-2"
+          placeholder="이름"
+          required
+        />
+        <input
+          type="text"
+          name="slug"
+          value={form.slug}
+          onChange={onChange}
+          className="form-control mb-2"
+          placeholder="슬러그"
+          required
+        />
+        <input
+          type="text"
+          name="description"
+          value={form.description}
+          onChange={onChange}
+          className="form-control mb-2"
+          placeholder="설명"
+        />
+        <button type="submit" className="btn btn-primary">
+          {editingId ? '수정' : '등록'}
+        </button>
+        {editingId && (
+          <button type="button" className="btn btn-secondary ms-2" onClick={cancelEdit}>
+            취소
+          </button>
+        )}
+      </form>
+      <table className="table table-bordered">
+        <thead>
+          <tr>
+            <th>이름</th>
+            <th>슬러그</th>
+            <th>설명</th>
+            <th>관리</th>
+          </tr>
+        </thead>
+        <tbody>
+          {boards.map((board) => (
+            <tr key={board._id}>
+              <td>{board.name}</td>
+              <td>{board.slug}</td>
+              <td>{board.description}</td>
+              <td>
+                <button
+                  type="button"
+                  className="btn btn-sm btn-outline-secondary me-2"
+                  onClick={() => startEdit(board)}
+                >
+                  수정
+                </button>
+                <button
+                  type="button"
+                  className="btn btn-sm btn-outline-danger"
+                  onClick={() => handleDelete(board._id)}
+                >
+                  삭제
+                </button>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+export default Boards;

--- a/client/src/routes/AdminRoutes.js
+++ b/client/src/routes/AdminRoutes.js
@@ -5,6 +5,7 @@ import AdminBanner from '../pages/admin/Banner';
 import AdminLogo from '../pages/admin/Logo';
 import AdminUsers from '../pages/admin/Users';
 import AdminPermissions from '../pages/admin/Permissions';
+import AdminBoards from '../pages/admin/Boards';
 
 /**
  * Router for admin pages. This nested router keeps admin related
@@ -19,6 +20,7 @@ function AdminRoutes() {
       <Route path="logo" element={<AdminLogo />} />
       <Route path="users" element={<AdminUsers />} />
       <Route path="permissions" element={<AdminPermissions />} />
+      <Route path="boards" element={<AdminBoards />} />
       <Route path="*" element={<Navigate to="." />} />
     </Routes>
   );

--- a/controllers/boardApiController.js
+++ b/controllers/boardApiController.js
@@ -1,0 +1,74 @@
+const { ObjectId } = require('mongodb');
+const asyncHandler = require('../middlewares/asyncHandler');
+
+// 게시판 목록 조회
+exports.list = asyncHandler(async (req, res) => {
+  const db = req.app.locals.db;
+  const boards = await db
+    .collection('board')
+    .find()
+    .sort({ createdAt: -1 })
+    .toArray();
+  res.json(boards);
+});
+
+// 게시판 생성
+exports.create = asyncHandler(async (req, res) => {
+  if (!req.user) {
+    return res.status(401).json({ message: '로그인이 필요합니다.' });
+  }
+  const db = req.app.locals.db;
+  const doc = {
+    name: req.body.name,
+    slug: req.body.slug,
+    description: req.body.description || '',
+    createdAt: new Date(),
+  };
+  await db.collection('board').insertOne(doc);
+  res.json({ success: true });
+});
+
+// 게시판 상세 조회
+exports.detail = asyncHandler(async (req, res) => {
+  const db = req.app.locals.db;
+  const board = await db
+    .collection('board')
+    .findOne({ _id: new ObjectId(req.params.id) });
+  if (!board) return res.status(404).json({ message: '존재하지 않는 게시판입니다.' });
+  res.json(board);
+});
+
+// 게시판 수정
+exports.update = asyncHandler(async (req, res) => {
+  if (!req.user) {
+    return res.status(401).json({ message: '로그인이 필요합니다.' });
+  }
+  const db = req.app.locals.db;
+  const result = await db.collection('board').updateOne(
+    { _id: new ObjectId(req.params.id) },
+    {
+      $set: {
+        name: req.body.name,
+        slug: req.body.slug,
+        description: req.body.description || '',
+      },
+    },
+  );
+  if (result.matchedCount === 0)
+    return res.status(404).json({ message: '존재하지 않는 게시판입니다.' });
+  res.json({ success: true });
+});
+
+// 게시판 삭제
+exports.remove = asyncHandler(async (req, res) => {
+  if (!req.user) {
+    return res.status(401).json({ message: '로그인이 필요합니다.' });
+  }
+  const db = req.app.locals.db;
+  const result = await db.collection('board').deleteOne({
+    _id: new ObjectId(req.params.id),
+  });
+  if (result.deletedCount === 0)
+    return res.status(404).json({ message: '존재하지 않는 게시판입니다.' });
+  res.json({ success: true });
+});

--- a/routes/api/boardApi.js
+++ b/routes/api/boardApi.js
@@ -1,0 +1,11 @@
+const express = require('express');
+const router = express.Router();
+const ctrl = require('../../controllers/boardApiController');
+
+router.get('/', ctrl.list);
+router.post('/', ctrl.create);
+router.get('/:id', ctrl.detail);
+router.put('/:id', ctrl.update);
+router.delete('/:id', ctrl.remove);
+
+module.exports = router;

--- a/routes/api/index.js
+++ b/routes/api/index.js
@@ -25,6 +25,8 @@ router.use("/weather", require("./weatherApi"));
 router.use("/analytics", require("./analytics"));
 // 게시판 API
 router.use("/posts", require("./postApi"));
+// 게시판 목록 API
+router.use("/boards", require("./boardApi"));
 
 // TODO: 다른 API 라우터 추가 시 아래와 같이 등록
 // router.use("/user", require("./userApi"));


### PR DESCRIPTION
## Summary
- switch admin pages to include a board management section
- create CRUD API for boards
- expose `/api/boards` endpoint and React admin page at `/admin/boards`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685fe56a08848329b60306e67433193f