### PR TITLE
Simplify stock board UI

### DIFF
--- a/client/src/pages/Stock.css
+++ b/client/src/pages/Stock.css
@@ -1,0 +1,9 @@
+.stock-actions .form-control {
+  height: calc(1.5em + 0.75rem + 2px);
+}
+
+.stock-actions .btn,
+.stock-search .btn {
+  white-space: nowrap;
+  width: auto;
+}

--- a/client/src/pages/Stock.js
+++ b/client/src/pages/Stock.js
@@ -1,10 +1,20 @@
-import React, { useEffect, useRef } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
+import './Stock.css';
 
 function Stock() {
   const itemCodeRef = useRef(null);
+  const itemNameRef = useRef(null);
   const colorRef = useRef(null);
   const sizeRef = useRef(null);
-  const formRef = useRef(null);
+  const qtyRef = useRef(null);
+  const allocationRef = useRef(null);
+  const searchItemCodeRef = useRef(null);
+  const searchColorRef = useRef(null);
+  const searchSizeRef = useRef(null);
+  const excelFormRef = useRef(null);
+  const manageFormRef = useRef(null);
+  const tableRef = useRef(null);
+  const [editing, setEditing] = useState(null);
 
   useEffect(() => {
     const $ = window.$;
@@ -14,8 +24,8 @@ function Stock() {
       ordering: true,
       paging: true,
       searching: false,
-      dom: 'Bfrtip',
-      buttons: ['copy', 'csv', 'excel', 'pdf', 'print', 'colvis'],
+      dom: 'Brtip',
+      buttons: ['excel'],
       fixedHeader: true,
       lengthChange: true,
       pageLength: 50,
@@ -58,9 +68,9 @@ function Stock() {
         url: '/api/stock',
         type: 'GET',
         data: function (d) {
-          d.item_code = itemCodeRef.current.value.trim();
-          d.color = colorRef.current.value.trim();
-          d.size = sizeRef.current.value.trim();
+          d.item_code = searchItemCodeRef.current.value.trim();
+          d.color = searchColorRef.current.value.trim();
+          d.size = searchSizeRef.current.value.trim();
         },
         dataSrc: 'data',
       },
@@ -81,21 +91,22 @@ function Stock() {
         }
       },
     });
+    tableRef.current = table;
 
     $('#btnSearch').on('click', function () {
       table.ajax.reload();
     });
 
     $('#btnRefresh').on('click', function () {
-      itemCodeRef.current.value = '';
-      colorRef.current.value = '';
-      sizeRef.current.value = '';
+      searchItemCodeRef.current.value = '';
+      searchColorRef.current.value = '';
+      searchSizeRef.current.value = '';
       table.ajax.reload();
     });
 
-    $(formRef.current).on('submit', function (e) {
+    $(excelFormRef.current).on('submit', function (e) {
       e.preventDefault();
-      const formData = new FormData(formRef.current);
+      const formData = new FormData(excelFormRef.current);
       $.ajax({
         url: '/stock/upload',
         type: 'POST',
@@ -112,38 +123,113 @@ function Stock() {
       });
     });
 
+    $('#stockTable tbody').on('click', 'tr', function () {
+      const data = table.row(this).data();
+      if (data) {
+        setEditing(data);
+        itemCodeRef.current.value = data.item_code || '';
+        itemNameRef.current.value = data.item_name || '';
+        colorRef.current.value = data.color || '';
+        sizeRef.current.value = data.size || '';
+        qtyRef.current.value = data.qty || 0;
+        allocationRef.current.value = data.allocation || 0;
+      }
+    });
+
     return () => {
+      $('#stockTable tbody').off('click');
       table.destroy();
     };
   }, []);
+
+  const handleSave = async (e) => {
+    e.preventDefault();
+    const body = {
+      item_code: itemCodeRef.current.value.trim(),
+      item_name: itemNameRef.current.value.trim(),
+      color: colorRef.current.value.trim(),
+      size: sizeRef.current.value.trim(),
+      qty: Number(qtyRef.current.value) || 0,
+      allocation: Number(allocationRef.current.value) || 0,
+    };
+    const url = editing ? `/api/stock/${editing._id}` : '/api/stock';
+    const method = editing ? 'PUT' : 'POST';
+    const res = await fetch(url, {
+      method,
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+      credentials: 'include',
+    });
+    if (res.ok && tableRef.current) {
+      tableRef.current.ajax.reload(null, false);
+    }
+    manageFormRef.current.reset();
+    setEditing(null);
+  };
+
+  const handleCancel = () => {
+    manageFormRef.current.reset();
+    setEditing(null);
+  };
 
   return (
     <div className="container my-5">
       <h2 className="fw-bold mb-4">재고 관리</h2>
 
       <div className="action-form mb-4">
-        <form ref={formRef} className="d-flex gap-2 flex-nowrap" encType="multipart/form-data">
+        <form ref={excelFormRef} className="d-flex gap-2 flex-nowrap" encType="multipart/form-data">
           <input type="file" name="excelFile" accept=".xlsx,.xls" className="form-control" required />
           <button type="submit" className="btn btn-success btn-upload">엑셀 업로드</button>
         </form>
         <button id="btnRefresh" className="btn btn-danger btn-reset ms-2">데이터 초기화</button>
       </div>
 
+      <form ref={manageFormRef} className="row g-2 mb-4 stock-actions" onSubmit={handleSave}>
+        <div className="col-sm">
+          <input ref={itemCodeRef} className="form-control" placeholder="품번" required />
+        </div>
+        <div className="col-sm">
+          <input ref={itemNameRef} className="form-control" placeholder="품명" required />
+        </div>
+        <div className="col-sm">
+          <input ref={colorRef} className="form-control" placeholder="색상" />
+        </div>
+        <div className="col-sm">
+          <input ref={sizeRef} className="form-control" placeholder="사이즈" />
+        </div>
+        <div className="col-sm">
+          <input ref={qtyRef} type="number" className="form-control" placeholder="수량" />
+        </div>
+        <div className="col-sm">
+          <input ref={allocationRef} type="number" className="form-control" placeholder="할당" />
+        </div>
+        <div className="col-auto">
+          <button type="submit" className="btn btn-primary">
+            {editing ? '수정' : '추가'}
+          </button>
+        </div>
+        {editing && (
+          <div className="col-auto">
+            <button type="button" className="btn btn-secondary" onClick={handleCancel}>취소</button>
+          </div>
+        )}
+      </form>
+
       <div className="row g-3 align-items-end mb-4 stock-search">
         <div className="col-md-3">
           <label htmlFor="itemCode" className="form-label">품번</label>
-          <input ref={itemCodeRef} type="text" id="itemCode" className="form-control" placeholder="품번 입력" />
+          <input ref={searchItemCodeRef} type="text" id="itemCode" className="form-control" placeholder="품번 입력" />
         </div>
         <div className="col-md-3">
           <label htmlFor="color" className="form-label">색상</label>
-          <input ref={colorRef} type="text" id="color" className="form-control" placeholder="색상 입력" />
+          <input ref={searchColorRef} type="text" id="color" className="form-control" placeholder="색상 입력" />
         </div>
         <div className="col-md-3">
           <label htmlFor="size" className="form-label">사이즈</label>
-          <input ref={sizeRef} type="text" id="size" className="form-control" placeholder="사이즈 입력" />
+          <input ref={searchSizeRef} type="text" id="size" className="form-control" placeholder="사이즈 입력" />
         </div>
         <div className="col-md-3 d-flex gap-2">
-          <button id="btnSearch" className="btn btn-outline-primary w-100">검색</button>
+          <button id="btnSearch" className="btn btn-outline-primary">검색</button>
         </div>
       </div>
 


### PR DESCRIPTION
## Summary
- switch stock board to simple DataTable with Excel button only
- add inline form to add or edit stock items
- adjust search form refs and button widths
- add basic CSS for buttons and form

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: react-hooks/exhaustive-deps rule not found)*

------
https://chatgpt.com/codex/tasks/task_e_685fe75264fc83299f9bb9bcfe68eff7