### PR TITLE
Simplify stock table and remove upload metadata

### DIFF
--- a/client/public/index.html
+++ b/client/public/index.html
@@ -21,11 +21,11 @@
       rel="stylesheet"
     />
     <link
-      href="https://cdn.datatables.net/1.13.6/css/dataTables.bootstrap5.min.css"
+      href="https://cdn.datatables.net/2.3.2/css/dataTables.bootstrap5.min.css"
       rel="stylesheet"
     />
     <link
-      href="https://cdn.datatables.net/fixedheader/3.4.0/css/fixedHeader.bootstrap5.min.css"
+      href="https://cdn.datatables.net/fixedheader/4.0.1/css/fixedHeader.bootstrap5.min.css"
       rel="stylesheet"
     />
     <link
@@ -49,14 +49,13 @@
     <!-- Bootstrap JS -->
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.6/dist/js/bootstrap.bundle.min.js"></script>
     <script src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
-    <script src="https://cdn.datatables.net/1.13.6/js/jquery.dataTables.min.js"></script>
-    <script src="https://cdn.datatables.net/1.13.6/js/dataTables.bootstrap5.min.js"></script>
-    <script src="https://cdn.datatables.net/fixedheader/3.4.0/js/dataTables.fixedHeader.min.js"></script>
+    <script src="https://cdn.datatables.net/2.3.2/js/jquery.dataTables.min.js"></script>
+    <script src="https://cdn.datatables.net/2.3.2/js/dataTables.bootstrap5.min.js"></script>
+    <script src="https://cdn.datatables.net/fixedheader/4.0.1/js/dataTables.fixedHeader.min.js"></script>
     <script src="https://cdn.datatables.net/buttons/2.4.2/js/dataTables.buttons.min.js"></script>
     <script src="https://cdn.datatables.net/buttons/2.4.2/js/buttons.bootstrap5.min.js"></script>
     <script src="https://cdn.datatables.net/buttons/2.4.2/js/buttons.html5.min.js"></script>
     <script src="https://cdn.datatables.net/buttons/2.4.2/js/buttons.print.min.js"></script>
-    <script src="https://cdn.datatables.net/buttons/2.4.2/js/buttons.colVis.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jszip/3.10.1/jszip.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/pdfmake/0.2.7/pdfmake.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/pdfmake/0.2.7/vfs_fonts.js"></script>

--- a/client/src/pages/Stock.js
+++ b/client/src/pages/Stock.js
@@ -43,21 +43,6 @@ function Stock() {
             $(td).addClass(cellData < 10 ? 'low-stock' : 'high-stock');
           },
         },
-        {
-          targets: 8,
-          render: function (data) {
-            if (!data) return '';
-            const d = new Date(data);
-            return d.toLocaleString('ko-KR', {
-              year: 'numeric',
-              month: '2-digit',
-              day: '2-digit',
-              hour: '2-digit',
-              minute: '2-digit',
-              hour12: false,
-            });
-          },
-        },
       ],
       language: {
         paginate: { previous: '이전', next: '다음' },
@@ -82,8 +67,6 @@ function Stock() {
         { data: 'size' },
         { data: 'qty' },
         { data: 'allocation' },
-        { data: 'uploadedBy' },
-        { data: 'createdAt' },
       ],
       createdRow: function (row, data) {
         if (data.qty < 10) {
@@ -244,8 +227,6 @@ function Stock() {
               <th>사이즈</th>
               <th>수량</th>
               <th>할당</th>
-              <th>업로드 사용자</th>
-              <th>업로드 시각</th>
             </tr>
           </thead>
           <tbody></tbody>

--- a/controllers/stockController.js
+++ b/controllers/stockController.js
@@ -43,8 +43,6 @@ exports.getStockData = asyncHandler(async (req, res) => {
     4: "size",
     5: "qty",
     6: "allocation",
-    7: "uploadedBy",
-    8: "createdAt",
   };
   const orderCol = columns[req.query["order[0][column]"]] || "item_code";
   const orderDir = req.query["order[0][dir]"] === "desc" ? -1 : 1;
@@ -114,18 +112,6 @@ exports.uploadExcel = asyncHandler(async (req, res) => {
 
     if (code === 0) {
       try {
-        const db = req.app.locals.db;
-        if (db) {
-          await db.collection(collectionName).updateMany(
-            {},
-            {
-              $set: {
-                createdAt: new Date(),
-                uploadedBy: req.user ? req.user.username : "알 수 없음",
-              },
-            },
-          );
-        }
         if (req.flash)
           req.flash("성공메시지", "✅ 엑셀 업로드가 완료되었습니다.");
         res.redirect("/stock");
@@ -199,17 +185,6 @@ exports.uploadExcelApi = asyncHandler(async (req, res) => {
     if (code === 0) {
       try {
         const db = req.app.locals.db;
-        if (db) {
-          await db.collection(collectionName).updateMany(
-            {},
-            {
-              $set: {
-                createdAt: new Date(),
-                uploadedBy: req.user ? req.user.username : "알 수 없음",
-              },
-            },
-          );
-        }
         res.json({ status: "success" });
       } catch (err) {
         console.error("❌ 업로드 후 처리 실패:", err);
@@ -263,8 +238,6 @@ exports.addStockItem = asyncHandler(async (req, res) => {
     size: req.body.size,
     qty: Number(req.body.qty) || 0,
     allocation: Number(req.body.allocation) || 0,
-    uploadedBy: req.user ? req.user.username : "api",
-    createdAt: new Date(),
   };
 
   const result = await db.collection("stock").insertOne(doc);

--- a/public/js/stock.js
+++ b/public/js/stock.js
@@ -34,23 +34,7 @@ $(document).ready(function () {
           $(td).addClass(cellData < 10 ? "low-stock" : "high-stock");
         },
         render: function (data) {
-          // 이모지 대신 수량만 표시
           return data;
-        },
-      },
-      {
-        targets: 8,
-        render: function (data) {
-          if (!data) return "";
-          const d = new Date(data);
-          return d.toLocaleString("ko-KR", {
-            year: "numeric",
-            month: "2-digit",
-            day: "2-digit",
-            hour: "2-digit",
-            minute: "2-digit",
-            hour12: false,
-          });
         },
       },
     ],
@@ -77,8 +61,6 @@ $(document).ready(function () {
       { data: "size" },
       { data: "qty" },
       { data: "allocation" },
-      { data: "uploadedBy" },
-      { data: "createdAt" },
     ],
     createdRow: function (row, data) {
       if (data.qty < 10) {

--- a/views/stock.ejs
+++ b/views/stock.ejs
@@ -6,8 +6,8 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.6/dist/css/bootstrap.min.css" rel="stylesheet">
   <link rel="stylesheet" href="/main.css">
-  <link rel="stylesheet" href="https://cdn.datatables.net/1.13.6/css/dataTables.bootstrap5.min.css">
-  <link rel="stylesheet" href="https://cdn.datatables.net/fixedheader/3.4.0/css/fixedHeader.bootstrap5.min.css">
+  <link rel="stylesheet" href="https://cdn.datatables.net/2.3.2/css/dataTables.bootstrap5.min.css">
+  <link rel="stylesheet" href="https://cdn.datatables.net/fixedheader/4.0.1/css/fixedHeader.bootstrap5.min.css">
 </head>
 <body class="bg-light">
   <%- include('nav.ejs') %>
@@ -66,8 +66,6 @@
             <th>사이즈</th>
             <th>수량</th>
             <th>할당</th>
-            <th>업로드 사용자</th>
-            <th>업로드 시각</th>
           </tr>
         </thead>
         <tbody></tbody>
@@ -77,9 +75,9 @@
   </div>
 
   <script src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
-  <script src="https://cdn.datatables.net/1.13.6/js/jquery.dataTables.min.js"></script>
-  <script src="https://cdn.datatables.net/1.13.6/js/dataTables.bootstrap5.min.js"></script>
-  <script src="https://cdn.datatables.net/fixedheader/3.4.0/js/dataTables.fixedHeader.min.js"></script>
+  <script src="https://cdn.datatables.net/2.3.2/js/jquery.dataTables.min.js"></script>
+  <script src="https://cdn.datatables.net/2.3.2/js/dataTables.bootstrap5.min.js"></script>
+  <script src="https://cdn.datatables.net/fixedheader/4.0.1/js/dataTables.fixedHeader.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.6/dist/js/bootstrap.bundle.min.js"></script>
   <script src="/js/common-dt.js"></script>
   <script src="/js/stock.js"></script>


### PR DESCRIPTION
## Summary
- drop uploaded user/time columns
- update CDN links to DataTables 2
- adjust stock pages and DataTable configs accordingly

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685feda167dc8329bb5198ba99e6a5a5