### PR TITLE
Fix Board effect deps and Header test

### DIFF
--- a/client/src/components/Header.test.js
+++ b/client/src/components/Header.test.js
@@ -1,4 +1,5 @@
 import { render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
 import Header from './Header';
 
 beforeEach(() => {
@@ -29,7 +30,11 @@ afterEach(() => {
 });
 
 test('displays weather info in header', async () => {
-  render(<Header onToggleSidebar={() => {}} />);
+  render(
+    <MemoryRouter>
+      <Header onToggleSidebar={() => {}} />
+    </MemoryRouter>
+  );
   await waitFor(() => screen.getByText(/맑음/));
   expect(screen.getByText('맑음')).toBeInTheDocument();
   expect(screen.getByText('20℃ 맑음 없음')).toBeInTheDocument();

--- a/client/src/pages/Board.js
+++ b/client/src/pages/Board.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useState, useCallback } from 'react';
 import { useParams } from 'react-router-dom';
 
 function Board() {
@@ -11,7 +11,7 @@ function Board() {
   const [page, setPage] = useState(1);
   const [total, setTotal] = useState(0);
 
-  const loadPosts = async () => {
+  const loadPosts = useCallback(async () => {
     const params = new URLSearchParams();
     params.set('board', board);
     params.set('page', page);
@@ -24,11 +24,11 @@ function Board() {
       setPosts(data.data || []);
       setTotal(data.total || 0);
     }
-  };
+  }, [board, page, search]);
 
   useEffect(() => {
     loadPosts();
-  }, [board, page, search]);
+  }, [loadPosts]);
 
   const onChange = (e) => {
     setForm({ ...form, [e.target.name]: e.target.value });


### PR DESCRIPTION
## Summary
- refactor `loadPosts` with useCallback and adjust effect dependencies
- wrap `Header` tests in `MemoryRouter`

## Testing
- `npm --prefix client test` *(fails: react-scripts not found)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ff042ddcc8329a0a2d5982cdb2c7e