### PR TITLE
Add weather seed script

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,18 @@ Korean Meteorological Administration using `WEATHER_API_KEY`. An accompanying
 
 
 Server-side requests use `node-fetch`, which is listed in `package.json`.
+
+### Initializing sample weather data
+
+Run the script below once to create the `weather` collection with an example
+document. The script respects `MONGO_URI` and `DB_NAME` environment variables:
+
+```bash
+node scripts/init_weather.js
+```
+
+This inserts a document for `2025-06-25` so the weather API endpoints return
+data even before the daily cron job populates the database.
 =======
 
 

--- a/scripts/init_weather.js
+++ b/scripts/init_weather.js
@@ -1,0 +1,38 @@
+const { MongoClient } = require('mongodb');
+require('dotenv').config();
+
+async function main() {
+  const uri = process.env.MONGO_URI || 'mongodb://localhost:27017';
+  const dbName = process.env.DB_NAME || 'testdb';
+
+  const client = new MongoClient(uri);
+  try {
+    await client.connect();
+    const db = client.db(dbName);
+    const weatherColl = db.collection('weather');
+
+    const sample = {
+      _id: '20250625',
+      year: 2025,
+      month: 6,
+      day: 25,
+      temp: 22.5,
+      rain: 0.2,
+      updatedAt: new Date(),
+    };
+
+    await weatherColl.updateOne(
+      { _id: sample._id },
+      { $set: sample },
+      { upsert: true },
+    );
+
+    console.log('✅ weather sample inserted or updated');
+  } catch (err) {
+    console.error('❌ init_weather failed:', err.message);
+  } finally {
+    await client.close();
+  }
+}
+
+main();


### PR DESCRIPTION
## Summary
- add script `scripts/init_weather.js` to create sample weather data
- document the script in README

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: definition for rule 'react-hooks/exhaustive-deps' not found)*

------
https://chatgpt.com/codex/tasks/task_e_6860f04f371883298a307255f57d01ed