### PR TITLE
Fix weather API key encoding

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,9 @@
+MONGO_URI=mongodb://127.0.0.1:27017
+DB_NAME=forum
+SESSION_SECRET=changeme
+WEATHER_API_KEY=your-decoded-weather-api-key
+CP_ACCESS_KEY=your-coupang-access-key
+CP_SECRET_KEY=your-coupang-secret-key
+CP_VENDOR_ID=your-coupang-vendor-id
+CP_API_HOST=https://api-gateway.coupang.com
+CP_RG_AUTH_TOKEN=your-rocketgross-token

--- a/controllers/weatherController.js
+++ b/controllers/weatherController.js
@@ -7,7 +7,7 @@ async function fetchDaily(date, time = '1200', nx = '60', ny = '127') {
     throw new Error('WEATHER_API_KEY not configured');
   }
 
-  const serviceKey = encodeURIComponent(process.env.WEATHER_API_KEY);
+  const serviceKey = process.env.WEATHER_API_KEY;
 
   const params = new URLSearchParams({
     serviceKey,


### PR DESCRIPTION
## Summary
- use raw weather API key instead of URI encoded value
- provide sample `.env` with decoded API key

## Testing
- `npm test` *(fails: jest not found)*
- `node server.js` *(fails: cannot find module 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_6860f37370dc83298912060431cc0905