### PR TITLE
Fix DataTables loading order

### DIFF
--- a/client/public/index.html
+++ b/client/public/index.html
@@ -21,11 +21,11 @@
       rel="stylesheet"
     />
     <link
-      href="https://cdn.datatables.net/2.3.2/css/dataTables.bootstrap5.min.css"
+      href="https://cdn.datatables.net/1.13.6/css/dataTables.bootstrap5.min.css"
       rel="stylesheet"
     />
     <link
-      href="https://cdn.datatables.net/fixedheader/4.0.1/css/fixedHeader.bootstrap5.min.css"
+      href="https://cdn.datatables.net/fixedheader/3.4.0/css/fixedHeader.bootstrap5.min.css"
       rel="stylesheet"
     />
     <link
@@ -49,9 +49,9 @@
     <!-- Bootstrap JS -->
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.6/dist/js/bootstrap.bundle.min.js"></script>
     <script src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
-    <script src="https://cdn.datatables.net/2.3.2/js/jquery.dataTables.min.js"></script>
-    <script src="https://cdn.datatables.net/2.3.2/js/dataTables.bootstrap5.min.js"></script>
-    <script src="https://cdn.datatables.net/fixedheader/4.0.1/js/dataTables.fixedHeader.min.js"></script>
+    <script src="https://cdn.datatables.net/1.13.6/js/jquery.dataTables.min.js"></script>
+    <script src="https://cdn.datatables.net/1.13.6/js/dataTables.bootstrap5.min.js"></script>
+    <script src="https://cdn.datatables.net/fixedheader/3.4.0/js/dataTables.fixedHeader.min.js"></script>
     <script src="https://cdn.datatables.net/buttons/2.4.2/js/dataTables.buttons.min.js"></script>
     <script src="https://cdn.datatables.net/buttons/2.4.2/js/buttons.bootstrap5.min.js"></script>
     <script src="https://cdn.datatables.net/buttons/2.4.2/js/buttons.html5.min.js"></script>


### PR DESCRIPTION
## Summary
- align DataTables script and CSS versions in React client
- keep DataTables extensions loaded after jQuery

## Testing
- `npm test` *(fails: jest not found)*
- `npm ci` *(fails: network access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6860f5adde2083299b6965eb9db31ca0