### PR TITLE
Implement DB-based monthly weather storage and upload feature

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -10,6 +10,7 @@ import CoupangStock from './pages/CoupangStock';
 import Login from './pages/Login';
 import Register from './pages/Register';
 import Weather from './pages/Weather';
+import WeatherUpload from './pages/WeatherUpload';
 import Dashboard from './pages/Dashboard';
 import DashboardLayout from './pages/DashboardLayout';
 import Board from './pages/Board';
@@ -39,6 +40,7 @@ function App() {
           <Route path="/coupang/stock" element={<CoupangStock />} />
           <Route path="/coupang-add" element={<CoupangAdd />} />
           <Route path="/weather" element={<Weather />} />
+          <Route path="/weather/upload" element={<WeatherUpload />} />
           <Route path="/:shop/:section" element={<Placeholder />} />
         </Route>
       </Routes>

--- a/client/src/pages/WeatherUpload.js
+++ b/client/src/pages/WeatherUpload.js
@@ -1,0 +1,34 @@
+import React, { useRef } from 'react';
+
+function WeatherUpload() {
+  const formRef = useRef(null);
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    const formData = new FormData(formRef.current);
+    const res = await fetch('/api/weather/upload', {
+      method: 'POST',
+      body: formData,
+      credentials: 'include',
+    });
+    if (res.ok) {
+      alert('업로드 완료');
+      formRef.current.reset();
+    } else {
+      const err = await res.text();
+      alert('업로드 실패: ' + err);
+    }
+  };
+
+  return (
+    <div className="container my-5">
+      <h2 className="fw-bold mb-4">월별 날씨 업로드</h2>
+      <form ref={formRef} onSubmit={handleSubmit} encType="multipart/form-data" className="d-flex gap-2">
+        <input type="file" name="excelFile" accept=".xlsx,.xls" className="form-control" required />
+        <button type="submit" className="btn btn-primary">업로드</button>
+      </form>
+    </div>
+  );
+}
+
+export default WeatherUpload;

--- a/routes/api/weatherApi.js
+++ b/routes/api/weatherApi.js
@@ -6,5 +6,6 @@ router.get('/daily', ctrl.getDailyWeather);
 router.get('/same-day', ctrl.getSameDay);
 router.get('/monthly', ctrl.getMonthlyWeather);
 router.get('/average', ctrl.getAverageTemperature);
+router.post('/upload', ctrl.upload, ctrl.uploadMonthlyExcel);
 
 module.exports = router;

--- a/tests/weatherApi.test.js
+++ b/tests/weatherApi.test.js
@@ -91,10 +91,22 @@ test('GET /api/weather/same-day returns past years data', async () => {
 });
 
 test('GET /api/weather/monthly returns array of daily data', async () => {
+  mockCollection.find.mockReturnThis();
+  mockCollection.sort.mockReturnThis();
+  mockCollection.toArray.mockResolvedValueOnce([
+    { _id: '20240601', temperature: 20, sky: '1', precipitationType: '0' },
+  ]);
+
   const res = await request(app).get('/api/weather/monthly?year=2024&month=06');
   expect(res.statusCode).toBe(200);
-  expect(Array.isArray(res.body)).toBe(true);
-  expect(res.body.length).toBeGreaterThan(0);
+  expect(res.body).toEqual([
+    {
+      date: '2024-06-01',
+      temperature: 20,
+      sky: '1',
+      precipitationType: '0',
+    },
+  ]);
 });
 
 test('GET /api/weather/average returns average temperature', async () => {


### PR DESCRIPTION
## Summary
- add Excel upload endpoint for weather history
- fetch daily weather 30 minutes delayed by default
- store monthly weather data in `monthlyWeather` collection
- add React page for admin Excel uploads
- adjust tests for DB-based monthly results

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6861186254f88329ac4568d3d5a5129d