### PR TITLE
Add ad history routes

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -18,6 +18,7 @@ import SalesVolume from './pages/SalesVolume';
 import Help from './pages/Help';
 import AdminRoutes from './routes/AdminRoutes';
 import Placeholder from './pages/Placeholder';
+import AdHistory from './pages/AdHistory';
 
 function App() {
   return (
@@ -32,14 +33,16 @@ function App() {
           <Route path="/board" element={<Board />} />
           <Route path="/:shop/board" element={<Board />} />
           <Route path="/sales-amount" element={<SalesAmount />} />
-          <Route path="/sales-volume" element={<SalesVolume />} />
-          <Route path="/admin/*" element={<AdminRoutes />} />
-          <Route path="/stock" element={<Stock />} />
-          <Route path="/coupang" element={<Coupang />} />
-          <Route path="/coupang/stock" element={<CoupangStock />} />
-          <Route path="/coupang-add" element={<CoupangAdd />} />
-          <Route path="/weather" element={<Weather />} />
-          <Route path="/:shop/:section" element={<Placeholder />} />
+        <Route path="/sales-volume" element={<SalesVolume />} />
+        <Route path="/admin/*" element={<AdminRoutes />} />
+        <Route path="/stock" element={<Stock />} />
+        <Route path="/coupang" element={<Coupang />} />
+        <Route path="/coupang/stock" element={<CoupangStock />} />
+        <Route path="/coupang-add" element={<CoupangAdd />} />
+        <Route path="/ad-history" element={<AdHistory />} />
+        <Route path="/:shop/ad-history" element={<AdHistory />} />
+        <Route path="/weather" element={<Weather />} />
+        <Route path="/:shop/:section" element={<Placeholder />} />
         </Route>
       </Routes>
     </BrowserRouter>

--- a/client/src/components/Sidebar.js
+++ b/client/src/components/Sidebar.js
@@ -10,6 +10,7 @@ const navData = [
       { label: '재고관리', path: '/stock' },
       { label: '매출금액', path: '/sales-amount' },
       { label: '판매량', path: '/sales-volume' },
+      { label: '광고내역', path: '/ad-history' },
       { label: '관리자', path: '/admin' }
     ]
   },
@@ -20,6 +21,7 @@ const navData = [
       { label: '재고관리', path: '/try/stock' },
       { label: '매출금액', path: '/try/sales-amount' },
       { label: '판매량', path: '/try/sales-volume' },
+      { label: '광고내역', path: '/try/ad-history' },
       { label: '입고요청', path: '/try/inbound-request' }
     ]
   },
@@ -30,6 +32,7 @@ const navData = [
       { label: '재고관리', path: '/byc/stock' },
       { label: '매출금액', path: '/byc/sales-amount' },
       { label: '판매량', path: '/byc/sales-volume' },
+      { label: '광고내역', path: '/byc/ad-history' },
       { label: '입고요청', path: '/byc/inbound-request' }
     ]
   },
@@ -40,6 +43,7 @@ const navData = [
       { label: '재고관리', path: '/james-dean/stock' },
       { label: '매출금액', path: '/james-dean/sales-amount' },
       { label: '판매량', path: '/james-dean/sales-volume' },
+      { label: '광고내역', path: '/james-dean/ad-history' },
       { label: '입고요청', path: '/james-dean/inbound-request' }
     ]
   },
@@ -50,6 +54,7 @@ const navData = [
       { label: '재고관리', path: '/coupang/stock' },
       { label: '매출금액', path: '/coupang/sales-amount' },
       { label: '판매량', path: '/coupang/sales-volume' },
+      { label: '광고내역', path: '/coupang/ad-history' },
       { label: '입고요청', path: '/coupang/inbound-request' }
     ]
   },
@@ -60,6 +65,7 @@ const navData = [
       { label: '재고관리', path: '/naver/stock' },
       { label: '매출금액', path: '/naver/sales-amount' },
       { label: '판매량', path: '/naver/sales-volume' },
+      { label: '광고내역', path: '/naver/ad-history' },
       { label: '입고요청', path: '/naver/inbound-request' }
     ]
   }

--- a/client/src/pages/AdHistory.js
+++ b/client/src/pages/AdHistory.js
@@ -1,0 +1,111 @@
+import React, { useEffect, useState } from 'react';
+
+function AdHistory() {
+  const [rows, setRows] = useState([]);
+  const [form, setForm] = useState({ date: '', campaign: '', clicks: '', cost: '' });
+
+  const loadData = async () => {
+    const res = await fetch('/api/ad-history', { credentials: 'include' });
+    if (res.ok) {
+      const data = await res.json();
+      setRows(data || []);
+    }
+  };
+
+  useEffect(() => {
+    loadData();
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+
+  const onChange = (e) => {
+    setForm({ ...form, [e.target.name]: e.target.value });
+  };
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    await fetch('/api/ad-history', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      credentials: 'include',
+      body: JSON.stringify(form),
+    });
+    setForm({ date: '', campaign: '', clicks: '', cost: '' });
+    loadData();
+  };
+
+  return (
+    <div className="container">
+      <h2>광고 내역</h2>
+      <form onSubmit={handleSubmit} className="mb-3">
+        <div className="row g-2 mb-2">
+          <div className="col-auto">
+            <input
+              type="date"
+              name="date"
+              value={form.date}
+              onChange={onChange}
+              className="form-control"
+              required
+            />
+          </div>
+          <div className="col-auto">
+            <input
+              type="text"
+              name="campaign"
+              value={form.campaign}
+              onChange={onChange}
+              className="form-control"
+              placeholder="캠페인명"
+            />
+          </div>
+          <div className="col-auto">
+            <input
+              type="number"
+              name="clicks"
+              value={form.clicks}
+              onChange={onChange}
+              className="form-control"
+              placeholder="클릭수"
+            />
+          </div>
+          <div className="col-auto">
+            <input
+              type="number"
+              name="cost"
+              value={form.cost}
+              onChange={onChange}
+              className="form-control"
+              placeholder="광고비"
+            />
+          </div>
+          <div className="col-auto">
+            <button type="submit" className="btn btn-primary">
+              추가
+            </button>
+          </div>
+        </div>
+      </form>
+      <table className="table table-bordered text-center">
+        <thead>
+          <tr>
+            <th>날짜</th>
+            <th>캠페인명</th>
+            <th>클릭수</th>
+            <th>광고비</th>
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map((row) => (
+            <tr key={row._id}>
+              <td>{row.date}</td>
+              <td className="text-start">{row.campaign}</td>
+              <td>{row.clicks}</td>
+              <td>{row.cost}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+export default AdHistory;

--- a/controllers/adHistoryController.js
+++ b/controllers/adHistoryController.js
@@ -1,0 +1,67 @@
+const { ObjectId } = require('mongodb');
+const asyncHandler = require('../middlewares/asyncHandler');
+
+// 광고 내역 목록 조회
+exports.list = asyncHandler(async (req, res) => {
+  const db = req.app.locals.db;
+  const rows = await db
+    .collection('adHistory')
+    .find()
+    .sort({ date: -1 })
+    .toArray();
+  res.json(rows);
+});
+
+// 광고 내역 생성
+exports.create = asyncHandler(async (req, res) => {
+  const db = req.app.locals.db;
+  const doc = {
+    date: req.body.date || new Date().toISOString().slice(0, 10),
+    campaign: req.body.campaign || '',
+    clicks: Number(req.body.clicks) || 0,
+    cost: Number(req.body.cost) || 0,
+    createdAt: new Date(),
+  };
+  await db.collection('adHistory').insertOne(doc);
+  res.json({ success: true });
+});
+
+// 광고 내역 상세 조회
+exports.detail = asyncHandler(async (req, res) => {
+  const db = req.app.locals.db;
+  const row = await db
+    .collection('adHistory')
+    .findOne({ _id: new ObjectId(req.params.id) });
+  if (!row) return res.status(404).json({ message: 'Not found' });
+  res.json(row);
+});
+
+// 광고 내역 수정
+exports.update = asyncHandler(async (req, res) => {
+  const db = req.app.locals.db;
+  const result = await db.collection('adHistory').updateOne(
+    { _id: new ObjectId(req.params.id) },
+    {
+      $set: {
+        date: req.body.date,
+        campaign: req.body.campaign,
+        clicks: Number(req.body.clicks),
+        cost: Number(req.body.cost),
+      },
+    },
+  );
+  if (result.matchedCount === 0)
+    return res.status(404).json({ message: 'Not found' });
+  res.json({ success: true });
+});
+
+// 광고 내역 삭제
+exports.remove = asyncHandler(async (req, res) => {
+  const db = req.app.locals.db;
+  const result = await db
+    .collection('adHistory')
+    .deleteOne({ _id: new ObjectId(req.params.id) });
+  if (result.deletedCount === 0)
+    return res.status(404).json({ message: 'Not found' });
+  res.json({ success: true });
+});

--- a/routes/api/adHistory.js
+++ b/routes/api/adHistory.js
@@ -1,0 +1,11 @@
+const express = require('express');
+const router = express.Router();
+const ctrl = require('../../controllers/adHistoryController');
+
+router.get('/', ctrl.list);
+router.post('/', ctrl.create);
+router.get('/:id', ctrl.detail);
+router.put('/:id', ctrl.update);
+router.delete('/:id', ctrl.remove);
+
+module.exports = router;

--- a/routes/api/index.js
+++ b/routes/api/index.js
@@ -23,6 +23,8 @@ router.use("/coupang-open", require("./coupangOpenApi"));
 router.use("/weather", require("./weatherApi"));
 // 광고 성과 API
 router.use("/analytics", require("./analytics"));
+// 광고 내역 API
+router.use('/ad-history', require('./adHistory'));
 // 게시판 API
 router.use("/posts", require("./postApi"));
 // 게시판 목록 API

--- a/views/nav.ejs
+++ b/views/nav.ejs
@@ -33,6 +33,9 @@
               <a class="nav-link text-dark <%= currentUrl.startsWith('/coupang/add') ? 'active' : '' %>" href="/coupang/add">💰 매출/광고비</a>
             </li>
             <li class="nav-item">
+              <a class="nav-link text-dark <%= currentUrl.startsWith('/ad-history') ? 'active' : '' %>" href="/ad-history">📊 광고내역</a>
+            </li>
+            <li class="nav-item">
               <a class="nav-link text-dark <%= currentUrl.startsWith('/weather') ? 'active' : '' %>" href="/weather">🌤️ 날씨</a>
             </li>
             <li class="nav-item">


### PR DESCRIPTION
## Summary
- add `adHistory` API and controller
- link ad history route in EJS nav and React sidebar
- add React page and routes for ad history

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: react-hooks/exhaustive-deps rule missing)*

------
https://chatgpt.com/codex/tasks/task_e_6861197ff414832991e9c6b286b11df5