### PR TITLE
Implement Excel upload for historical weather

### DIFF
--- a/client/src/pages/Weather.js
+++ b/client/src/pages/Weather.js
@@ -8,6 +8,7 @@ function Weather() {
   const [date, setDate] = useState(now.toISOString().slice(0, 10));
   const [result, setResult] = useState(null);
   const [error, setError] = useState(null);
+  const [uploadMsg, setUploadMsg] = useState(null);
 
   const handleSearch = async () => {
     setError(null);
@@ -24,6 +25,21 @@ function Weather() {
     } catch (e) {
       setError('데이터 없음');
     }
+  };
+
+  const handleUpload = async (e) => {
+    setUploadMsg(null);
+    const file = e.target.files[0];
+    if (!file) return;
+    const formData = new FormData();
+    formData.append('excelFile', file);
+    const res = await fetch('/api/weather/upload', {
+      method: 'POST',
+      body: formData,
+      credentials: 'include',
+    });
+    setUploadMsg(res.ok ? '업로드 완료' : '업로드 실패');
+    e.target.value = '';
   };
 
   return (
@@ -84,6 +100,10 @@ function Weather() {
         </div>
       </div>
       <MonthlyWeatherChart year={year} month={month} />
+      <div className="mt-3">
+        <input type="file" accept=".xlsx,.xls" onChange={handleUpload} />
+        {uploadMsg && <p>{uploadMsg}</p>}
+      </div>
     </div>
   );
 }

--- a/routes/api/weatherApi.js
+++ b/routes/api/weatherApi.js
@@ -1,10 +1,13 @@
 const express = require('express');
 const router = express.Router();
 const ctrl = require('../../controllers/weatherController');
+const upload = require('../../upload');
 
 router.get('/daily', ctrl.getDailyWeather);
 router.get('/same-day', ctrl.getSameDay);
 router.get('/monthly', ctrl.getMonthlyWeather);
 router.get('/average', ctrl.getAverageTemperature);
+router.post('/upload', upload.single('excelFile'), ctrl.uploadMonthlyExcel);
+router.get('/history', ctrl.getHistory);
 
 module.exports = router;

--- a/tests/weatherApi.test.js
+++ b/tests/weatherApi.test.js
@@ -19,6 +19,12 @@ jest.mock('../config/db', () => {
 // Mock node-fetch
 jest.mock('node-fetch');
 const mockFetch = require('node-fetch');
+const path = require('path');
+
+jest.mock('xlsx', () => ({
+  readFile: jest.fn(() => ({ SheetNames: ['s'], Sheets: { s: {} } })),
+  utils: { sheet_to_json: jest.fn(() => [{ date: '2024-06-01', temperature: 20, sky: 1, precipitationType: 0 }]) },
+}));
 
 const request = require('supertest');
 const { initApp } = require('../server');
@@ -107,4 +113,24 @@ test('GET /api/weather/average returns average temperature', async () => {
     date: '2024-06-01',
     averageTemperature: '20.0',
   });
+});
+
+test('POST /api/weather/upload stores data', async () => {
+  mockCollection.bulkWrite = jest.fn().mockResolvedValue({});
+  const res = await request(app)
+    .post('/api/weather/upload')
+    .attach('excelFile', path.join(__dirname, 'fixtures', 'dummy.xlsx'));
+  expect(res.statusCode).toBe(200);
+  expect(mockCollection.bulkWrite).toHaveBeenCalled();
+});
+
+test('GET /api/weather/history returns stored docs', async () => {
+  mockCollection.find.mockReturnThis();
+  mockCollection.sort.mockReturnThis();
+  mockCollection.toArray.mockResolvedValueOnce([{ _id: '20240601' }]);
+  const res = await request(app).get(
+    '/api/weather/history?from=2024-06-01&to=2024-06-02',
+  );
+  expect(res.statusCode).toBe(200);
+  expect(res.body).toEqual([{ _id: '20240601' }]);
 });


### PR DESCRIPTION
## Summary
- add real-time adjustment for daily weather
- load or fetch monthly weather and store to MongoDB
- allow Excel upload and history query endpoints
- expose upload & history routes
- support uploading from React UI
- test new weather upload/history APIs

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68611c585b248329bbbfba6ae7132956