### PR TITLE
Implement weather upload/history APIs

### DIFF
--- a/routes/api/weatherApi.js
+++ b/routes/api/weatherApi.js
@@ -2,6 +2,8 @@ const express = require('express');
 const router = express.Router();
 const ctrl = require('../../controllers/weatherController');
 
+router.post('/upload', ctrl.upload, ctrl.uploadExcelApi);
+router.get('/history', ctrl.getHistory);
 router.get('/daily', ctrl.getDailyWeather);
 router.get('/same-day', ctrl.getSameDay);
 router.get('/monthly', ctrl.getMonthlyWeather);


### PR DESCRIPTION
## Summary
- allow weather uploads via Excel file
- add history query endpoint

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68611e049610832996a466f60848d38b