### PR TITLE
Fix 30-day sales fields parsing

### DIFF
--- a/lib/parseCoupangExcel.js
+++ b/lib/parseCoupangExcel.js
@@ -41,11 +41,15 @@ function parseCoupangExcel(filePath) {
       .replace(/\(.*?\)/g, '')
       .toLowerCase();
 
-  // 헤더명 검색 함수
+  // 헤더명 검색 함수 (부분 일치 허용)
   const findIndex = (names) =>
-    headers.findIndex((h) =>
-      names.some((n) => normalize(h) === normalize(n))
-    );
+    headers.findIndex((h) => {
+      const norm = normalize(h);
+      return names.some((n) => {
+        const target = normalize(n);
+        return norm === target || norm.includes(target);
+      });
+    });
 
   // 주요 열 인덱스
   const optionIdIdx = findIndex(['Option ID', '옵션ID']);
@@ -57,15 +61,21 @@ function parseCoupangExcel(filePath) {
   const salesAmountIdx = findIndex([
     'Sales amount on the last 30 days',
     'Sales amount in the last 30 days',
+    'Sales amount last 30 days',
     '30일 판매금액',
     '최근 30일 판매금액',
-    '최근30일판매금액'
+    '최근30일판매금액',
+    '최근 30일 매출금액',
+    '최근30일매출금액'
   ]);
   const salesCountIdx = findIndex([
     'Sales in the last 30 days',
+    'Sales of the last 30 days',
     '30일 판매량',
     '최근 30일 판매량',
-    '최근30일판매량'
+    '최근30일판매량',
+    '최근 30일 매출수량',
+    '최근30일매출수량'
   ]);
 
   // 본문 데이터 가공


### PR DESCRIPTION
## Summary
- improve header matching logic in `parseCoupangExcel`
- add more synonyms for sales amount and count columns

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: react-hooks/exhaustive-deps rule missing)*

------
https://chatgpt.com/codex/tasks/task_e_68611e45e5308329ab8ac91c1c106024