### PR TITLE
Refactor stock page with better UX

### DIFF
--- a/client/src/pages/Stock.css
+++ b/client/src/pages/Stock.css
@@ -24,3 +24,15 @@
 .stock-table tbody tr:hover {
   background-color: #eaeaea;
 }
+
+.stock-table th[role='button'] {
+  cursor: pointer;
+}
+
+.stock-table tbody tr.table-danger {
+  background-color: #ffecec;
+}
+
+.table-container {
+  overflow-x: auto;
+}


### PR DESCRIPTION
## Summary
- rework stock page data table using columns array
- add loading indicator and toast-like alert for uploads
- highlight editing rows and improve clickable headers
- style stock table for better responsiveness

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: Definition for rule 'react-hooks/exhaustive-deps' was not found)*

------
https://chatgpt.com/codex/tasks/task_e_686127e3d7f08329b6b741ebc2416f60