### PR TITLE
Add live Coupang stock tools

### DIFF
--- a/client/src/pages/CoupangStock.js
+++ b/client/src/pages/CoupangStock.js
@@ -1,9 +1,14 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
+
+const BRANDS = ['트라이', 'BYC', '제임스딘'];
 
 function CoupangStock() {
   const [rows, setRows] = useState([]);
   const [keyword, setKeyword] = useState('');
   const [brand, setBrand] = useState('');
+  const [sortCol, setSortCol] = useState('Product name');
+  const [sortDir, setSortDir] = useState('asc');
+  const fileRef = useRef(null);
 
   const loadData = async () => {
     const params = new URLSearchParams({
@@ -11,6 +16,8 @@ function CoupangStock() {
       limit: '100',
       keyword,
       brand,
+      sort: sortCol,
+      order: sortDir,
     });
     const res = await fetch(`/api/coupang?${params.toString()}`, {
       credentials: 'include',
@@ -21,22 +28,73 @@ function CoupangStock() {
     }
   };
 
+  const handleUpload = async (e) => {
+    e.preventDefault();
+    const formData = new FormData();
+    if (fileRef.current.files.length === 0) return;
+    formData.append('excelFile', fileRef.current.files[0]);
+    const res = await fetch('/api/coupang/upload', {
+      method: 'POST',
+      body: formData,
+      credentials: 'include',
+    });
+    if (res.ok) {
+      loadData();
+    } else {
+      alert('업로드 실패');
+    }
+  };
+
+  const handleDeleteAll = async () => {
+    if (!window.confirm('모든 데이터를 삭제하시겠습니까?')) return;
+    const res = await fetch('/api/coupang', {
+      method: 'DELETE',
+      credentials: 'include',
+    });
+    if (res.ok) {
+      loadData();
+    } else {
+      alert('삭제 실패');
+    }
+  };
+
+  const changeSort = (col) => {
+    if (sortCol === col) {
+      setSortDir((d) => (d === 'asc' ? 'desc' : 'asc'));
+    } else {
+      setSortCol(col);
+      setSortDir('asc');
+    }
+  };
+
   useEffect(() => {
-    loadData();
-  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+    const t = setTimeout(() => {
+      loadData();
+    }, 300);
+    return () => clearTimeout(t);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [keyword, brand, sortCol, sortDir]);
 
   return (
     <div className="container">
       <h2>쿠팡 재고</h2>
+      <form onSubmit={handleUpload} className="d-flex gap-2 mb-3">
+        <input type="file" ref={fileRef} className="form-control" accept=".xlsx,.xls" />
+        <button type="submit" className="btn btn-success">엑셀 업로드</button>
+        <button type="button" onClick={handleDeleteAll} className="btn btn-danger ms-auto">
+          데이터 초기화
+        </button>
+      </form>
       <div className="row g-2 mb-3">
         <div className="col">
-          <input
-            type="text"
-            className="form-control"
-            placeholder="브랜드"
-            value={brand}
-            onChange={(e) => setBrand(e.target.value)}
-          />
+          <select className="form-select" value={brand} onChange={(e) => setBrand(e.target.value)}>
+            <option value="">전체 브랜드</option>
+            {BRANDS.map((b) => (
+              <option key={b} value={b}>
+                {b}
+              </option>
+            ))}
+          </select>
         </div>
         <div className="col">
           <input
@@ -47,23 +105,34 @@ function CoupangStock() {
             onChange={(e) => setKeyword(e.target.value)}
           />
         </div>
-        <div className="col">
-          <button className="btn btn-outline-primary w-100" onClick={loadData}>
-            검색
-          </button>
-        </div>
       </div>
-      <table className="table table-bordered text-center">
+      <table className="table table-bordered text-center auto-width">
         <thead>
           <tr>
-            <th>옵션ID</th>
-            <th>상품명</th>
-            <th>옵션명</th>
-            <th>상품상태</th>
-            <th>재고량</th>
-            <th>30일 판매금액</th>
-            <th>30일 판매량</th>
-            <th>부족재고량</th>
+            <th onClick={() => changeSort('Option ID')} role="button">
+              옵션ID {sortCol === 'Option ID' && (sortDir === 'asc' ? '▲' : '▼')}
+            </th>
+            <th onClick={() => changeSort('Product name')} role="button">
+              상품명 {sortCol === 'Product name' && (sortDir === 'asc' ? '▲' : '▼')}
+            </th>
+            <th onClick={() => changeSort('Option name')} role="button">
+              옵션명 {sortCol === 'Option name' && (sortDir === 'asc' ? '▲' : '▼')}
+            </th>
+            <th onClick={() => changeSort('Offer condition')} role="button">
+              상품상태 {sortCol === 'Offer condition' && (sortDir === 'asc' ? '▲' : '▼')}
+            </th>
+            <th onClick={() => changeSort('Orderable quantity (real-time)')} role="button">
+              재고량 {sortCol === 'Orderable quantity (real-time)' && (sortDir === 'asc' ? '▲' : '▼')}
+            </th>
+            <th onClick={() => changeSort('Sales amount on the last 30 days')} role="button">
+              30일 판매금액 {sortCol === 'Sales amount on the last 30 days' && (sortDir === 'asc' ? '▲' : '▼')}
+            </th>
+            <th onClick={() => changeSort('Sales in the last 30 days')} role="button">
+              30일 판매량 {sortCol === 'Sales in the last 30 days' && (sortDir === 'asc' ? '▲' : '▼')}
+            </th>
+            <th onClick={() => changeSort('Shortage quantity')} role="button">
+              부족재고량 {sortCol === 'Shortage quantity' && (sortDir === 'asc' ? '▲' : '▼')}
+            </th>
           </tr>
         </thead>
         <tbody>

--- a/routes/api/coupangApi.js
+++ b/routes/api/coupangApi.js
@@ -29,6 +29,10 @@ router.get("/", async (req, res) => {
     const skip = (page - 1) * limit;
     const keyword = req.query.keyword || "";
     const brand = req.query.brand || "";
+    const sortField = DEFAULT_COLUMNS.includes(req.query.sort)
+      ? req.query.sort
+      : "Product name";
+    const sortOrder = req.query.order === "desc" ? -1 : 1;
 
     const conditions = [];
     if (keyword) {
@@ -51,6 +55,7 @@ router.get("/", async (req, res) => {
       db
         .collection("coupang")
         .find(query)
+        .sort({ [sortField]: sortOrder })
         .skip(skip)
         .limit(limit)
         .toArray(),

--- a/routes/web/coupang.js
+++ b/routes/web/coupang.js
@@ -14,7 +14,7 @@ if (!fs.existsSync(uploadsDir)) fs.mkdirSync(uploadsDir);
 const upload = multer({ dest: uploadsDir });
 
 // 검색 가능한 브랜드 목록
-const BRANDS = ["BYC", "트라이", "제임스딘", "스페클로", "물랑루즈"];
+const BRANDS = ["트라이", "BYC", "제임스딘"];
 
 const 한글 = {
   "Option ID": "옵션ID",


### PR DESCRIPTION
## Summary
- add sorting to Coupang API
- restrict Coupang brands to 트라이, BYC and 제임스딘
- enhance React Coupang stock page with upload, reset, live search and sort

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: react-hooks/exhaustive-deps rule missing)*

------
https://chatgpt.com/codex/tasks/task_e_686128cef3008329babf2e8a9bdff1d1