### PR TITLE
Add item management API and React page

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -20,6 +20,7 @@ import Help from './pages/Help';
 import AdminRoutes from './routes/AdminRoutes';
 import Placeholder from './pages/Placeholder';
 import AdHistory from './pages/AdHistory';
+import Items from './pages/Items';
 
 function App() {
   return (
@@ -45,6 +46,7 @@ function App() {
         <Route path="/ad-history" element={<AdHistory />} />
         <Route path="/:shop/ad-history" element={<AdHistory />} />
         <Route path="/weather" element={<Weather />} />
+        <Route path="/items" element={<Items />} />
         <Route path="/:shop/:section" element={<Placeholder />} />
         </Route>
       </Routes>

--- a/client/src/pages/Items.js
+++ b/client/src/pages/Items.js
@@ -1,0 +1,106 @@
+import React, { useEffect, useState } from 'react';
+
+function Items() {
+  const [items, setItems] = useState([]);
+  const [form, setForm] = useState({ name: '', price: '' });
+  const [editing, setEditing] = useState(null);
+
+  const fetchItems = async () => {
+    const res = await fetch('/api/items', { credentials: 'include' });
+    if (res.ok) {
+      const data = await res.json();
+      setItems(data);
+    }
+  };
+
+  useEffect(() => {
+    fetchItems();
+  }, []);
+
+  const handleChange = (e) => {
+    const { name, value } = e.target;
+    setForm((prev) => ({ ...prev, [name]: value }));
+  };
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    const method = editing ? 'PUT' : 'POST';
+    const url = editing ? `/api/items/${editing._id}` : '/api/items';
+    const res = await fetch(url, {
+      method,
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name: form.name, price: Number(form.price) }),
+      credentials: 'include',
+    });
+    if (res.ok) {
+      setForm({ name: '', price: '' });
+      setEditing(null);
+      fetchItems();
+    }
+  };
+
+  const handleEdit = (item) => {
+    setEditing(item);
+    setForm({ name: item.name, price: item.price });
+  };
+
+  const handleDelete = async (id) => {
+    const res = await fetch(`/api/items/${id}`, { method: 'DELETE', credentials: 'include' });
+    if (res.ok) fetchItems();
+  };
+
+  return (
+    <div className="container my-5">
+      <h2 className="mb-4">Items</h2>
+      <form onSubmit={handleSubmit} className="mb-3 d-flex gap-2">
+        <input
+          name="name"
+          value={form.name}
+          onChange={handleChange}
+          placeholder="Name"
+          className="form-control"
+          required
+        />
+        <input
+          name="price"
+          type="number"
+          value={form.price}
+          onChange={handleChange}
+          placeholder="Price"
+          className="form-control"
+          required
+        />
+        <button className="btn btn-primary" type="submit">
+          {editing ? 'Update' : 'Add'}
+        </button>
+      </form>
+      <ul className="list-group">
+        {items.map((item) => (
+          <li key={item._id} className="list-group-item d-flex justify-content-between">
+            <span>
+              {item.name} - {item.price}
+            </span>
+            <span>
+              <button
+                type="button"
+                className="btn btn-sm btn-secondary me-2"
+                onClick={() => handleEdit(item)}
+              >
+                Edit
+              </button>
+              <button
+                type="button"
+                className="btn btn-sm btn-danger"
+                onClick={() => handleDelete(item._id)}
+              >
+                Delete
+              </button>
+            </span>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+export default Items;

--- a/controllers/itemApiController.js
+++ b/controllers/itemApiController.js
@@ -1,0 +1,37 @@
+const { ObjectId } = require('mongodb');
+const asyncHandler = require('../middlewares/asyncHandler');
+
+// Get all items
+exports.list = asyncHandler(async (req, res) => {
+  const items = await req.app.locals.db.collection('items').find().toArray();
+  res.json(items);
+});
+
+// Create new item
+exports.create = asyncHandler(async (req, res) => {
+  const { name, price } = req.body;
+  const item = { name, price: Number(price), createdAt: new Date() };
+  const result = await req.app.locals.db.collection('items').insertOne(item);
+  item._id = result.insertedId;
+  res.json(item);
+});
+
+// Update existing item
+exports.update = asyncHandler(async (req, res) => {
+  const { id } = req.params;
+  const { name, price } = req.body;
+  const result = await req.app.locals.db.collection('items').updateOne(
+    { _id: new ObjectId(id) },
+    { $set: { name, price: Number(price) } },
+  );
+  if (result.matchedCount === 0) return res.status(404).json({ message: 'Item not found' });
+  res.json({ success: true });
+});
+
+// Delete an item
+exports.remove = asyncHandler(async (req, res) => {
+  const { id } = req.params;
+  const result = await req.app.locals.db.collection('items').deleteOne({ _id: new ObjectId(id) });
+  if (result.deletedCount === 0) return res.status(404).json({ message: 'Item not found' });
+  res.json({ success: true });
+});

--- a/routes/api/index.js
+++ b/routes/api/index.js
@@ -31,6 +31,8 @@ router.use("/posts", require("./postApi"));
 router.use("/comments", require("./commentApi"));
 // 게시판 목록 API
 router.use("/boards", require("./boardApi"));
+// Items CRUD API
+router.use('/items', require('./itemApi'));
 
 // TODO: 다른 API 라우터 추가 시 아래와 같이 등록
 // router.use("/user", require("./userApi"));

--- a/routes/api/itemApi.js
+++ b/routes/api/itemApi.js
@@ -1,0 +1,10 @@
+const express = require('express');
+const router = express.Router();
+const ctrl = require('../../controllers/itemApiController');
+
+router.get('/', ctrl.list);
+router.post('/', ctrl.create);
+router.put('/:id', ctrl.update);
+router.delete('/:id', ctrl.remove);
+
+module.exports = router;

--- a/tests/itemApi.test.js
+++ b/tests/itemApi.test.js
@@ -1,0 +1,65 @@
+jest.setTimeout(60000);
+
+const mockCollection = {
+  find: jest.fn().mockReturnThis(),
+  toArray: jest.fn().mockResolvedValue([]),
+  insertOne: jest.fn().mockResolvedValue({ insertedId: '1' }),
+  updateOne: jest.fn().mockResolvedValue({ matchedCount: 1 }),
+  deleteOne: jest.fn().mockResolvedValue({ deletedCount: 1 }),
+};
+
+jest.mock('../config/db', () => {
+  const mockDb = { collection: jest.fn(() => mockCollection) };
+  const mockConnect = jest.fn().mockResolvedValue(mockDb);
+  mockConnect.then = (fn) => fn(mockDb);
+  return { connectDB: mockConnect, closeDB: jest.fn().mockResolvedValue() };
+});
+
+const request = require('supertest');
+const { initApp } = require('../server');
+const { closeDB } = require('../config/db');
+
+let app;
+
+beforeAll(async () => {
+  process.env.NODE_ENV = 'test';
+  process.env.MONGO_URI = 'mongodb://127.0.0.1:27017/testdb';
+  process.env.DB_NAME = 'testdb';
+  process.env.SESSION_SECRET = 'testsecret';
+
+  app = await initApp();
+});
+
+afterAll(async () => {
+  await closeDB();
+});
+
+test('GET /api/items returns list', async () => {
+  const res = await request(app).get('/api/items');
+  expect(res.statusCode).toBe(200);
+  expect(Array.isArray(res.body)).toBe(true);
+  expect(mockCollection.find).toHaveBeenCalled();
+});
+
+test('POST /api/items creates item', async () => {
+  const res = await request(app).post('/api/items').send({ name: 'A', price: 1 });
+  expect(res.statusCode).toBe(200);
+  expect(res.body).toMatchObject({ name: 'A', price: 1, _id: '1' });
+  expect(mockCollection.insertOne).toHaveBeenCalled();
+});
+
+test('PUT /api/items/:id updates item', async () => {
+  const res = await request(app)
+    .put('/api/items/1')
+    .send({ name: 'B', price: 2 });
+  expect(res.statusCode).toBe(200);
+  expect(res.body).toEqual({ success: true });
+  expect(mockCollection.updateOne).toHaveBeenCalled();
+});
+
+test('DELETE /api/items/:id removes item', async () => {
+  const res = await request(app).delete('/api/items/1');
+  expect(res.statusCode).toBe(200);
+  expect(res.body).toEqual({ success: true });
+  expect(mockCollection.deleteOne).toHaveBeenCalled();
+});


### PR DESCRIPTION
## Summary
- create CRUD API for generic items
- register new API route under `/api/items`
- add Items React page and route
- cover new API with Jest tests

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: plugin not found)*

------
https://chatgpt.com/codex/tasks/task_e_68612a6380c48329b4390208f4f78078