### PR TITLE
Integrate React post pages and item API

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,6 +244,12 @@ client authenticates by sending credentials to the Express endpoint
 
 The Help page has also been converted to React and is accessible at `/help`.
 
+### Post pages migrated to React
+Legacy EJS templates under `/post` are now served by the React client. Visiting
+`/post`, `/post/write` or a detail page loads `client/public/index.html`. CRUD
+operations continue to use the `/api/posts` endpoints so the frontend can evolve
+independently of Express routes.
+
 ### Board management API
 Boards are stored in the `board` collection. CRUD operations are available via
 `/api/boards`. A simple management page is located at `/admin/boards` in the

--- a/controllers/itemController.js
+++ b/controllers/itemController.js
@@ -1,0 +1,23 @@
+const Item = require('../models/Item');
+
+exports.listItems = async (req, res) => {
+  const items = await Item.find().lean();
+  res.json(items);
+};
+
+exports.getItem = async (req, res) => {
+  const item = await Item.findById(req.params.id).lean();
+  if (!item) return res.status(404).json({ message: 'Not found' });
+  res.json(item);
+};
+
+exports.createItem = async (req, res) => {
+  const item = await Item.create(req.body);
+  res.status(201).json(item);
+};
+
+exports.updateItem = async (req, res) => {
+  const item = await Item.findByIdAndUpdate(req.params.id, req.body, { new: true }).lean();
+  if (!item) return res.status(404).json({ message: 'Not found' });
+  res.json(item);
+};

--- a/models/Item.js
+++ b/models/Item.js
@@ -1,0 +1,9 @@
+const mongoose = require('mongoose');
+
+const itemSchema = new mongoose.Schema({
+  name: { type: String, required: true },
+  price: { type: Number, required: true },
+  createdAt: { type: Date, default: Date.now },
+});
+
+module.exports = mongoose.model('Item', itemSchema);

--- a/routes/api/index.js
+++ b/routes/api/index.js
@@ -21,6 +21,8 @@ router.use("/coupang-add", require("./coupangAddApi"));
 router.use("/coupang-open", require("./coupangOpenApi"));
 // 날씨 API
 router.use("/weather", require("./weatherApi"));
+// 간단한 Item API
+router.use('/items', require('./itemApi'));
 // 광고 성과 API
 router.use("/analytics", require("./analytics"));
 // 광고 내역 API

--- a/routes/api/itemApi.js
+++ b/routes/api/itemApi.js
@@ -1,0 +1,10 @@
+const express = require('express');
+const router = express.Router();
+const itemCtrl = require('../../controllers/itemController');
+
+router.get('/', itemCtrl.listItems);
+router.get('/:id', itemCtrl.getItem);
+router.post('/', itemCtrl.createItem);
+router.put('/:id', itemCtrl.updateItem);
+
+module.exports = router;

--- a/routes/web/post.js
+++ b/routes/web/post.js
@@ -1,13 +1,16 @@
 const express = require('express');
+const path = require('path');
 const router = express.Router();
 const upload = require('../../upload.js');
 const postController = require('../../controllers/postController');
 
-router.get(['/', '/:page'], postController.listPosts);
-router.get('/write', postController.renderWritePage);
+// React page routes
+router.get(['/', '/:page', '/write', '/detail/:id', '/edit/:id'], (req, res) => {
+  res.sendFile(path.join(__dirname, '../../client/public/index.html'));
+});
+
+// API actions remain
 router.post('/add', upload.single('img1'), postController.addPost);
-router.get('/detail/:id', postController.viewPost);
-router.get('/edit/:id', postController.renderEditPage);
 router.put('/edit', postController.updatePost);
 router.delete('/delete', postController.deletePost);
 router.post('/comment/add', postController.addComment);


### PR DESCRIPTION
## Summary
- serve React for `/post` routes
- add Item Mongoose model and controller
- expose `/api/items` endpoints
- document React migration in README

## Testing
- `npm test` *(fails: jest not found due to offline environment)*

------
https://chatgpt.com/codex/tasks/task_e_68612ba554e48329a790d4a6040f70d9