### PR TITLE
Fix Header prop-types lint error

### DIFF
--- a/client/src/components/Header.js
+++ b/client/src/components/Header.js
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from "react";
+import PropTypes from "prop-types";
 import { Link } from "react-router-dom";
 import "./Header.css";
 
@@ -58,3 +59,7 @@ function Header({ onToggleSidebar }) {
 }
 
 export default Header;
+
+Header.propTypes = {
+  onToggleSidebar: PropTypes.func.isRequired,
+};


### PR DESCRIPTION
## Summary
- validate Header component props

## Testing
- `npm run lint` in `client`
- `npm test` *(fails: jest not found)*
- `npm test -- --watchAll=false` in `client` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_686204b4a96c8329ba1ebd8930b96b71