### PR TITLE
Add monthly weather excel upload

### DIFF
--- a/client/src/pages/Weather.js
+++ b/client/src/pages/Weather.js
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useRef } from 'react';
 import MonthlyWeatherChart from '../MonthlyWeatherChart';
 
 function Weather() {
@@ -8,6 +8,11 @@ function Weather() {
   const [date, setDate] = useState(now.toISOString().slice(0, 10));
   const [result, setResult] = useState(null);
   const [error, setError] = useState(null);
+  const fileRef = useRef(null);
+  const [uploadMsg, setUploadMsg] = useState(null);
+  const [dbYear, setDbYear] = useState(now.getFullYear());
+  const [dbMonth, setDbMonth] = useState(now.getMonth() + 1);
+  const [records, setRecords] = useState([]);
 
   const handleSearch = async () => {
     setError(null);
@@ -23,6 +28,38 @@ function Weather() {
       setResult(data);
     } catch (e) {
       setError('데이터 없음');
+    }
+  };
+
+  const handleUpload = async (e) => {
+    e.preventDefault();
+    if (!fileRef.current || fileRef.current.files.length === 0) return;
+    const formData = new FormData();
+    formData.append('excelFile', fileRef.current.files[0]);
+    const res = await fetch('/api/weather/upload', {
+      method: 'POST',
+      body: formData,
+      credentials: 'include',
+    });
+    if (res.ok) {
+      setUploadMsg('업로드 완료');
+      fileRef.current.value = '';
+    } else {
+      setUploadMsg('업로드 실패');
+    }
+    setTimeout(() => setUploadMsg(null), 3000);
+  };
+
+  const handleDbSearch = async () => {
+    const res = await fetch(
+      `/api/weather/monthly-db?year=${dbYear}&month=${dbMonth}`,
+      { credentials: 'include' },
+    );
+    if (res.ok) {
+      const data = await res.json();
+      setRecords(data);
+    } else {
+      setRecords([]);
     }
   };
 
@@ -62,6 +99,12 @@ function Weather() {
         </table>
       )}
       <hr />
+      <h2>엑셀 업로드</h2>
+      <form onSubmit={handleUpload} className="d-flex gap-2 mb-3" encType="multipart/form-data">
+        <input type="file" ref={fileRef} className="form-control" accept=".xlsx,.xls" />
+        <button type="submit" className="btn btn-success">업로드</button>
+      </form>
+      {uploadMsg && <p>{uploadMsg}</p>}
       <h2>월별 날씨</h2>
       <div className="row g-2 mb-3">
         <div className="col">
@@ -84,6 +127,50 @@ function Weather() {
         </div>
       </div>
       <MonthlyWeatherChart year={year} month={month} />
+      <h2 className="mt-4">업로드 데이터 조회</h2>
+      <div className="row g-2 mb-3">
+        <div className="col">
+          <input
+            type="number"
+            className="form-control"
+            value={dbYear}
+            onChange={(e) => setDbYear(e.target.value)}
+          />
+        </div>
+        <div className="col">
+          <input
+            type="number"
+            min="1"
+            max="12"
+            className="form-control"
+            value={dbMonth}
+            onChange={(e) => setDbMonth(e.target.value)}
+          />
+        </div>
+        <div className="col-auto">
+          <button type="button" className="btn btn-primary" onClick={handleDbSearch}>
+            조회
+          </button>
+        </div>
+      </div>
+      {records.length > 0 && (
+        <table className="table">
+          <thead>
+            <tr>
+              <th>날짜</th>
+              <th>기온</th>
+            </tr>
+          </thead>
+          <tbody>
+            {records.map((r) => (
+              <tr key={r._id}>
+                <td>{r.date || r._id}</td>
+                <td>{r.temperature ?? '-'}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
     </div>
   );
 }

--- a/routes/api/weatherApi.js
+++ b/routes/api/weatherApi.js
@@ -7,6 +7,7 @@ router.get('/history', ctrl.getHistory);
 router.get('/daily', ctrl.getDailyWeather);
 router.get('/same-day', ctrl.getSameDay);
 router.get('/monthly', ctrl.getMonthlyWeather);
+router.get('/monthly-db', ctrl.getMonthlyWeatherFromDb);
 router.get('/average', ctrl.getAverageTemperature);
 
 module.exports = router;


### PR DESCRIPTION
## Summary
- enable Excel-based weather uploads with xlsx
- allow querying stored monthly weather data
- expose upload and monthly-db endpoints
- update React weather page for uploads and DB search

## Testing
- `npm run lint`
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686205573f948329a0431adceefed595