### PR TITLE
Add React datatables for coupang pages

### DIFF
--- a/client/src/pages/AdHistory.js
+++ b/client/src/pages/AdHistory.js
@@ -1,20 +1,38 @@
 import React, { useEffect, useState } from 'react';
 
+/**
+ * 광고 내역을 조회하고 수정할 수 있는 테이블 페이지.
+ * 기본 리스트에 검색 및 정렬 기능을 추가한다.
+ */
+
 function AdHistory() {
   const [rows, setRows] = useState([]);
   const [form, setForm] = useState({ date: '', campaign: '', clicks: '', cost: '' });
+  const [keyword, setKeyword] = useState('');
+  const [sortField, setSortField] = useState('date');
+  const [sortDir, setSortDir] = useState('desc');
 
   const loadData = async () => {
     const res = await fetch('/api/ad-history', { credentials: 'include' });
     if (res.ok) {
       const data = await res.json();
-      setRows(data || []);
+      const filtered = data.filter((row) =>
+        row.campaign.toLowerCase().includes(keyword.toLowerCase()),
+      );
+      filtered.sort((a, b) => {
+        const valA = a[sortField];
+        const valB = b[sortField];
+        if (valA < valB) return sortDir === 'asc' ? -1 : 1;
+        if (valA > valB) return sortDir === 'asc' ? 1 : -1;
+        return 0;
+      });
+      setRows(filtered);
     }
   };
 
   useEffect(() => {
     loadData();
-  }, []); // eslint-disable-line
+  }, [keyword, sortField, sortDir]);
 
   const onChange = (e) => {
     setForm({ ...form, [e.target.name]: e.target.value });
@@ -35,6 +53,18 @@ function AdHistory() {
   return (
     <div className="container">
       <h2>광고 내역</h2>
+      <div className="input-group mb-3">
+        <input
+          type="text"
+          className="form-control"
+          placeholder="캠페인 검색"
+          value={keyword}
+          onChange={(e) => setKeyword(e.target.value)}
+        />
+        <button className="btn btn-outline-primary" onClick={loadData}>
+          검색
+        </button>
+      </div>
       <form onSubmit={handleSubmit} className="mb-3">
         <div className="row g-2 mb-2">
           <div className="col-auto">
@@ -87,10 +117,38 @@ function AdHistory() {
       <table className="table table-bordered text-center">
         <thead>
           <tr>
-            <th>날짜</th>
-            <th>캠페인명</th>
-            <th>클릭수</th>
-            <th>광고비</th>
+            <th
+              onClick={() => {
+                setSortField('date');
+                setSortDir((d) => (sortField === 'date' ? (d === 'asc' ? 'desc' : 'asc') : 'asc'));
+              }}
+            >
+              날짜 {sortField === 'date' ? (sortDir === 'asc' ? '▲' : '▼') : ''}
+            </th>
+            <th
+              onClick={() => {
+                setSortField('campaign');
+                setSortDir((d) => (sortField === 'campaign' ? (d === 'asc' ? 'desc' : 'asc') : 'asc'));
+              }}
+            >
+              캠페인명 {sortField === 'campaign' ? (sortDir === 'asc' ? '▲' : '▼') : ''}
+            </th>
+            <th
+              onClick={() => {
+                setSortField('clicks');
+                setSortDir((d) => (sortField === 'clicks' ? (d === 'asc' ? 'desc' : 'asc') : 'asc'));
+              }}
+            >
+              클릭수 {sortField === 'clicks' ? (sortDir === 'asc' ? '▲' : '▼') : ''}
+            </th>
+            <th
+              onClick={() => {
+                setSortField('cost');
+                setSortDir((d) => (sortField === 'cost' ? (d === 'asc' ? 'desc' : 'asc') : 'asc'));
+              }}
+            >
+              광고비 {sortField === 'cost' ? (sortDir === 'asc' ? '▲' : '▼') : ''}
+            </th>
           </tr>
         </thead>
         <tbody>
@@ -98,8 +156,8 @@ function AdHistory() {
             <tr key={row._id}>
               <td>{row.date}</td>
               <td className="text-start">{row.campaign}</td>
-              <td>{row.clicks}</td>
-              <td>{row.cost}</td>
+              <td>{Number(row.clicks).toLocaleString()}</td>
+              <td>{Number(row.cost).toLocaleString()}</td>
             </tr>
           ))}
         </tbody>

--- a/client/src/pages/CoupangAdd.js
+++ b/client/src/pages/CoupangAdd.js
@@ -1,25 +1,67 @@
 import React, { useEffect, useState } from 'react';
 
+/**
+ * 쿠팡 광고비 페이지 - React 버전
+ * 엑셀 업로드와 데이터 초기화 기능을 제공하며
+ * 서버의 DB 자료를 조회하여 테이블로 보여준다.
+ */
+
 function CoupangAdd() {
   const [rows, setRows] = useState([]);
   const [keyword, setKeyword] = useState('');
+  const [file, setFile] = useState(null);
 
   const loadData = async () => {
-    const params = new URLSearchParams({ start: '0', length: '100', search: keyword });
-    const res = await fetch(`/api/coupang-add?${params.toString()}`, { credentials: 'include' });
+    const params = new URLSearchParams({ start: '0', length: '1000', search: keyword });
+    const res = await fetch(`/api/coupang-add?${params.toString()}`, {
+      credentials: 'include',
+    });
     if (res.ok) {
       const data = await res.json();
       setRows(data.data || []);
     }
   };
 
+  const handleUpload = async (e) => {
+    e.preventDefault();
+    if (!file) return;
+    const formData = new FormData();
+    formData.append('excelFile', file);
+    await fetch('/api/coupang-add/upload', {
+      method: 'POST',
+      body: formData,
+      credentials: 'include',
+    });
+    setFile(null);
+    loadData();
+  };
+
+  const handleReset = async () => {
+    await fetch('/api/coupang-add', { method: 'DELETE', credentials: 'include' });
+    loadData();
+  };
+
   useEffect(() => {
     loadData();
-  }, []); // eslint-disable-line
+  }, []);
 
   return (
     <div className="container">
       <h2>쿠팡 매출/광고비</h2>
+      <form onSubmit={handleUpload} className="mb-3 d-flex gap-2">
+        <input
+          type="file"
+          className="form-control"
+          accept=".xlsx,.xls"
+          onChange={(e) => setFile(e.target.files[0])}
+        />
+        <button type="submit" className="btn btn-success">
+          엑셀 업로드
+        </button>
+        <button type="button" className="btn btn-danger" onClick={handleReset}>
+          데이터 초기화
+        </button>
+      </form>
       <div className="input-group mb-3">
         <input
           type="text"


### PR DESCRIPTION
## Summary
- convert coupang add page to React with upload & reset actions
- implement sortable/searchable ad history table

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686209f132908329b9ede7449c1f0de5