### PR TITLE
Add weather record API

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,18 @@ node scripts/init_weather.js
 
 This inserts a document for `2025-06-25` so the weather API endpoints return
 data even before the daily cron job populates the database.
+
+### Weather record API
+
+Individual weather entries can be managed via dedicated endpoints:
+
+- `POST /api/weather/record` – create or replace a record. Provide a `date`
+  like `2025-06-01` and optional fields such as `temperature`.
+- `GET /api/weather/record/:id` – fetch a single record by its `YYYYMMDD` id.
+- `PUT /api/weather/record/:id` – update an existing record.
+
+These endpoints allow the React client to add, modify and retrieve weather data
+stored in MongoDB.
 =======
 
 ## Weather API details

--- a/routes/api/weatherApi.js
+++ b/routes/api/weatherApi.js
@@ -9,5 +9,8 @@ router.get('/same-day', ctrl.getSameDay);
 router.get('/monthly', ctrl.getMonthlyWeather);
 router.get('/monthly-db', ctrl.getMonthlyWeatherFromDb);
 router.get('/average', ctrl.getAverageTemperature);
+router.post('/record', ctrl.createRecord);
+router.get('/record/:id', ctrl.getRecord);
+router.put('/record/:id', ctrl.updateRecord);
 
 module.exports = router;

--- a/tests/weatherApi.test.js
+++ b/tests/weatherApi.test.js
@@ -108,3 +108,34 @@ test('GET /api/weather/average returns average temperature', async () => {
     averageTemperature: '20.0',
   });
 });
+
+test('POST /api/weather/record creates or updates a record', async () => {
+  const res = await request(app)
+    .post('/api/weather/record')
+    .send({ date: '2025-06-01', temperature: 22.6 });
+  expect(res.statusCode).toBe(201);
+  expect(mockCollection.updateOne).toHaveBeenCalled();
+});
+
+test('GET /api/weather/record/:id returns a record', async () => {
+  mockCollection.findOne.mockResolvedValueOnce({
+    _id: '20250601',
+    temperature: 22.6,
+  });
+  const res = await request(app).get('/api/weather/record/20250601');
+  expect(res.statusCode).toBe(200);
+  expect(res.body).toEqual({ _id: '20250601', temperature: 22.6 });
+});
+
+test('PUT /api/weather/record/:id updates a record', async () => {
+  mockCollection.updateOne.mockResolvedValueOnce({ matchedCount: 1 });
+  mockCollection.findOne.mockResolvedValueOnce({
+    _id: '20250601',
+    temperature: 25.1,
+  });
+  const res = await request(app)
+    .put('/api/weather/record/20250601')
+    .send({ temperature: 25.1 });
+  expect(res.statusCode).toBe(200);
+  expect(res.body).toEqual({ _id: '20250601', temperature: 25.1 });
+});


### PR DESCRIPTION
## Summary
- create MongoDB API for weather records
- expose `/api/weather/record` routes
- document weather record API in README
- test POST/GET/PUT weather record endpoints

## Testing
- `npm test` *(fails: jest missing)*

------
https://chatgpt.com/codex/tasks/task_e_68623432f1e483298513c19464f5bd0d