### PR TITLE
Fix stock table actions and pagination

### DIFF
--- a/client/src/pages/Stock.js
+++ b/client/src/pages/Stock.js
@@ -119,9 +119,9 @@ function Stock() {
           onSubmit={handleUpload}
         >
           <input type="file" name="excelFile" accept=".xlsx,.xls" className="form-control" required />
-          <button type="submit" className="btn btn-success btn-upload">엑셀 업로드</button>
+          <button type="submit" className="btn btn-success btn-upload">업로드</button>
         </form>
-        <button onClick={handleRefresh} className="btn btn-danger btn-reset">데이터 초기화</button>
+        <button onClick={handleRefresh} className="btn btn-danger btn-reset">초기화</button>
       </div>
 
 
@@ -191,7 +191,7 @@ function Stock() {
           <table className="table table-bordered shadow-sm rounded bg-white align-middle text-center stock-table">
             <thead className="table-light">
               <tr>
-                <th>#</th>
+                <th># 순번</th>
                 {columns.map((col) => (
                   <th
                     key={col.key}

--- a/public/js/common-dt.js
+++ b/public/js/common-dt.js
@@ -1,3 +1,6 @@
+// limit pagination to show at most 10 page buttons
+$.fn.DataTable.ext.pager.numbers_length = 10;
+
 function createDataTable(selector, opts = {}) {
   const $table = $(selector);
   const orderCol = Number($table.data('order-col'));

--- a/views/stock.ejs
+++ b/views/stock.ejs
@@ -17,12 +17,12 @@
 
     <!-- 업로드/삭제 -->
     <div class="action-form mb-4">
-      <form id="uploadForm" class="d-flex gap-2 flex-nowrap" enctype="multipart/form-data">
+      <form id="uploadForm" class="d-flex gap-2 flex-nowrap align-items-end" enctype="multipart/form-data">
         <input type="file" name="excelFile" accept=".xlsx,.xls" class="form-control" required>
-        <button type="submit" class="btn btn-success btn-upload">엑셀 업로드</button>
+        <button type="submit" class="btn btn-success btn-upload">업로드</button>
       </form>
-      <form action="/stock/delete-all" method="POST" onsubmit="return confirm('정말 모든 데이터를 삭제하시겠습니까?')">
-        <button type="submit" class="btn btn-danger btn-reset">데이터 초기화</button>
+      <form class="d-flex align-items-end" action="/stock/delete-all" method="POST" onsubmit="return confirm('정말 모든 데이터를 삭제하시겠습니까?')">
+        <button type="submit" class="btn btn-danger btn-reset">초기화</button>
       </form>
     </div>
 
@@ -59,7 +59,7 @@
       <table id="stockTable" data-order-col="1" data-order-dir="asc" class="table table-striped table-hover table-bordered shadow-sm rounded bg-white align-middle text-center auto-width">
         <thead class="table-light">
           <tr>
-            <th>번호</th>
+            <th># 순번</th>
             <th>품번</th>
             <th>품명</th>
             <th>색상</th>


### PR DESCRIPTION
## Summary
- show at most 10 page links for DataTables
- align stock upload/reset buttons and update labels
- update table headers in the stock page

## Testing
- `npm run lint`
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686234ca512c8329b9db84302a158217