### PR TITLE
Implement weather record endpoints

### DIFF
--- a/controllers/weatherController.js
+++ b/controllers/weatherController.js
@@ -262,6 +262,40 @@ const getHistory = asyncHandler(async (req, res) => {
   res.json(history);
 });
 
+const createRecord = asyncHandler(async (req, res) => {
+  const { _id, temperature } = req.body;
+  if (!_id || temperature === undefined) {
+    return res.status(400).json({ message: "_id and temperature required" });
+  }
+  await req.app.locals.db
+    .collection("weather")
+    .insertOne({ _id, temperature });
+  res.status(201).json({ insertedId: _id });
+});
+
+const getRecord = asyncHandler(async (req, res) => {
+  const id = req.params.id;
+  const doc = await req.app.locals.db
+    .collection("weather")
+    .findOne({ _id: id });
+  if (!doc) return res.status(404).json({ message: "not found" });
+  res.json({ _id: doc._id, temperature: doc.temperature });
+});
+
+const updateRecord = asyncHandler(async (req, res) => {
+  const id = req.params.id;
+  const { temperature } = req.body;
+  const result = await req.app.locals.db
+    .collection("weather")
+    .findOneAndUpdate(
+      { _id: id },
+      { $set: { temperature } },
+      { returnDocument: "after" }
+    );
+  if (!result.value) return res.status(404).json(null);
+  res.json({ _id: result.value._id, temperature: result.value.temperature });
+});
+
 module.exports = {
   fetchDaily,
   getDailyWeather,
@@ -272,4 +306,7 @@ module.exports = {
   upload,
   uploadExcelApi,
   getHistory,
+  createRecord,
+  getRecord,
+  updateRecord,
 };

--- a/routes/api/weatherApi.js
+++ b/routes/api/weatherApi.js
@@ -9,5 +9,8 @@ router.get('/same-day', ctrl.getSameDay);
 router.get('/monthly', ctrl.getMonthlyWeather);
 router.get('/monthly-db', ctrl.getMonthlyWeatherFromDb);
 router.get('/average', ctrl.getAverageTemperature);
+router.post('/record', ctrl.createRecord);
+router.get('/record/:id', ctrl.getRecord);
+router.put('/record/:id', ctrl.updateRecord);
 
 module.exports = router;

--- a/tests/weatherRecordApi.test.js
+++ b/tests/weatherRecordApi.test.js
@@ -1,0 +1,59 @@
+// tests/weatherRecordApi.test.js
+jest.setTimeout(60000);
+
+const mockCollection = {
+  insertOne: jest.fn().mockResolvedValue({ insertedId: '20250601' }),
+  findOne: jest.fn().mockResolvedValue({ _id: '20250601', temperature: 22.6 }),
+  findOneAndUpdate: jest.fn().mockResolvedValue({ value: { _id: '20250601', temperature: 25.1 } }),
+};
+
+jest.mock('../config/db', () => {
+  const mockDb = { collection: jest.fn(() => mockCollection) };
+  const mockConnect = jest.fn().mockResolvedValue(mockDb);
+  mockConnect.then = (fn) => fn(mockDb);
+  return { connectDB: mockConnect, closeDB: jest.fn().mockResolvedValue() };
+});
+
+const request = require('supertest');
+const { initApp } = require('../server');
+const { closeDB } = require('../config/db');
+
+let app;
+
+beforeAll(async () => {
+  process.env.NODE_ENV = 'test';
+  process.env.MONGO_URI = 'mongodb://127.0.0.1:27017/testdb';
+  process.env.DB_NAME = 'testdb';
+  process.env.SESSION_SECRET = 'testsecret';
+
+  app = await initApp();
+});
+
+afterAll(async () => {
+  await closeDB();
+});
+
+test('POST /api/weather/record inserts a record', async () => {
+  const res = await request(app)
+    .post('/api/weather/record')
+    .send({ _id: '20250601', temperature: 22.6 });
+  expect(res.statusCode).toBe(201);
+  expect(res.body).toEqual({ insertedId: '20250601' });
+  expect(mockCollection.insertOne).toHaveBeenCalled();
+});
+
+test('GET /api/weather/record/:id returns a record', async () => {
+  const res = await request(app).get('/api/weather/record/20250601');
+  expect(res.statusCode).toBe(200);
+  expect(res.body).toEqual({ _id: '20250601', temperature: 22.6 });
+  expect(mockCollection.findOne).toHaveBeenCalledWith({ _id: '20250601' });
+});
+
+test('PUT /api/weather/record/:id updates a record', async () => {
+  const res = await request(app)
+    .put('/api/weather/record/20250601')
+    .send({ temperature: 25.1 });
+  expect(res.statusCode).toBe(200);
+  expect(res.body).toEqual({ _id: '20250601', temperature: 25.1 });
+  expect(mockCollection.findOneAndUpdate).toHaveBeenCalled();
+});


### PR DESCRIPTION
## Summary
- add create/get/update operations for weather record
- wire new endpoints into API routes
- add tests for weather record API

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862358ff2608329ab192dd7431c2443