### PR TITLE
Add admin API and React pages

### DIFF
--- a/client/src/pages/admin/Permissions.js
+++ b/client/src/pages/admin/Permissions.js
@@ -1,10 +1,110 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 
 function Permissions() {
+  const [views, setViews] = useState([]);
+  const [permissions, setPermissions] = useState({});
+  const [users, setUsers] = useState([]);
+
+  const loadData = async () => {
+    const res = await fetch('/api/admin/permissions', { credentials: 'include' });
+    if (res.ok) {
+      const data = await res.json();
+      setViews(data.views);
+      setPermissions(data.permissions || {});
+      setUsers(data.users || []);
+    }
+  };
+
+  useEffect(() => {
+    loadData();
+  }, []);
+
+  const onCheckLogin = (view) => {
+    setPermissions({
+      ...permissions,
+      [view]: {
+        ...(permissions[view] || {}),
+        loginRequired: !(permissions[view]?.loginRequired),
+        allowedUsers: permissions[view]?.allowedUsers || [],
+      },
+    });
+  };
+
+  const onToggleUser = (view, userId) => {
+    const current = permissions[view]?.allowedUsers || [];
+    const exists = current.includes(userId);
+    const updated = exists ? current.filter((u) => u !== userId) : [...current, userId];
+    setPermissions({
+      ...permissions,
+      [view]: {
+        ...(permissions[view] || {}),
+        allowedUsers: updated,
+        loginRequired: permissions[view]?.loginRequired || false,
+      },
+    });
+  };
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    const body = new URLSearchParams();
+    Object.entries(permissions).forEach(([view, perm]) => {
+      if (perm.loginRequired) body.append('view', view);
+      perm.allowedUsers?.forEach((u) => body.append('user_' + view, u));
+    });
+    await fetch('/api/admin/permissions', {
+      method: 'POST',
+      credentials: 'include',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      body: body.toString(),
+    });
+    loadData();
+  };
+
   return (
-    <div>
-      <h2>접근 권한 설정</h2>
-      <p>React 기반의 권한 설정 페이지입니다.</p>
+    <div className="container">
+      <h2 className="mb-3">접근 권한 설정</h2>
+      <form onSubmit={handleSubmit}>
+        <table className="table table-bordered">
+          <thead>
+            <tr>
+              <th>View</th>
+              <th>Login Required</th>
+              <th>Allowed Users</th>
+            </tr>
+          </thead>
+          <tbody>
+            {views.map((v) => {
+              const perm = permissions[v] || { allowedUsers: [] };
+              return (
+                <tr key={v}>
+                  <td>{v}</td>
+                  <td>
+                    <input
+                      type="checkbox"
+                      checked={perm.loginRequired || false}
+                      onChange={() => onCheckLogin(v)}
+                    />
+                  </td>
+                  <td>
+                    {users.map((u) => (
+                      <label key={u._id} className="me-2">
+                        <input
+                          type="checkbox"
+                          className="me-1"
+                          checked={perm.allowedUsers.includes(u._id)}
+                          onChange={() => onToggleUser(v, u._id)}
+                        />
+                        {u.username}
+                      </label>
+                    ))}
+                  </td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+        <button type="submit" className="btn btn-primary">저장</button>
+      </form>
     </div>
   );
 }

--- a/client/src/pages/admin/Users.js
+++ b/client/src/pages/admin/Users.js
@@ -1,10 +1,57 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 
 function Users() {
+  const [users, setUsers] = useState([]);
+
+  const loadUsers = async () => {
+    const res = await fetch('/api/admin/users', { credentials: 'include' });
+    if (res.ok) {
+      const data = await res.json();
+      setUsers(data.users);
+    }
+  };
+
+  const handleDelete = async (id) => {
+    if (!window.confirm('삭제하시겠습니까?')) return;
+    await fetch(`/api/admin/users/${id}`, { method: 'DELETE', credentials: 'include' });
+    loadUsers();
+  };
+
+  useEffect(() => {
+    loadUsers();
+  }, []);
+
   return (
-    <div>
-      <h2>사용자 관리</h2>
-      <p>React 기반의 사용자 관리 페이지입니다.</p>
+    <div className="container">
+      <h2 className="mb-3">사용자 관리</h2>
+      <table className="table table-bordered">
+        <thead>
+          <tr>
+            <th>아이디</th>
+            <th>이름</th>
+            <th>권한</th>
+            <th>관리</th>
+          </tr>
+        </thead>
+        <tbody>
+          {users.map((u) => (
+            <tr key={u._id}>
+              <td>{u.username}</td>
+              <td>{u.name}</td>
+              <td>{u.role || 'user'}</td>
+              <td>
+                <button
+                  type="button"
+                  className="btn btn-sm btn-outline-danger"
+                  onClick={() => handleDelete(u._id)}
+                >
+                  삭제
+                </button>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
     </div>
   );
 }

--- a/controllers/adminApiController.js
+++ b/controllers/adminApiController.js
@@ -1,0 +1,80 @@
+const fs = require('fs');
+const path = require('path');
+const { ObjectId } = require('mongodb');
+
+function getViewNames() {
+  const viewsDir = path.join(__dirname, '../views');
+  return fs
+    .readdirSync(viewsDir, { withFileTypes: true })
+    .filter((d) => d.isFile() && d.name.endsWith('.ejs'))
+    .map((d) => path.basename(d.name, '.ejs'))
+    .filter((name) => !['nav', 'error', 'layouts'].includes(name));
+}
+
+exports.listUsers = async (req, res, next) => {
+  try {
+    const db = req.app.locals.db;
+    const q = req.query.q || '';
+    const query = q ? { username: new RegExp(q, 'i') } : {};
+    const users = await db.collection('user').find(query).sort({ username: 1 }).toArray();
+    res.json({ users });
+  } catch (err) {
+    next(err);
+  }
+};
+
+exports.deleteUser = async (req, res, next) => {
+  try {
+    const db = req.app.locals.db;
+    const userId = req.params.id;
+    if (userId) {
+      await db.collection('user').deleteOne({ _id: new ObjectId(userId) });
+      await db.collection('permissions').updateMany({}, { $pull: { allowedUsers: userId } });
+    }
+    res.json({ success: true });
+  } catch (err) {
+    next(err);
+  }
+};
+
+exports.getPermissions = async (req, res, next) => {
+  try {
+    const db = req.app.locals.db;
+    const views = getViewNames();
+    const permsArray = await db.collection('permissions').find({ view: { $in: views } }).toArray();
+    const permissions = {};
+    permsArray.forEach((p) => {
+      permissions[p.view] = { loginRequired: p.loginRequired, allowedUsers: p.allowedUsers || [] };
+    });
+    const users = await db.collection('user').find().toArray();
+    res.json({ views, permissions, users });
+  } catch (err) {
+    next(err);
+  }
+};
+
+exports.savePermissions = async (req, res, next) => {
+  try {
+    const db = req.app.locals.db;
+    const views = getViewNames();
+    const selectedViews = req.body.view || [];
+    const updates = views.map((v) => {
+      const loginRequired = Array.isArray(selectedViews)
+        ? selectedViews.includes(v)
+        : selectedViews === v;
+      let allowed = req.body['user_' + v] || [];
+      if (!Array.isArray(allowed)) allowed = allowed ? [allowed] : [];
+      return {
+        updateOne: {
+          filter: { view: v },
+          update: { $set: { view: v, loginRequired, allowedUsers: allowed } },
+          upsert: true,
+        },
+      };
+    });
+    if (updates.length) await db.collection('permissions').bulkWrite(updates);
+    res.json({ success: true });
+  } catch (err) {
+    next(err);
+  }
+};

--- a/controllers/apiAuthController.js
+++ b/controllers/apiAuthController.js
@@ -60,6 +60,7 @@ exports.register = async (req, res, next) => {
       username,
       name,
       email,
+      role: 'user',
       password: hashedPassword,
       createdAt: new Date(),
     });

--- a/controllers/authController.js
+++ b/controllers/authController.js
@@ -73,6 +73,7 @@ exports.register = async (req, res) => {
       username,
       name,
       email,
+      role: 'user',
       password: hashedPassword,
       createdAt: new Date(),
     });

--- a/middlewares/auth.js
+++ b/middlewares/auth.js
@@ -1,6 +1,12 @@
 // Permission checks have been disabled to allow access to all routes.
 // These middleware functions now simply pass control to the next handler.
 function checkLogin(req, res, next) {
+  if (!req.user) {
+    if (req.path.startsWith('/api')) {
+      return res.status(401).json({ message: '로그인이 필요합니다.' });
+    }
+    return res.redirect('/login');
+  }
   next();
 }
 
@@ -10,6 +16,12 @@ function checkAuth(req, res, next) {
 }
 
 function checkAdmin(req, res, next) {
+  if (!req.user || req.user.role !== 'admin') {
+    if (req.path.startsWith('/api')) {
+      return res.status(403).json({ message: '관리자 권한 필요' });
+    }
+    return res.status(403).send('관리자 권한 필요');
+  }
   next();
 }
 

--- a/routes/api/adminApi.js
+++ b/routes/api/adminApi.js
@@ -1,0 +1,11 @@
+const express = require('express');
+const router = express.Router();
+const { checkAdmin } = require('../../middlewares/auth');
+const ctrl = require('../../controllers/adminApiController');
+
+router.get('/users', checkAdmin, ctrl.listUsers);
+router.delete('/users/:id', checkAdmin, ctrl.deleteUser);
+router.get('/permissions', checkAdmin, ctrl.getPermissions);
+router.post('/permissions', checkAdmin, ctrl.savePermissions);
+
+module.exports = router;

--- a/routes/api/index.js
+++ b/routes/api/index.js
@@ -33,6 +33,8 @@ router.use("/posts", require("./postApi"));
 router.use("/comments", require("./commentApi"));
 // 게시판 목록 API
 router.use("/boards", require("./boardApi"));
+// 관리자 전용 API
+router.use('/admin', require('./adminApi'));
 
 // TODO: 다른 API 라우터 추가 시 아래와 같이 등록
 // router.use("/user", require("./userApi"));


### PR DESCRIPTION
## Summary
- implement user role field when registering
- enforce login/admin checks in middleware
- expose new `/api/admin` endpoints for users and permissions
- create React admin pages to manage users and permissions

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6862357a9b9c83299679dbecd3aff778