### PR TITLE
Fix /post route to serve React without redirect

### DIFF
--- a/routes/web/post.js
+++ b/routes/web/post.js
@@ -5,7 +5,8 @@ const upload = require('../../upload.js');
 const postController = require('../../controllers/postController');
 
 // React page routes
-router.get(['/', '/:page', '/write', '/detail/:id', '/edit/:id'], (req, res) => {
+// Serve React pages without redirecting when trailing slash is omitted
+router.get(['', '/', '/:page', '/write', '/detail/:id', '/edit/:id'], (req, res) => {
   res.sendFile(path.join(__dirname, '../../client/public/index.html'));
 });
 


### PR DESCRIPTION
## Summary
- avoid redirect on `/post` by handling missing trailing slash

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862376497c08329b0c401ffdc42622a