### PR TITLE
Port coupangAdd to React ad history

### DIFF
--- a/controllers/coupangAddController.js
+++ b/controllers/coupangAddController.js
@@ -281,3 +281,25 @@ exports.uploadExcelApi = asyncHandler(async (req, res) => {
   fs.unlink(filePath, () => {});
   res.json({ status: 'success' });
 });
+
+// Get single document by ID
+exports.getItem = asyncHandler(async (req, res) => {
+  const db = req.app.locals.db;
+  const row = await db
+    .collection('coupangAdd')
+    .findOne({ _id: new require('mongodb').ObjectId(req.params.id) });
+  if (!row) return res.status(404).json({ message: 'Not found' });
+  res.json(row);
+});
+
+// Update document by ID
+exports.updateItem = asyncHandler(async (req, res) => {
+  const db = req.app.locals.db;
+  const result = await db.collection('coupangAdd').updateOne(
+    { _id: new require('mongodb').ObjectId(req.params.id) },
+    { $set: req.body }
+  );
+  if (result.matchedCount === 0)
+    return res.status(404).json({ message: 'Not found' });
+  res.json({ success: true });
+});

--- a/routes/api/coupangAddApi.js
+++ b/routes/api/coupangAddApi.js
@@ -3,7 +3,9 @@ const router = express.Router();
 const ctrl = require('../../controllers/coupangAddController');
 
 router.get('/', ctrl.getData);
+router.get('/:id', ctrl.getItem);
 router.post('/upload', ctrl.upload, ctrl.uploadExcelApi);
+router.put('/:id', ctrl.updateItem);
 router.delete('/', async (req, res) => {
   const db = req.app.locals.db;
   await db.collection('coupangAdd').deleteMany({});


### PR DESCRIPTION
## Summary
- migrate coupangAdd API to provide item get/update endpoints
- move coupangAdd page functionality into React AdHistory page
- expose new ad history edit API routes

## Testing
- `npm run lint`
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686237428ddc8329bbdbd2edfeb5e586