### PR TITLE
Fix static asset redirects

### DIFF
--- a/server.js
+++ b/server.js
@@ -121,8 +121,13 @@ async function initApp() {
     const reactIndex = path.join(__dirname, "client", "public", "index.html");
     res.sendFile(reactIndex);
   });
-  app.use(express.static(path.join(__dirname, "client", "public")));
-  app.use(express.static(path.join(__dirname, "public")));
+  // Serve static assets without automatic redirect to avoid status code 302
+  app.use(
+    express.static(path.join(__dirname, "client", "public"), { redirect: false })
+  );
+  app.use(
+    express.static(path.join(__dirname, "public"), { redirect: false })
+  );
   app.get("/dashboard", checkAuth, (req, res) => {
     const reactIndex = path.join(__dirname, "client", "public", "index.html");
     res.sendFile(reactIndex);


### PR DESCRIPTION
## Summary
- serve static files with redirects disabled to prevent 302 responses

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686239c09e388329a52775b9042b7236