### PR TITLE
Switch register success page to React

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,6 +237,8 @@ The login page was migrated from an EJS template to a React component. The
 client authenticates by sending credentials to the Express endpoint
 `/api/auth/login`. In production the server serves `client/public/index.html` for
 `/login`, so navigating directly to `/login` loads the React app.
+Successful registration redirects to `/register-success`, which is also handled
+by the React client.
 
 ### 게시판
 

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -9,6 +9,7 @@ import CoupangAdd from './pages/CoupangAdd';
 import CoupangStock from './pages/CoupangStock';
 import Login from './pages/Login';
 import Register from './pages/Register';
+import RegisterSuccess from './pages/RegisterSuccess';
 import Weather from './pages/Weather';
 import Dashboard from './pages/Dashboard';
 import DashboardLayout from './pages/DashboardLayout';
@@ -28,6 +29,7 @@ function App() {
         <Route path="/" element={<Home />} />
         <Route path="/login" element={<Login />} />
         <Route path="/register" element={<Register />} />
+        <Route path="/register-success" element={<RegisterSuccess />} />
         <Route path="/help" element={<Help />} />
         <Route element={<DashboardLayout />}>
           <Route path="/dashboard" element={<Dashboard />} />

--- a/client/src/pages/RegisterSuccess.js
+++ b/client/src/pages/RegisterSuccess.js
@@ -1,0 +1,26 @@
+import React, { useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
+import './Register.css';
+
+function RegisterSuccess() {
+  const navigate = useNavigate();
+  useEffect(() => {
+    const timer = setTimeout(() => navigate('/login'), 2000);
+    return () => clearTimeout(timer);
+  }, [navigate]);
+
+  return (
+    <div className="register-container">
+      <div className="card shadow-sm register-card text-center p-4">
+        <div className="alert alert-success mb-3">
+          🎉 회원가입이 완료되었습니다. 잠시 후 로그인 페이지로 이동합니다...
+        </div>
+        <button onClick={() => navigate('/login')} className="btn btn-primary">
+          바로 이동
+        </button>
+      </div>
+    </div>
+  );
+}
+
+export default RegisterSuccess;

--- a/controllers/authController.js
+++ b/controllers/authController.js
@@ -87,5 +87,6 @@ exports.register = async (req, res) => {
 };
 
 exports.renderRegisterSuccess = (req, res) => {
-  res.render('register-success');
+  const reactIndex = path.join(__dirname, '..', 'client', 'public', 'index.html');
+  res.sendFile(reactIndex);
 };


### PR DESCRIPTION
## Summary
- serve `/register-success` from React instead of EJS
- add RegisterSuccess component and route
- document the new route in the React client section

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68623df23cdc8329b79768252659e267