### PR TITLE
Add React dashboard chart with API

### DIFF
--- a/client/src/components/DailyAdCostChart.jsx
+++ b/client/src/components/DailyAdCostChart.jsx
@@ -1,0 +1,53 @@
+import React, { useEffect, useState } from 'react';
+import { Line } from 'react-chartjs-2';
+import {
+  Chart as ChartJS,
+  CategoryScale,
+  LinearScale,
+  PointElement,
+  LineElement,
+  Tooltip,
+  Legend,
+} from 'chart.js';
+
+ChartJS.register(
+  CategoryScale,
+  LinearScale,
+  PointElement,
+  LineElement,
+  Tooltip,
+  Legend,
+);
+
+function DailyAdCostChart() {
+  const [data, setData] = useState([]);
+
+  useEffect(() => {
+    fetch('/api/dashboard/ad-cost-daily', { credentials: 'include' })
+      .then((res) => (res.ok ? res.json() : []))
+      .then((d) => setData(d))
+      .catch(() => {});
+  }, []);
+
+  const chartData = {
+    labels: data.map((d) => d.date),
+    datasets: [
+      {
+        label: '광고비',
+        data: data.map((d) => d.totalCost),
+        borderColor: 'rgba(75,192,192,1)',
+        backgroundColor: 'rgba(75,192,192,0.2)',
+        tension: 0.1,
+      },
+    ],
+  };
+
+  return (
+    <div>
+      <h3>쿠팡 광고비 (일자별)</h3>
+      <Line data={chartData} />
+    </div>
+  );
+}
+
+export default DailyAdCostChart;

--- a/client/src/pages/Dashboard.css
+++ b/client/src/pages/Dashboard.css
@@ -1,0 +1,13 @@
+.dashboard-grid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  grid-auto-rows: 1fr;
+  gap: 1rem;
+}
+
+.grid-item {
+  background: #fff;
+  border: 1px solid #dee2e6;
+  padding: 1rem;
+  border-radius: 0.25rem;
+}

--- a/client/src/pages/Dashboard.js
+++ b/client/src/pages/Dashboard.js
@@ -1,10 +1,16 @@
 import React from 'react';
+import DailyAdCostChart from '../components/DailyAdCostChart';
+import './Dashboard.css';
 
 function Dashboard() {
   return (
-    <div>
-      <h1>대시보드</h1>
-      <p>환영합니다. 원하는 메뉴를 선택하세요.</p>
+    <div className="dashboard-grid">
+      <div className="grid-item">
+        <DailyAdCostChart />
+      </div>
+      <div className="grid-item">2</div>
+      <div className="grid-item">3</div>
+      <div className="grid-item">4</div>
     </div>
   );
 }

--- a/controllers/dashboardController.js
+++ b/controllers/dashboardController.js
@@ -1,0 +1,25 @@
+const asyncHandler = require('../middlewares/asyncHandler');
+
+// GET /api/dashboard/ad-cost-daily
+// Return daily sum of Coupang ad cost
+exports.getDailyAdCost = asyncHandler(async (req, res) => {
+  const db = req.app.locals.db;
+  const pipeline = [
+    {
+      $group: {
+        _id: '$날짜',
+        totalCost: { $sum: '$광고비' },
+      },
+    },
+    { $sort: { _id: 1 } },
+    {
+      $project: {
+        _id: 0,
+        date: '$_id',
+        totalCost: 1,
+      },
+    },
+  ];
+  const data = await db.collection('coupangAdd').aggregate(pipeline).toArray();
+  res.json(data);
+});

--- a/routes/api/dashboard.js
+++ b/routes/api/dashboard.js
@@ -1,0 +1,7 @@
+const express = require('express');
+const router = express.Router();
+const ctrl = require('../../controllers/dashboardController');
+
+router.get('/ad-cost-daily', ctrl.getDailyAdCost);
+
+module.exports = router;

--- a/routes/api/index.js
+++ b/routes/api/index.js
@@ -29,6 +29,8 @@ router.use('/records', require('./records'));
 router.use("/analytics", require("./analytics"));
 // 광고 내역 API
 router.use('/ad-history', require('./adHistory'));
+// 대시보드 API
+router.use('/dashboard', require('./dashboard'));
 // 게시판 API
 router.use("/posts", require("./postApi"));
 // 댓글 API

--- a/tests/dashboardApi.test.js
+++ b/tests/dashboardApi.test.js
@@ -1,0 +1,47 @@
+jest.setTimeout(60000);
+
+const mockCollection = {
+  aggregate: jest.fn().mockReturnThis(),
+  toArray: jest.fn().mockResolvedValue([]),
+};
+
+jest.mock('../config/db', () => {
+  const mockDb = { collection: jest.fn(() => mockCollection) };
+  const mockConnect = jest.fn().mockResolvedValue(mockDb);
+  mockConnect.then = (fn) => fn(mockDb);
+  return { connectDB: mockConnect, closeDB: jest.fn().mockResolvedValue() };
+});
+
+const request = require('supertest');
+const { initApp } = require('../server');
+const { closeDB } = require('../config/db');
+
+let app;
+
+beforeAll(async () => {
+  process.env.NODE_ENV = 'test';
+  process.env.MONGO_URI = 'mongodb://127.0.0.1:27017/testdb';
+  process.env.DB_NAME = 'testdb';
+  process.env.SESSION_SECRET = 'testsecret';
+  app = await initApp();
+});
+
+afterAll(async () => {
+  await closeDB();
+});
+
+test('GET /api/dashboard/ad-cost-daily returns aggregated data', async () => {
+  mockCollection.toArray.mockResolvedValueOnce([
+    { date: '2024-06-01', totalCost: 100 },
+    { date: '2024-06-02', totalCost: 200 },
+  ]);
+
+  const res = await request(app).get('/api/dashboard/ad-cost-daily');
+  expect(res.statusCode).toBe(200);
+  expect(res.body).toEqual([
+    { date: '2024-06-01', totalCost: 100 },
+    { date: '2024-06-02', totalCost: 200 },
+  ]);
+  expect(app.locals.db.collection).toHaveBeenCalledWith('coupangAdd');
+  expect(mockCollection.aggregate).toHaveBeenCalled();
+});


### PR DESCRIPTION
## Summary
- show daily Coupang ad cost in a dashboard chart
- implement dashboard controller and route for aggregated data
- render chart on the new dashboard page
- add API test for dashboard endpoint

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862437a972c83298eceef46fdd255bc