### PR TITLE
Add admin supply price management

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,20 @@ const createProduct = async (body) => {
 createProduct({ name: "Sample" });
 ```
 
+## Coupang supply price API
+
+Upload option supply prices and calculate the total stock value. The API exposes
+three endpoints under `/api/coupang-supply`:
+
+- `GET /api/coupang-supply` returns the saved prices with the current total
+  stock value computed from the Coupang inventory collection.
+- `POST /api/coupang-supply/upload` accepts an Excel file containing `Option ID`
+  and `Supply Price` columns. Existing records are upserted.
+- `GET /api/coupang-supply/download` downloads the saved data as an Excel file.
+
+React admin pages provide a simple interface for uploading or downloading the
+Excel file.
+
 =======
 
 ## Weather integration

--- a/client/src/pages/Admin.js
+++ b/client/src/pages/Admin.js
@@ -22,6 +22,9 @@ function Admin() {
         <li className="list-group-item">
           <Link to="/admin/boards">게시판 관리</Link>
         </li>
+        <li className="list-group-item">
+          <Link to="/admin/coupang-supply">쿠팡 공급가 관리</Link>
+        </li>
       </ul>
     </div>
   );

--- a/client/src/pages/admin/CoupangSupply.js
+++ b/client/src/pages/admin/CoupangSupply.js
@@ -1,0 +1,68 @@
+import React, { useState, useEffect, useRef } from 'react';
+
+function CoupangSupply() {
+  const [items, setItems] = useState([]);
+  const [total, setTotal] = useState(0);
+  const fileRef = useRef(null);
+
+  const fetchData = async () => {
+    const res = await fetch('/api/coupang-supply', { credentials: 'include' });
+    if (res.ok) {
+      const data = await res.json();
+      setItems(data.data);
+      setTotal(data.totalStockValue);
+    }
+  };
+
+  useEffect(() => {
+    fetchData();
+  }, []);
+
+  const handleUpload = async (e) => {
+    e.preventDefault();
+    if (!fileRef.current || fileRef.current.files.length === 0) return;
+    const formData = new FormData();
+    formData.append('excelFile', fileRef.current.files[0]);
+    const res = await fetch('/api/coupang-supply/upload', {
+      method: 'POST',
+      body: formData,
+      credentials: 'include',
+    });
+    if (res.ok) {
+      fetchData();
+      fileRef.current.value = '';
+    }
+  };
+
+  return (
+    <div>
+      <h2>쿠팡 공급가 관리</h2>
+      <form onSubmit={handleUpload} className="d-flex gap-2 mb-3" encType="multipart/form-data">
+        <input type="file" ref={fileRef} className="form-control" accept=".xlsx,.xls" />
+        <button type="submit" className="btn btn-success">업로드</button>
+        <a href="/api/coupang-supply/download" className="btn btn-secondary">다운로드</a>
+      </form>
+      <p>총 재고 금액: {total.toLocaleString()} 원</p>
+      {items.length > 0 && (
+        <table className="table">
+          <thead>
+            <tr>
+              <th>Option ID</th>
+              <th>Supply Price</th>
+            </tr>
+          </thead>
+          <tbody>
+            {items.map((i) => (
+              <tr key={i.optionId}>
+                <td>{i.optionId}</td>
+                <td>{i.supplyPrice}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+    </div>
+  );
+}
+
+export default CoupangSupply;

--- a/client/src/routes/AdminRoutes.js
+++ b/client/src/routes/AdminRoutes.js
@@ -6,6 +6,7 @@ import AdminLogo from '../pages/admin/Logo';
 import AdminUsers from '../pages/admin/Users';
 import AdminPermissions from '../pages/admin/Permissions';
 import AdminBoards from '../pages/admin/Boards';
+import CoupangSupply from '../pages/admin/CoupangSupply';
 
 /**
  * Router for admin pages. This nested router keeps admin related
@@ -21,6 +22,7 @@ function AdminRoutes() {
       <Route path="users" element={<AdminUsers />} />
       <Route path="permissions" element={<AdminPermissions />} />
       <Route path="boards" element={<AdminBoards />} />
+      <Route path="coupang-supply" element={<CoupangSupply />} />
       <Route path="*" element={<Navigate to="." />} />
     </Routes>
   );

--- a/controllers/coupangSupplyController.js
+++ b/controllers/coupangSupplyController.js
@@ -1,0 +1,67 @@
+const path = require('path');
+const fs = require('fs');
+const os = require('os');
+const xlsx = require('xlsx');
+const multerImport = require('multer');
+const multer = multerImport.default || multerImport;
+const asyncHandler = require('./../middlewares/asyncHandler');
+
+const storage = multer.diskStorage({
+  destination: (req, file, cb) => cb(null, 'uploads/'),
+  filename: (req, file, cb) => cb(null, `supply_${Date.now()}${path.extname(file.originalname)}`),
+});
+exports.upload = multer({ storage }).single('excelFile');
+
+function parseExcel(filePath) {
+  const wb = xlsx.readFile(filePath);
+  const sheet = wb.Sheets[wb.SheetNames[0]];
+  const rows = xlsx.utils.sheet_to_json(sheet, { header: 1, raw: true });
+  if (rows.length < 2) return [];
+  const headers = rows[0].map((h) => String(h).trim());
+  const optionIdx = headers.findIndex((h) => /option id/i.test(h));
+  const priceIdx = headers.findIndex((h) => /supply/i.test(h) || /공급가/i.test(h));
+  return rows.slice(1).map((r) => ({
+    optionId: String(r[optionIdx] || '').trim(),
+    supplyPrice: Number(r[priceIdx]) || 0,
+  })).filter((r) => r.optionId);
+}
+
+exports.uploadExcel = asyncHandler(async (req, res) => {
+  const db = req.app.locals.db;
+  if (!req.file) {
+    return res.status(400).json({ status: 'error', message: '파일이 없습니다.' });
+  }
+  const filePath = req.file.path;
+  const data = parseExcel(filePath);
+  const bulk = data.map((d) => ({
+    updateOne: {
+      filter: { optionId: d.optionId },
+      update: { $set: d },
+      upsert: true,
+    },
+  }));
+  if (bulk.length) await db.collection('coupangSupply').bulkWrite(bulk);
+  fs.unlink(filePath, () => {});
+  res.json({ status: 'success' });
+});
+
+exports.downloadExcel = asyncHandler(async (req, res) => {
+  const db = req.app.locals.db;
+  const list = await db.collection('coupangSupply').find().toArray();
+  const wb = xlsx.utils.book_new();
+  const ws = xlsx.utils.json_to_sheet(list.map((d) => ({ optionId: d.optionId, supplyPrice: d.supplyPrice })));
+  xlsx.utils.book_append_sheet(wb, ws, 'Supply');
+  const tempPath = path.join(os.tmpdir(), `supply_${Date.now()}.xlsx`);
+  xlsx.writeFile(wb, tempPath);
+  res.download(tempPath, 'coupang_supply.xlsx', () => fs.unlink(tempPath, () => {}));
+});
+
+exports.getList = asyncHandler(async (req, res) => {
+  const db = req.app.locals.db;
+  const supply = await db.collection('coupangSupply').find().toArray();
+  const stock = await db.collection('coupang').find().project({ 'Option ID': 1, 'Orderable quantity (real-time)': 1 }).toArray();
+  const qtyMap = {};
+  stock.forEach((s) => { qtyMap[s['Option ID']] = Number(s['Orderable quantity (real-time)'] || 0); });
+  const totalStockValue = supply.reduce((sum, s) => sum + (Number(s.supplyPrice) || 0) * (qtyMap[s.optionId] || 0), 0);
+  res.json({ data: supply, totalStockValue });
+});

--- a/routes/api/coupangSupplyApi.js
+++ b/routes/api/coupangSupplyApi.js
@@ -1,0 +1,9 @@
+const express = require('express');
+const router = express.Router();
+const ctrl = require('../../controllers/coupangSupplyController');
+
+router.get('/', ctrl.getList);
+router.post('/upload', ctrl.upload, ctrl.uploadExcel);
+router.get('/download', ctrl.downloadExcel);
+
+module.exports = router;

--- a/routes/api/index.js
+++ b/routes/api/index.js
@@ -19,6 +19,8 @@ router.use("/coupang", require("./coupangApi"));
 router.use("/coupang-add", require("./coupangAddApi"));
 // 쿠팡 오픈 API 연동
 router.use("/coupang-open", require("./coupangOpenApi"));
+// 쿠팡 공급가 API
+router.use("/coupang-supply", require("./coupangSupplyApi"));
 // 날씨 API
 router.use("/weather", require("./weatherApi"));
 // 간단한 Item API


### PR DESCRIPTION
## Summary
- add controller and API routes for uploading coupang option supply prices
- expose `/api/coupang-supply` endpoints
- add React admin page and navigation link
- document new endpoints in README

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68624436a69c8329bbd7f9028857c0ed