### PR TITLE
Implement weather record deletion

### DIFF
--- a/controllers/weatherController.js
+++ b/controllers/weatherController.js
@@ -296,6 +296,15 @@ const updateRecord = asyncHandler(async (req, res) => {
   res.json({ _id: result.value._id, temperature: result.value.temperature });
 });
 
+const deleteRecord = asyncHandler(async (req, res) => {
+  const id = req.params.id;
+  const result = await req.app.locals.db
+    .collection("weather")
+    .deleteOne({ _id: id });
+  if (result.deletedCount === 0) return res.status(404).json(null);
+  res.json({ deleted: id });
+});
+
 module.exports = {
   fetchDaily,
   getDailyWeather,
@@ -309,4 +318,5 @@ module.exports = {
   createRecord,
   getRecord,
   updateRecord,
+  deleteRecord,
 };

--- a/routes/api/weatherApi.js
+++ b/routes/api/weatherApi.js
@@ -12,5 +12,6 @@ router.get('/average', ctrl.getAverageTemperature);
 router.post('/record', ctrl.createRecord);
 router.get('/record/:id', ctrl.getRecord);
 router.put('/record/:id', ctrl.updateRecord);
+router.delete('/record/:id', ctrl.deleteRecord);
 
 module.exports = router;

--- a/tests/weatherRecordApi.test.js
+++ b/tests/weatherRecordApi.test.js
@@ -5,6 +5,7 @@ const mockCollection = {
   insertOne: jest.fn().mockResolvedValue({ insertedId: '20250601' }),
   findOne: jest.fn().mockResolvedValue({ _id: '20250601', temperature: 22.6 }),
   findOneAndUpdate: jest.fn().mockResolvedValue({ value: { _id: '20250601', temperature: 25.1 } }),
+  deleteOne: jest.fn().mockResolvedValue({ deletedCount: 1 }),
 };
 
 jest.mock('../config/db', () => {
@@ -56,4 +57,11 @@ test('PUT /api/weather/record/:id updates a record', async () => {
   expect(res.statusCode).toBe(200);
   expect(res.body).toEqual({ _id: '20250601', temperature: 25.1 });
   expect(mockCollection.findOneAndUpdate).toHaveBeenCalled();
+});
+
+test('DELETE /api/weather/record/:id removes a record', async () => {
+  const res = await request(app).delete('/api/weather/record/20250601');
+  expect(res.statusCode).toBe(200);
+  expect(res.body).toEqual({ deleted: '20250601' });
+  expect(mockCollection.deleteOne).toHaveBeenCalledWith({ _id: '20250601' });
 });


### PR DESCRIPTION
## Summary
- add `deleteRecord` in weather controller
- expose DELETE route for weather records
- test DELETE /api/weather/record/:id

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686245ea4b948329b9ac859d22a50577