### PR TITLE
Enhance ad history upload workflow

### DIFF
--- a/client/src/components/DailyAdCostChart.jsx
+++ b/client/src/components/DailyAdCostChart.jsx
@@ -27,12 +27,13 @@ function DailyAdCostChart() {
       .catch(() => {});
   }, []);
 
+  const sliced = data.slice(0, 50);
   const chartData = {
-    labels: data.map((d) => d.date),
+    labels: sliced.map((d) => d.date),
     datasets: [
       {
         label: '광고비',
-        data: data.map((d) => d.totalCost),
+        data: sliced.map((d) => d.totalCost),
         backgroundColor: 'rgba(75,192,192,0.6)',
         borderColor: 'rgba(75,192,192,1)',
       },
@@ -43,7 +44,19 @@ function DailyAdCostChart() {
     responsive: true,
     maintainAspectRatio: false,
     scales: {
-      y: { beginAtZero: true },
+      x: {
+        ticks: {
+          maxRotation: 45,
+          autoSkip: true,
+          maxTicksLimit: 10,
+        },
+      },
+      y: {
+        beginAtZero: true,
+        ticks: {
+          callback: (v) => v.toLocaleString(),
+        },
+      },
     },
   };
 

--- a/routes/api/coupangAddApi.js
+++ b/routes/api/coupangAddApi.js
@@ -3,6 +3,8 @@ const router = express.Router();
 const ctrl = require('../../controllers/coupangAddController');
 
 router.get('/', ctrl.getData);
+router.get('/summary/product', ctrl.getProductSummary);
+router.get('/summary/date', ctrl.getDateSummary);
 router.get('/:id', ctrl.getItem);
 router.post('/upload', ctrl.upload, ctrl.uploadExcelApi);
 router.put('/:id', ctrl.updateItem);


### PR DESCRIPTION
## Summary
- show upload progress in React ad history page
- alert on completion of upload or reset
- fetch product/date summary data from new API endpoints
- update chart axes and limit to 50 entries
- add MongoDB summary endpoints

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862558ef49083298c0c1912ef837daa