### PR TITLE
Introduce react-query for stock page

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -10,7 +10,8 @@
     "react-scripts": "^5.0.1",
     "web-vitals": "^2.1.4",
     "chart.js": "^4.4.1",
-    "react-chartjs-2": "^5.2.0"
+    "react-chartjs-2": "^5.2.0",
+    "@tanstack/react-query": "^4.38.1"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/client/src/hooks/useCoupangStocks.js
+++ b/client/src/hooks/useCoupangStocks.js
@@ -1,0 +1,29 @@
+import { useQuery } from '@tanstack/react-query';
+
+const pageSize = 50;
+
+async function fetchCoupangStocks({ page, keyword, brand, sort, order }) {
+  const params = new URLSearchParams({
+    page: String(page),
+    limit: String(pageSize),
+    keyword,
+    brand,
+    sort,
+    order,
+  });
+  const res = await fetch(`/api/coupang?${params.toString()}`, {
+    credentials: 'include',
+  });
+  if (!res.ok) {
+    throw new Error('Failed to load');
+  }
+  return res.json();
+}
+
+export default function useCoupangStocks(params) {
+  return useQuery({
+    queryKey: ['coupangStock', params],
+    queryFn: () => fetchCoupangStocks(params),
+    keepPreviousData: true,
+  });
+}

--- a/client/src/hooks/useDebounce.js
+++ b/client/src/hooks/useDebounce.js
@@ -1,0 +1,12 @@
+import { useEffect, useState } from 'react';
+
+export default function useDebounce(value, delay = 300) {
+  const [debounced, setDebounced] = useState(value);
+
+  useEffect(() => {
+    const id = setTimeout(() => setDebounced(value), delay);
+    return () => clearTimeout(id);
+  }, [value, delay]);
+
+  return debounced;
+}

--- a/client/src/index.js
+++ b/client/src/index.js
@@ -1,13 +1,18 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import './index.css';
 import App from './App';
 import reportWebVitals from './reportWebVitals';
 
+const queryClient = new QueryClient();
+
 const root = ReactDOM.createRoot(document.getElementById('root'));
 root.render(
   <React.StrictMode>
-    <App />
+    <QueryClientProvider client={queryClient}>
+      <App />
+    </QueryClientProvider>
   </React.StrictMode>
 );
 

--- a/client/src/pages/CoupangStock.js
+++ b/client/src/pages/CoupangStock.js
@@ -1,11 +1,13 @@
 import React, { useEffect, useRef, useState } from 'react';
 import './CoupangStock.css';
+import { useQueryClient } from '@tanstack/react-query';
+import useDebounce from '../hooks/useDebounce';
+import useCoupangStocks from '../hooks/useCoupangStocks';
 
 const BRANDS = ['트라이', 'BYC', '제임스딘'];
 
 function CoupangStock() {
   const pageSize = 50;
-  const [rows, setRows] = useState([]);
   const [total, setTotal] = useState(0);
   const [page, setPage] = useState(1);
   const [keyword, setKeyword] = useState('');
@@ -14,26 +16,24 @@ function CoupangStock() {
   const [sortDir, setSortDir] = useState('asc');
   const [uploadProgress, setUploadProgress] = useState(0);
   const fileRef = useRef(null);
+  const queryClient = useQueryClient();
   const totalPages = Math.ceil(total / pageSize) || 1;
 
-  const loadData = async () => {
-    const params = new URLSearchParams({
-      page: String(page),
-      limit: String(pageSize),
-      keyword,
-      brand,
-      sort: sortCol,
-      order: sortDir,
-    });
-    const res = await fetch(`/api/coupang?${params.toString()}`, {
-      credentials: 'include',
-    });
-    if (res.ok) {
-      const data = await res.json();
-      setRows(data.data || []);
+  const debouncedKeyword = useDebounce(keyword, 300);
+
+  const { data, isFetching } = useCoupangStocks({
+    page,
+    keyword: debouncedKeyword,
+    brand,
+    sort: sortCol,
+    order: sortDir,
+  });
+
+  useEffect(() => {
+    if (data) {
       setTotal(data.total || 0);
     }
-  };
+  }, [data]);
 
   const handleUpload = (e) => {
     e.preventDefault();
@@ -56,7 +56,7 @@ function CoupangStock() {
         alert('업로드 완료');
         fileRef.current.value = '';
         setPage(1);
-        loadData();
+        queryClient.invalidateQueries({ queryKey: ['coupangStock'] });
       } else {
         alert('업로드 실패');
       }
@@ -77,7 +77,7 @@ function CoupangStock() {
     if (res.ok) {
       alert('초기화 완료');
       setPage(1);
-      loadData();
+      queryClient.invalidateQueries({ queryKey: ['coupangStock'] });
     } else {
       alert('삭제 실패');
     }
@@ -93,13 +93,6 @@ function CoupangStock() {
     setPage(1);
   };
 
-  useEffect(() => {
-    const t = setTimeout(() => {
-      loadData();
-    }, 300);
-    return () => clearTimeout(t);
-    // eslint-disable-next-line
-  }, [page, keyword, brand, sortCol, sortDir]);
 
   return (
     <div className="container">
@@ -157,7 +150,7 @@ function CoupangStock() {
             type="button"
             onClick={() => {
               setPage(1);
-              loadData();
+              queryClient.invalidateQueries({ queryKey: ['coupangStock'] });
             }}
             className="btn btn-primary text-nowrap"
           >
@@ -195,7 +188,7 @@ function CoupangStock() {
           </tr>
         </thead>
         <tbody>
-          {rows.map((row, idx) => (
+          {(data?.data || []).map((row, idx) => (
             <tr key={idx}>
               <td>{row['Option ID']}</td>
               <td className="text-start">{row['Product name']}</td>


### PR DESCRIPTION
## Summary
- add `@tanstack/react-query` to the client dependencies
- wrap the React app with `QueryClientProvider`
- create reusable hooks `useDebounce` and `useCoupangStocks`
- refactor `CoupangStock` page to fetch data via React Query

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68625783f62483299812ad85c7a9b388