### PR TITLE
Fix monthly chart when API fails

### DIFF
--- a/client/src/MonthlyWeatherChart.js
+++ b/client/src/MonthlyWeatherChart.js
@@ -29,14 +29,27 @@ function MonthlyWeatherChart({ year, month }) {
   useEffect(() => {
     async function fetchData() {
       try {
-        const res = await fetch(`/api/weather/monthly?year=${year}&month=${month}`, {
+        // 먼저 외부 API 호출 시도
+        let res = await fetch(`/api/weather/monthly?year=${year}&month=${month}`, {
           credentials: 'include',
         });
-        if (!res.ok) throw new Error('Failed to fetch');
-        const json = await res.json();
+        if (!res.ok) throw new Error('failed');
+
+        let json = await res.json();
         setData(json.filter((d) => !d.error));
-      } catch (e) {
-        setError('데이터 없음');
+      } catch (_) {
+        // 실패 시 DB에 저장된 데이터 조회 시도
+        try {
+          const res = await fetch(
+            `/api/weather/monthly-db?year=${year}&month=${month}`,
+            { credentials: 'include' },
+          );
+          if (!res.ok) throw new Error('failed');
+          const json = await res.json();
+          setData(json.filter((d) => !d.error));
+        } catch (err) {
+          setError('데이터 없음');
+        }
       }
     }
     fetchData();


### PR DESCRIPTION
## Summary
- add fallback logic in React chart to query MongoDB when external API fails

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686397b73ba8832987c25f727e9c75a5