### PR TITLE
Remove extra ad history links

### DIFF
--- a/client/src/components/Sidebar.js
+++ b/client/src/components/Sidebar.js
@@ -10,7 +10,6 @@ const navData = [
       { label: '재고관리', path: '/stock' },
       { label: '매출금액', path: '/sales-amount' },
       { label: '판매량', path: '/sales-volume' },
-      { label: '광고내역', path: '/ad-history' },
       { label: '관리자', path: '/admin' }
     ]
   },
@@ -21,7 +20,6 @@ const navData = [
       { label: '재고관리', path: '/try/stock' },
       { label: '매출금액', path: '/try/sales-amount' },
       { label: '판매량', path: '/try/sales-volume' },
-      { label: '광고내역', path: '/try/ad-history' },
       { label: '입고요청', path: '/try/inbound-request' }
     ]
   },
@@ -32,7 +30,6 @@ const navData = [
       { label: '재고관리', path: '/byc/stock' },
       { label: '매출금액', path: '/byc/sales-amount' },
       { label: '판매량', path: '/byc/sales-volume' },
-      { label: '광고내역', path: '/byc/ad-history' },
       { label: '입고요청', path: '/byc/inbound-request' }
     ]
   },
@@ -43,7 +40,6 @@ const navData = [
       { label: '재고관리', path: '/james-dean/stock' },
       { label: '매출금액', path: '/james-dean/sales-amount' },
       { label: '판매량', path: '/james-dean/sales-volume' },
-      { label: '광고내역', path: '/james-dean/ad-history' },
       { label: '입고요청', path: '/james-dean/inbound-request' }
     ]
   },


### PR DESCRIPTION
## Summary
- prune ad history menu items to only show Coupang and Naver

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686397fd0bec832997be7a05cc844a8d