### PR TITLE
Improve stock upload layout

### DIFF
--- a/client/src/pages/Stock.css
+++ b/client/src/pages/Stock.css
@@ -17,6 +17,29 @@
   white-space: nowrap;
 }
 
+.action-form form {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: nowrap;
+  align-items: flex-end;
+}
+
+@media (max-width: 575.98px) {
+  .action-form {
+    flex-wrap: wrap;
+  }
+  .action-form form {
+    flex: 1 1 100%;
+  }
+  .btn-upload,
+  .btn-reset {
+    width: 100%;
+  }
+  .action-form input[type='file'] {
+    width: 100%;
+  }
+}
+
 .stock-table {
   width: 100%;
   table-layout: fixed;

--- a/client/src/pages/Stock.js
+++ b/client/src/pages/Stock.js
@@ -117,8 +117,15 @@ function Stock() {
           ref={excelFormRef}
           encType="multipart/form-data"
           onSubmit={handleUpload}
+          className="d-flex gap-2 flex-nowrap align-items-end"
         >
-          <input type="file" name="excelFile" accept=".xlsx,.xls" className="form-control" required />
+          <input
+            type="file"
+            name="excelFile"
+            accept=".xlsx,.xls"
+            className="form-control"
+            required
+          />
           <button type="submit" className="btn btn-success btn-upload">업로드</button>
         </form>
         <button onClick={handleRefresh} className="btn btn-danger btn-reset">초기화</button>


### PR DESCRIPTION
## Summary
- align file input with upload and reset buttons on the stock page
- support flex styling for upload form

## Testing
- `npm run lint`
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68639849d3848329976a92ce5fc0a599