### PR TITLE
Fix daily ad cost aggregation

### DIFF
--- a/controllers/dashboardController.js
+++ b/controllers/dashboardController.js
@@ -8,7 +8,7 @@ exports.getDailyAdCost = asyncHandler(async (req, res) => {
     {
       $group: {
         _id: '$date',
-        totalCost: { $sum: '$cost' },
+        totalCost: { $sum: { $toDouble: '$cost' } },
       },
     },
     { $sort: { _id: 1 } },


### PR DESCRIPTION
## Summary
- convert cost to number when aggregating ad spend

## Testing
- `npm run lint`
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686399640a448329915b4a77976cdacd