### PR TITLE
Improve chart loading states

### DIFF
--- a/client/src/__tests__/DailyAdCostChart.test.js
+++ b/client/src/__tests__/DailyAdCostChart.test.js
@@ -1,0 +1,43 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import DailyAdCostChart from '../components/DailyAdCostChart';
+
+jest.mock('react-chartjs-2', () => ({
+  Bar: ({ data }) => <div data-testid="bar-props">{JSON.stringify(data)}</div>,
+}));
+
+afterEach(() => {
+  jest.resetAllMocks();
+});
+
+test('renders bar chart with fetched data', async () => {
+  global.fetch = jest.fn(() =>
+    Promise.resolve({
+      ok: true,
+      json: () =>
+        Promise.resolve([
+          { date: '2023-01-01', totalCost: 100 },
+        ]),
+    })
+  );
+
+  render(<DailyAdCostChart />);
+
+  await waitFor(() => screen.getByTestId('bar-props'));
+
+  expect(global.fetch).toHaveBeenCalledWith('/api/dashboard/ad-cost-daily', {
+    credentials: 'include',
+  });
+
+  const data = JSON.parse(screen.getByTestId('bar-props').textContent);
+  expect(data.labels).toEqual(['2023-01-01']);
+  expect(data.datasets[0].data).toEqual([100]);
+});
+
+test('shows error message on fetch failure', async () => {
+  global.fetch = jest.fn(() => Promise.reject(new Error('fail')));
+
+  render(<DailyAdCostChart />);
+
+  await waitFor(() => screen.getByRole('alert'));
+  expect(screen.getByRole('alert')).toHaveTextContent('데이터를 불러오지 못했습니다.');
+});

--- a/client/src/components/DailyAdCostChart.jsx
+++ b/client/src/components/DailyAdCostChart.jsx
@@ -19,12 +19,23 @@ ChartJS.register(
 
 function DailyAdCostChart() {
   const [data, setData] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
 
   useEffect(() => {
+    setLoading(true);
     fetch('/api/dashboard/ad-cost-daily', { credentials: 'include' })
-      .then((res) => (res.ok ? res.json() : []))
+      .then((res) => {
+        if (!res.ok) throw new Error('Failed to fetch');
+        return res.json();
+      })
       .then((d) => setData(d))
-      .catch(() => {});
+      .catch(() => {
+        setError('데이터를 불러오지 못했습니다.');
+      })
+      .finally(() => {
+        setLoading(false);
+      });
   }, []);
 
   const sliced = data.slice(0, 50);
@@ -63,9 +74,13 @@ function DailyAdCostChart() {
   return (
     <div>
       <h3>쿠팡 광고비 (일자별)</h3>
-      <div style={{ height: '300px' }}>
-        <Bar options={options} data={chartData} />
-      </div>
+      {loading && <p>Loading…</p>}
+      {error && !loading && <p role="alert">{error}</p>}
+      {!loading && !error && (
+        <div style={{ height: '300px' }}>
+          <Bar options={options} data={chartData} />
+        </div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- show loading and error states in `DailyAdCostChart`
- add unit tests for chart component

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68639f257cfc8329a594621cbb31a98a