### PR TITLE
Implement Coupang sales amount feature

### DIFF
--- a/client/src/components/DailySalesAmountChart.jsx
+++ b/client/src/components/DailySalesAmountChart.jsx
@@ -1,0 +1,68 @@
+import React, { useEffect, useState } from 'react';
+import { Bar } from 'react-chartjs-2';
+import {
+  Chart as ChartJS,
+  CategoryScale,
+  LinearScale,
+  BarElement,
+  Tooltip,
+  Legend,
+} from 'chart.js';
+
+ChartJS.register(CategoryScale, LinearScale, BarElement, Tooltip, Legend);
+
+function DailySalesAmountChart() {
+  const [data, setData] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    fetch('/api/coupang-sales', { credentials: 'include' })
+      .then((res) => {
+        if (!res.ok) throw new Error('failed');
+        return res.json();
+      })
+      .then((d) => setData(d))
+      .catch(() => setError('데이터를 불러오지 못했습니다.'))
+      .finally(() => setLoading(false));
+  }, []);
+
+  const labels = data.map((d) => d.settlementId);
+  const chartData = {
+    labels,
+    datasets: [
+      {
+        label: '정산금액',
+        data: data.map((d) => d.payoutAmount),
+        backgroundColor: 'rgba(153,102,255,0.6)',
+        borderColor: 'rgba(153,102,255,1)',
+      },
+    ],
+  };
+
+  const options = {
+    responsive: true,
+    maintainAspectRatio: false,
+    scales: {
+      y: {
+        beginAtZero: true,
+        ticks: { callback: (v) => Number(v).toLocaleString() },
+      },
+    },
+  };
+
+  return (
+    <div>
+      <h3>쿠팡 매출금액</h3>
+      {loading && <p>Loading…</p>}
+      {error && !loading && <p role="alert">{error}</p>}
+      {!loading && !error && (
+        <div style={{ height: '300px' }}>
+          <Bar options={options} data={chartData} />
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default DailySalesAmountChart;

--- a/client/src/pages/SalesAmount.css
+++ b/client/src/pages/SalesAmount.css
@@ -1,0 +1,3 @@
+.sales-amount-table th {
+  white-space: nowrap;
+}

--- a/client/src/pages/SalesAmount.js
+++ b/client/src/pages/SalesAmount.js
@@ -1,10 +1,100 @@
-import React from 'react';
+import React, { useState } from 'react';
+import DailySalesAmountChart from '../components/DailySalesAmountChart';
+import './SalesAmount.css';
 
 function SalesAmount() {
+  const [list, setList] = useState([]);
+  const [start, setStart] = useState('');
+  const [end, setEnd] = useState('');
+  const [sortCol, setSortCol] = useState('settlementId');
+  const [sortDir, setSortDir] = useState('desc');
+
+  const fetchData = async () => {
+    const params = new URLSearchParams();
+    if (start) params.set('start', start);
+    if (end) params.set('end', end);
+    const res = await fetch(`/api/coupang-sales/fetch?${params}`, {
+      credentials: 'include',
+    });
+    if (res.ok) {
+      const data = await res.json();
+      setList(data);
+    }
+  };
+
+  const sorted = [...list].sort((a, b) => {
+    if (sortCol === 'payoutAmount') {
+      return sortDir === 'asc'
+        ? a.payoutAmount - b.payoutAmount
+        : b.payoutAmount - a.payoutAmount;
+    }
+    return sortDir === 'asc'
+      ? String(a[sortCol]).localeCompare(String(b[sortCol]))
+      : String(b[sortCol]).localeCompare(String(a[sortCol]));
+  });
+
+  const changeSort = (col) => {
+    if (sortCol === col) {
+      setSortDir((d) => (d === 'asc' ? 'desc' : 'asc'));
+    } else {
+      setSortCol(col);
+      setSortDir('asc');
+    }
+  };
+
   return (
-    <div>
-      <h2>매출금액</h2>
-      <p>콘텐츠를 준비 중입니다.</p>
+    <div className="container">
+      <h2>쿠팡 매출금액</h2>
+      <form
+        onSubmit={(e) => {
+          e.preventDefault();
+          fetchData();
+        }}
+        className="d-flex gap-2 mb-3"
+      >
+        <input
+          type="date"
+          className="form-control"
+          value={start}
+          onChange={(e) => setStart(e.target.value)}
+        />
+        <input
+          type="date"
+          className="form-control"
+          value={end}
+          onChange={(e) => setEnd(e.target.value)}
+        />
+        <button type="submit" className="btn btn-primary text-nowrap">
+          조회
+        </button>
+      </form>
+      {list.length > 0 && (
+        <table className="table table-bordered text-center sales-amount-table">
+          <thead>
+            <tr>
+              <th onClick={() => changeSort('settlementId')} role="button">
+                정산ID {sortCol === 'settlementId' && (sortDir === 'asc' ? '▲' : '▼')}
+              </th>
+              <th onClick={() => changeSort('payoutAmount')} role="button">
+                금액 {sortCol === 'payoutAmount' && (sortDir === 'asc' ? '▲' : '▼')}
+              </th>
+              <th>시작일</th>
+              <th>종료일</th>
+            </tr>
+          </thead>
+          <tbody>
+            {sorted.map((row) => (
+              <tr key={row.settlementId}>
+                <td>{row.settlementId}</td>
+                <td>{Number(row.payoutAmount).toLocaleString()}</td>
+                <td>{row.startDate}</td>
+                <td>{row.endDate}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+      <DailySalesAmountChart />
     </div>
   );
 }

--- a/controllers/coupangSalesController.js
+++ b/controllers/coupangSalesController.js
@@ -1,0 +1,40 @@
+const { coupangRequest } = require('../lib/coupangApiClient');
+const asyncHandler = require('../middlewares/asyncHandler');
+
+exports.fetchPayouts = asyncHandler(async (req, res) => {
+  const db = req.app.locals.db;
+  const { start, end, page = 0, size = 20 } = req.query;
+  const query = { page: Number(page), size: Number(size) };
+  if (start) query.startDate = start;
+  if (end) query.endDate = end;
+
+  const data = await coupangRequest(
+    'GET',
+    '/v2/providers/seller_api/apis/api/v1/settlement/payouts',
+    { query }
+  );
+
+  const list = Array.isArray(data.content) ? data.content : [];
+  if (list.length) {
+    const bulk = list.map((item) => ({
+      updateOne: {
+        filter: { settlementId: item.settlementId },
+        update: { $set: item },
+        upsert: true,
+      },
+    }));
+    await db.collection('coupangSales').bulkWrite(bulk);
+  }
+
+  res.json(list);
+});
+
+exports.getAll = asyncHandler(async (req, res) => {
+  const db = req.app.locals.db;
+  const rows = await db
+    .collection('coupangSales')
+    .find()
+    .sort({ settlementId: -1 })
+    .toArray();
+  res.json(rows);
+});

--- a/routes/api/coupangSalesApi.js
+++ b/routes/api/coupangSalesApi.js
@@ -1,0 +1,8 @@
+const express = require('express');
+const router = express.Router();
+const ctrl = require('../../controllers/coupangSalesController');
+
+router.get('/', ctrl.getAll);
+router.get('/fetch', ctrl.fetchPayouts);
+
+module.exports = router;

--- a/routes/api/index.js
+++ b/routes/api/index.js
@@ -21,6 +21,8 @@ router.use("/coupang-add", require("./coupangAddApi"));
 router.use("/coupang-open", require("./coupangOpenApi"));
 // 쿠팡 공급가 API
 router.use("/coupang-supply", require("./coupangSupplyApi"));
+// 쿠팡 매출금액 API
+router.use("/coupang-sales", require("./coupangSalesApi"));
 // 날씨 API
 router.use("/weather", require("./weatherApi"));
 // 간단한 Item API

--- a/routes/web/coupang.js
+++ b/routes/web/coupang.js
@@ -93,6 +93,13 @@ router.get("/stock", (req, res) => {
   res.sendFile(reactIndex);
 });
 
+// React page for /coupang/sales-amount
+router.get("/sales-amount", (req, res) => {
+  const path = require("path");
+  const reactIndex = path.join(__dirname, "..", "..", "client", "public", "index.html");
+  res.sendFile(reactIndex);
+});
+
 // ✅ 엑셀 업로드
 router.post("/upload", upload.single("excelFile"), async (req, res) => {
   const db = req.app.locals.db;


### PR DESCRIPTION
## Summary
- implement new `coupangSalesController` to fetch payout data from Coupang and store it in MongoDB
- expose API routes under `/api/coupang-sales`
- add React page `/coupang/sales-amount` with table and chart

## Testing
- `npm test` *(fails: jest not found)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'scripts')*

------
https://chatgpt.com/codex/tasks/task_e_6863a13144148329ae83edf71d43d80f