### PR TITLE
Fix Coupang inventory endpoint

### DIFF
--- a/services/cronJobs.js
+++ b/services/cronJobs.js
@@ -5,7 +5,8 @@ async function updateInventory(db) {
   const ids = await db.collection('coupang').distinct('Option ID');
   for (const id of ids) {
     try {
-      const path = `/v2/providers/openapi/apis/api/v1/marketplace/vendor-items/${id}`;
+      const vendorId = process.env.CP_VENDOR_ID;
+      const path = `/v2/providers/openapi/apis/api/v1/vendors/${vendorId}/marketplace/vendor-items/${id}`;
       const data = await coupangRequest('GET', path);
       const item = {
         optionId: id,


### PR DESCRIPTION
## Summary
- ensure vendor ID is included when fetching vendor items

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6863ae59dd04832986dd5a556971fb97