### PR TITLE
Fix Coupang API HMAC signature

### DIFF
--- a/lib/coupangApiClient.js
+++ b/lib/coupangApiClient.js
@@ -11,7 +11,11 @@ const fetch = require('node-fetch');
  */
 function signRequest(method, urlPath, secretKey, timestamp) {
   const message = `${timestamp}${method}${urlPath}`;
-  return crypto.createHmac('sha256', secretKey).update(message).digest('base64');
+  // Coupang's documentation specifies a hex-encoded HMAC signature
+  // Use hex to match the Python helper implementation for consistency
+  return crypto.createHmac('sha256', secretKey)
+    .update(message)
+    .digest('hex');
 }
 
 /**

--- a/tests/coupangApiClient.test.js
+++ b/tests/coupangApiClient.test.js
@@ -30,7 +30,7 @@ test('coupangRequest sends signed request and returns data', async () => {
   const expectedSignature = crypto
     .createHmac('sha256', 'secret')
     .update('1600000000000GET/test?a=1')
-    .digest('base64');
+    .digest('hex');
 
   expect(mockFetch).toHaveBeenCalledWith(
     'https://api.example.com/test?a=1',


### PR DESCRIPTION
## Summary
- use hex encoded signature in Coupang API client
- update test to match new signature algorithm

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68687ce07c18832999d9ea56e5b10835