### PR TITLE
Implement session extension feature

### DIFF
--- a/client/src/components/Header.js
+++ b/client/src/components/Header.js
@@ -44,9 +44,15 @@ function Header({ onToggleSidebar }) {
     return () => clearInterval(id);
   }, [logoutAt]);
 
-  const handleLogout = async () => {
-    await fetch("/api/auth/logout", { method: "POST", credentials: "include" });
-    window.location.href = "/login";
+  const handleExtend = async () => {
+    const res = await fetch("/api/auth/extend", {
+      method: "POST",
+      credentials: "include",
+    });
+    if (res.ok) {
+      const data = await res.json();
+      setLogoutAt(data.expiresAt);
+    }
   };
 
   return (
@@ -72,12 +78,13 @@ function Header({ onToggleSidebar }) {
         {user && <span className="me-3">{user.name || user.username}</span>}
         {timeLeft !== null && (
           <span className="me-3 text-muted">
-            로그아웃 {Math.floor(timeLeft / 60000)}:
+            시간연장 {String(Math.floor(timeLeft / 3600000)).padStart(2, "0")}:
+            {String(Math.floor((timeLeft % 3600000) / 60000)).padStart(2, "0")}:
             {String(Math.floor((timeLeft % 60000) / 1000)).padStart(2, "0")}
           </span>
         )}
-        <button type="button" className="btn btn-link" onClick={handleLogout}>
-          로그아웃
+        <button type="button" className="btn btn-link" onClick={handleExtend}>
+          시간연장
         </button>
       </div>
     </header>

--- a/controllers/apiAuthController.js
+++ b/controllers/apiAuthController.js
@@ -75,3 +75,14 @@ exports.sessionInfo = (req, res) => {
   const expires = cookie?.expires || new Date(Date.now() + (cookie?.maxAge || 0));
   res.json({ expiresAt: expires });
 };
+
+exports.extendSession = (req, res) => {
+  if (req.session && req.session.cookie) {
+    const maxAge = req.session.cookie.originalMaxAge || req.session.cookie.maxAge;
+    req.session.cookie.expires = new Date(Date.now() + maxAge);
+    if (typeof req.session.touch === 'function') {
+      req.session.touch();
+    }
+  }
+  res.json({ expiresAt: req.session?.cookie?.expires });
+};

--- a/routes/api/authApi.js
+++ b/routes/api/authApi.js
@@ -5,6 +5,7 @@ const controller = require('../../controllers/apiAuthController');
 router.post('/login', controller.login);
 router.post('/register', controller.register);
 router.post('/logout', controller.logout);
+router.post('/extend', controller.extendSession);
 router.get('/user', controller.getUser);
 router.get('/session', controller.sessionInfo);
 

--- a/views/nav.ejs
+++ b/views/nav.ejs
@@ -67,7 +67,7 @@
           <% if (logoutAt) { %>
             <span id="logout-timer" class="nav-link text-muted pe-2" data-logout-at="<%= logoutAt %>"></span>
           <% } %>
-          <a class="nav-link text-danger" href="/logout">🚪 로그아웃</a>
+          <a id="extend-btn" class="nav-link text-danger" href="#">시간연장</a>
         </li>
       <% } else { %>
         <!-- 비로그인 사용자용 메뉴 -->
@@ -95,17 +95,39 @@
     });
 
     var timerEl = document.getElementById('logout-timer');
+    var extendBtn = document.getElementById('extend-btn');
+    var logoutTime;
+    function updateTimer() {
+      if (!logoutTime) return;
+      var diff = logoutTime - new Date();
+      if (diff < 0) diff = 0;
+      var h = Math.floor(diff / 3600000);
+      var m = Math.floor((diff % 3600000) / 60000);
+      var s = Math.floor((diff % 60000) / 1000);
+      timerEl.textContent =
+        '시간연장 ' +
+        String(h).padStart(2, '0') + ':' +
+        String(m).padStart(2, '0') + ':' +
+        String(s).padStart(2, '0');
+    }
     if (timerEl && timerEl.dataset.logoutAt) {
-      var logoutTime = new Date(timerEl.dataset.logoutAt);
-      function updateTimer() {
-        var diff = logoutTime - new Date();
-        if (diff < 0) diff = 0;
-        var m = Math.floor(diff / 60000);
-        var s = Math.floor((diff % 60000) / 1000);
-        timerEl.textContent = '로그아웃 ' + m + ':' + (s < 10 ? '0' : '') + s;
-      }
+      logoutTime = new Date(timerEl.dataset.logoutAt);
       updateTimer();
       setInterval(updateTimer, 1000);
+    }
+    if (extendBtn) {
+      extendBtn.addEventListener('click', function (e) {
+        e.preventDefault();
+        fetch('/api/auth/extend', { method: 'POST', credentials: 'include' })
+          .then(function (res) { return res.json(); })
+          .then(function (data) {
+            logoutTime = new Date(data.expiresAt);
+            if (timerEl) {
+              timerEl.dataset.logoutAt = data.expiresAt;
+            }
+            updateTimer();
+          });
+      });
     }
   });
 </script>


### PR DESCRIPTION
## Summary
- add new `/api/auth/extend` route and controller to refresh the session cookie
- show remaining session time as `HH:MM:SS` and rename logout UI to `시간연장`
- update React header to use new endpoint
- tweak EJS navigation to support session extension

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6868860f498083298c6d68f49998a91b