### PR TITLE
Add real-time city temperature graph

### DIFF
--- a/client/src/components/CityTempChart.jsx
+++ b/client/src/components/CityTempChart.jsx
@@ -1,0 +1,105 @@
+import React, { useEffect, useState } from "react";
+import { Line } from "react-chartjs-2";
+import {
+  Chart as ChartJS,
+  CategoryScale,
+  LinearScale,
+  PointElement,
+  LineElement,
+  Tooltip,
+  Legend,
+} from "chart.js";
+
+ChartJS.register(
+  CategoryScale,
+  LinearScale,
+  PointElement,
+  LineElement,
+  Tooltip,
+  Legend,
+);
+
+function CityTempChart() {
+  const [city, setCity] = useState("seoul");
+  const [data, setData] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+
+  const cities = [
+    { label: "서울", value: "seoul" },
+    { label: "부산", value: "busan" },
+    { label: "대구", value: "daegu" },
+    { label: "인천", value: "incheon" },
+    { label: "광주", value: "gwangju" },
+    { label: "대전", value: "daejeon" },
+  ];
+
+  const fetchData = () => {
+    setLoading(true);
+    fetch(`/api/dashboard/city-temp?city=${city}`, { credentials: "include" })
+      .then((res) => {
+        if (!res.ok) throw new Error("failed");
+        return res.json();
+      })
+      .then((d) => setData(d))
+      .catch(() => setError("데이터를 불러오지 못했습니다."))
+      .finally(() => setLoading(false));
+  };
+
+  useEffect(() => {
+    fetchData();
+    const id = setInterval(fetchData, 10 * 60 * 1000);
+    return () => clearInterval(id);
+  }, [city]);
+
+  const chartData = {
+    labels: data.map((d) => d.time.slice(11, 16)),
+    datasets: [
+      {
+        label: "기온(℃)",
+        data: data.map((d) => d.temperature),
+        borderColor: "rgba(255,99,132,1)",
+        backgroundColor: "rgba(255,99,132,0.2)",
+        tension: 0.3,
+      },
+    ],
+  };
+
+  const options = {
+    responsive: true,
+    maintainAspectRatio: false,
+    scales: {
+      y: {
+        ticks: { callback: (v) => `${v}°` },
+      },
+    },
+  };
+
+  return (
+    <div>
+      <h3>도시별 기온</h3>
+      <div className="mb-2">
+        <select
+          className="form-select"
+          value={city}
+          onChange={(e) => setCity(e.target.value)}
+        >
+          {cities.map((c) => (
+            <option key={c.value} value={c.value}>
+              {c.label}
+            </option>
+          ))}
+        </select>
+      </div>
+      {loading && <p>Loading…</p>}
+      {error && !loading && <p role="alert">{error}</p>}
+      {!loading && !error && (
+        <div style={{ height: "300px" }}>
+          <Line options={options} data={chartData} />
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default CityTempChart;

--- a/client/src/pages/Dashboard.js
+++ b/client/src/pages/Dashboard.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import DailyAdCostChart from '../components/DailyAdCostChart';
+import CityTempChart from '../components/CityTempChart';
 import './Dashboard.css';
 
 function Dashboard() {
@@ -8,7 +9,9 @@ function Dashboard() {
       <div className="grid-item">
         <DailyAdCostChart />
       </div>
-      <div className="grid-item">2</div>
+      <div className="grid-item">
+        <CityTempChart />
+      </div>
       <div className="grid-item">3</div>
       <div className="grid-item">4</div>
     </div>

--- a/controllers/dashboardController.js
+++ b/controllers/dashboardController.js
@@ -23,3 +23,37 @@ exports.getDailyAdCost = asyncHandler(async (req, res) => {
   const data = await db.collection('adHistory').aggregate(pipeline).toArray();
   res.json(data);
 });
+
+// GET /api/dashboard/city-temp
+// Return hourly temperature for a given city (past 24 hours)
+exports.getCityTempHistory = asyncHandler(async (req, res) => {
+  const city = (req.query.city || 'seoul').toLowerCase();
+  const cityCoords = {
+    seoul: { lat: 37.5665, lon: 126.978 },
+    busan: { lat: 35.1796, lon: 129.0756 },
+    daegu: { lat: 35.8722, lon: 128.6025 },
+    incheon: { lat: 37.4563, lon: 126.7052 },
+    gwangju: { lat: 35.1595, lon: 126.8526 },
+    daejeon: { lat: 36.3504, lon: 127.3845 },
+  };
+  const coords = cityCoords[city];
+  if (!coords) {
+    return res.status(400).json({ message: 'Unknown city' });
+  }
+  const params = new URLSearchParams({
+    latitude: coords.lat,
+    longitude: coords.lon,
+    hourly: 'temperature_2m',
+    timezone: 'Asia/Seoul',
+    past_days: '1',
+  });
+  const response = await fetch(`https://api.open-meteo.com/v1/forecast?${params}`);
+  if (!response.ok) {
+    return res.status(502).json({ message: 'Weather API error' });
+  }
+  const data = await response.json();
+  const times = data.hourly.time || [];
+  const temps = data.hourly.temperature_2m || [];
+  const result = times.map((t, idx) => ({ time: t, temperature: temps[idx] }));
+  res.json(result);
+});

--- a/routes/api/dashboard.js
+++ b/routes/api/dashboard.js
@@ -3,5 +3,6 @@ const router = express.Router();
 const ctrl = require('../../controllers/dashboardController');
 
 router.get('/ad-cost-daily', ctrl.getDailyAdCost);
+router.get('/city-temp', ctrl.getCityTempHistory);
 
 module.exports = router;


### PR DESCRIPTION
## Summary
- show temperature by city in dashboard
- expose `/api/dashboard/city-temp` API for fetching city temperature data

## Testing
- `npm run lint`
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68689e1cffb8832991ad5d2e2de24c8d