### PR TITLE
Fix dashboard city temperature source

### DIFF
--- a/client/src/pages/Stock.css
+++ b/client/src/pages/Stock.css
@@ -48,6 +48,7 @@
 
 .stock-table th {
   background-color: #ffffff;
+  white-space: nowrap;
 }
 
 .stock-table tbody tr {

--- a/controllers/dashboardController.js
+++ b/controllers/dashboardController.js
@@ -25,35 +25,21 @@ exports.getDailyAdCost = asyncHandler(async (req, res) => {
 });
 
 // GET /api/dashboard/city-temp
-// Return hourly temperature for a given city (past 24 hours)
+// Return hourly temperature for a given city (stored in DB)
 exports.getCityTempHistory = asyncHandler(async (req, res) => {
   const city = (req.query.city || 'seoul').toLowerCase();
-  const cityCoords = {
-    seoul: { lat: 37.5665, lon: 126.978 },
-    busan: { lat: 35.1796, lon: 129.0756 },
-    daegu: { lat: 35.8722, lon: 128.6025 },
-    incheon: { lat: 37.4563, lon: 126.7052 },
-    gwangju: { lat: 35.1595, lon: 126.8526 },
-    daejeon: { lat: 36.3504, lon: 127.3845 },
-  };
-  const coords = cityCoords[city];
-  if (!coords) {
-    return res.status(400).json({ message: 'Unknown city' });
-  }
-  const params = new URLSearchParams({
-    latitude: coords.lat,
-    longitude: coords.lon,
-    hourly: 'temperature_2m',
-    timezone: 'Asia/Seoul',
-    past_days: '1',
-  });
-  const response = await fetch(`https://api.open-meteo.com/v1/forecast?${params}`);
-  if (!response.ok) {
-    return res.status(502).json({ message: 'Weather API error' });
-  }
-  const data = await response.json();
-  const times = data.hourly.time || [];
-  const temps = data.hourly.temperature_2m || [];
-  const result = times.map((t, idx) => ({ time: t, temperature: temps[idx] }));
+  const db = req.app.locals.db;
+
+  const data = await db
+    .collection('cityWeather')
+    .find({ city })
+    .sort({ time: 1 })
+    .toArray();
+
+  const result = data.map((d) => ({
+    time: d.time,
+    temperature: d.temperature,
+  }));
+
   res.json(result);
 });

--- a/tests/dashboardApi.test.js
+++ b/tests/dashboardApi.test.js
@@ -2,6 +2,8 @@ jest.setTimeout(60000);
 
 const mockCollection = {
   aggregate: jest.fn().mockReturnThis(),
+  find: jest.fn().mockReturnThis(),
+  sort: jest.fn().mockReturnThis(),
   toArray: jest.fn().mockResolvedValue([]),
 };
 
@@ -44,4 +46,18 @@ test('GET /api/dashboard/ad-cost-daily returns aggregated data', async () => {
   ]);
   expect(app.locals.db.collection).toHaveBeenCalledWith('adHistory');
   expect(mockCollection.aggregate).toHaveBeenCalled();
+});
+
+test('GET /api/dashboard/city-temp returns data from db', async () => {
+  mockCollection.toArray.mockResolvedValueOnce([
+    { time: '2024-06-27T10:00', temperature: 21.2 },
+  ]);
+
+  const res = await request(app).get('/api/dashboard/city-temp?city=seoul');
+  expect(res.statusCode).toBe(200);
+  expect(res.body).toEqual([
+    { time: '2024-06-27T10:00', temperature: 21.2 },
+  ]);
+  expect(app.locals.db.collection).toHaveBeenCalledWith('cityWeather');
+  expect(mockCollection.find).toHaveBeenCalledWith({ city: 'seoul' });
 });


### PR DESCRIPTION
## Summary
- fetch city temperature history from MongoDB instead of an external API
- keep header text on a single line in stock tables
- cover dashboard API for city temperature with tests

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6868a2e3649c8329bede404861a7489c