### PR TITLE
Ensure numeric data for charts

### DIFF
--- a/client/src/__tests__/DailyAdCostChart.test.js
+++ b/client/src/__tests__/DailyAdCostChart.test.js
@@ -15,7 +15,7 @@ test('renders bar chart with fetched data', async () => {
       ok: true,
       json: () =>
         Promise.resolve([
-          { date: '2023-01-01', totalCost: 100 },
+          { date: '2023-01-01', totalCost: '1,234' },
         ]),
     })
   );
@@ -30,7 +30,7 @@ test('renders bar chart with fetched data', async () => {
 
   const data = JSON.parse(screen.getByTestId('bar-props').textContent);
   expect(data.labels).toEqual(['2023-01-01']);
-  expect(data.datasets[0].data).toEqual([100]);
+  expect(data.datasets[0].data).toEqual([1234]);
 });
 
 test('shows error message on fetch failure', async () => {

--- a/client/src/components/DailyAdCostChart.jsx
+++ b/client/src/components/DailyAdCostChart.jsx
@@ -44,7 +44,9 @@ function DailyAdCostChart() {
     datasets: [
       {
         label: '광고비',
-        data: sliced.map((d) => d.totalCost),
+        data: sliced.map((d) =>
+          Number(String(d.totalCost).replace(/,/g, ''))
+        ),
         backgroundColor: 'rgba(75,192,192,0.6)',
         borderColor: 'rgba(75,192,192,1)',
       },

--- a/client/src/components/DailySalesAmountChart.jsx
+++ b/client/src/components/DailySalesAmountChart.jsx
@@ -33,7 +33,9 @@ function DailySalesAmountChart() {
     datasets: [
       {
         label: '정산금액',
-        data: data.map((d) => d.payoutAmount),
+        data: data.map((d) =>
+          Number(String(d.payoutAmount).replace(/,/g, ''))
+        ),
         backgroundColor: 'rgba(153,102,255,0.6)',
         borderColor: 'rgba(153,102,255,1)',
       },


### PR DESCRIPTION
## Summary
- sanitize numeric values in DailyAdCostChart and DailySalesAmountChart
- update DailyAdCostChart test to cover string numbers

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6868a0297bc0832984847488e9ee4817