### PR TITLE
Add data labels to chart components

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -10,7 +10,8 @@
     "react-scripts": "^5.0.1",
     "web-vitals": "^2.1.4",
     "chart.js": "^4.4.1",
-    "react-chartjs-2": "^5.2.0"
+    "react-chartjs-2": "^5.2.0",
+    "chartjs-plugin-datalabels": "^2.2.0"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/client/src/components/DailyAdCostChart.jsx
+++ b/client/src/components/DailyAdCostChart.jsx
@@ -8,6 +8,7 @@ import {
   Tooltip,
   Legend,
 } from 'chart.js';
+import ChartDataLabels from 'chartjs-plugin-datalabels';
 
 ChartJS.register(
   CategoryScale,
@@ -15,6 +16,7 @@ ChartJS.register(
   BarElement,
   Tooltip,
   Legend,
+  ChartDataLabels,
 );
 
 function DailyAdCostChart() {
@@ -69,6 +71,13 @@ function DailyAdCostChart() {
         ticks: {
           callback: (v) => v.toLocaleString(),
         },
+      },
+    },
+    plugins: {
+      datalabels: {
+        anchor: 'end',
+        align: 'end',
+        formatter: (v) => v.toLocaleString(),
       },
     },
   };

--- a/client/src/components/DailySalesAmountChart.jsx
+++ b/client/src/components/DailySalesAmountChart.jsx
@@ -8,8 +8,16 @@ import {
   Tooltip,
   Legend,
 } from 'chart.js';
+import ChartDataLabels from 'chartjs-plugin-datalabels';
 
-ChartJS.register(CategoryScale, LinearScale, BarElement, Tooltip, Legend);
+ChartJS.register(
+  CategoryScale,
+  LinearScale,
+  BarElement,
+  Tooltip,
+  Legend,
+  ChartDataLabels,
+);
 
 function DailySalesAmountChart() {
   const [data, setData] = useState([]);
@@ -49,6 +57,13 @@ function DailySalesAmountChart() {
       y: {
         beginAtZero: true,
         ticks: { callback: (v) => Number(v).toLocaleString() },
+      },
+    },
+    plugins: {
+      datalabels: {
+        anchor: 'end',
+        align: 'end',
+        formatter: (v) => v.toLocaleString(),
       },
     },
   };


### PR DESCRIPTION
## Summary
- display chart values directly on charts
- register chartjs-plugin-datalabels and add dependency

## Testing
- `npm run lint`
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6868aa1715148329836334d59fbc44df