### PR TITLE
Fix daily ad cost API

### DIFF
--- a/routes/api/dashboard.js
+++ b/routes/api/dashboard.js
@@ -2,7 +2,39 @@ const express = require('express');
 const router = express.Router();
 const ctrl = require('../../controllers/dashboardController');
 
-router.get('/ad-cost-daily', ctrl.getDailyAdCost);
+router.get('/ad-cost-daily', async (req, res) => {
+  const db = req.app.locals.db;
+
+  try {
+    const data = await db
+      .collection('adHistory')
+      .aggregate([
+        {
+          $group: {
+            _id: '$date',
+            totalCost: { $sum: '$cost' },
+          },
+        },
+        { $sort: { _id: 1 } },
+        {
+          $project: {
+            _id: 0,
+            date: '$_id',
+            totalCost: 1,
+          },
+        },
+      ])
+      .toArray();
+
+    res.json(data);
+  } catch (err) {
+    console.error(err);
+    res
+      .status(500)
+      .json({ message: '서버에서 데이터를 조회하는 중 오류가 발생했습니다.' });
+  }
+});
+
 router.get('/city-temp', ctrl.getCityTempHistory);
 router.post('/city-temp', ctrl.saveCityTemp);
 


### PR DESCRIPTION
## Summary
- implement the `/api/dashboard/ad-cost-daily` endpoint directly in the router with a MongoDB aggregation

## Testing
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6868b227158483298823a28f8c576d12