### PR TITLE
Automate ad history update

### DIFF
--- a/controllers/coupangAddController.js
+++ b/controllers/coupangAddController.js
@@ -4,6 +4,7 @@ const multer = multerImport.default || multerImport;
 const xlsx = require('xlsx');
 const fs = require('fs');
 const asyncHandler = require('../middlewares/asyncHandler');
+const { saveDailyAdCost } = require('../services/cronJobs');
 
 // Multer storage
 const storage = multer.diskStorage({
@@ -259,6 +260,7 @@ exports.uploadExcel = asyncHandler(async (req, res) => {
   const db = req.app.locals.db;
   await db.collection('coupangAdd').deleteMany({});
   if (data.length > 0) await db.collection('coupangAdd').insertMany(data);
+  await saveDailyAdCost(db);
 
   fs.unlink(filePath, () => {});
   if (req.flash) req.flash('성공메시지', '✅ 업로드 완료');
@@ -299,6 +301,7 @@ exports.uploadExcelApi = asyncHandler(async (req, res) => {
   const db = req.app.locals.db;
   await db.collection('coupangAdd').deleteMany({});
   if (data.length > 0) await db.collection('coupangAdd').insertMany(data);
+  await saveDailyAdCost(db);
 
   fs.unlink(filePath, () => {});
   res.json({ status: 'success' });

--- a/services/cronJobs.js
+++ b/services/cronJobs.js
@@ -200,4 +200,4 @@ function startCronJobs(db) {
   }, costRun - now);
 }
 
-module.exports = { startCronJobs };
+module.exports = { startCronJobs, saveDailyAdCost };

--- a/tests/coupangAddController.test.js
+++ b/tests/coupangAddController.test.js
@@ -16,6 +16,7 @@ const mockCollection = {
         .map((d) => ({ 날짜: d, 광고비: summary[d] }));
     })
   })),
+  updateOne: jest.fn().mockResolvedValue(),
 };
 
 jest.mock('../config/db', () => {
@@ -72,5 +73,7 @@ test('upload normalizes date formats and date summary aggregates', async () => {
   ]);
 
   fs.unlinkSync(tmpFile);
+  expect(app.locals.db.collection).toHaveBeenCalledWith('adHistory');
+  expect(mockCollection.updateOne).toHaveBeenCalledTimes(2);
 });
 


### PR DESCRIPTION
## Summary
- update ad history after uploading Coupang ad data
- expose `saveDailyAdCost` helper for reuse
- test ad history updates after Excel upload

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6868c0631284832992d75bc44d45a9f7