### PR TITLE
Support Korean cities for weather chart

### DIFF
--- a/client/src/components/CityTempChart.jsx
+++ b/client/src/components/CityTempChart.jsx
@@ -17,19 +17,16 @@ ChartJS.register(
   Legend,
 );
 
+import cityCoords from '../../../data/cityCoords.json';
+
 function CityTempChart() {
   const [data, setData] = useState([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
 
-  const cityLabels = {
-    seoul: '서울',
-    busan: '부산',
-    daegu: '대구',
-    incheon: '인천',
-    gwangju: '광주',
-    daejeon: '대전',
-  };
+  const cityLabels = Object.fromEntries(
+    Object.entries(cityCoords).map(([k, v]) => [k, v.label]),
+  );
 
   const fetchData = () => {
     setLoading(true);

--- a/controllers/dashboardController.js
+++ b/controllers/dashboardController.js
@@ -1,5 +1,6 @@
 const asyncHandler = require('../middlewares/asyncHandler');
 const { fetchDaily } = require('./weatherController');
+const cityCoords = require('../data/cityCoords.json');
 
 function getDefaultBaseDateTime() {
   const now = new Date();
@@ -85,15 +86,7 @@ exports.getCityTempHistory = asyncHandler(async (req, res) => {
 exports.saveCityTemp = asyncHandler(async (req, res) => {
   const city = (req.body.city || req.query.city || 'seoul').toLowerCase();
 
-  const coordsMap = {
-    seoul: { nx: '60', ny: '127' },
-    busan: { nx: '98', ny: '76' },
-    daegu: { nx: '89', ny: '90' },
-    incheon: { nx: '55', ny: '124' },
-    gwangju: { nx: '58', ny: '74' },
-    daejeon: { nx: '67', ny: '100' },
-  };
-  const coords = coordsMap[city];
+  const coords = cityCoords[city];
   if (!coords) return res.status(400).json({ message: 'Unknown city' });
 
   const { baseDate, baseTime } = getDefaultBaseDateTime();

--- a/data/cityCoords.json
+++ b/data/cityCoords.json
@@ -1,0 +1,19 @@
+{
+  "seoul": { "nx": "60", "ny": "127", "label": "서울" },
+  "busan": { "nx": "98", "ny": "76", "label": "부산" },
+  "daegu": { "nx": "89", "ny": "90", "label": "대구" },
+  "incheon": { "nx": "55", "ny": "124", "label": "인천" },
+  "gwangju": { "nx": "58", "ny": "74", "label": "광주" },
+  "daejeon": { "nx": "67", "ny": "100", "label": "대전" },
+  "ulsan": { "nx": "102", "ny": "84", "label": "울산" },
+  "sejong": { "nx": "66", "ny": "103", "label": "세종" },
+  "gyeonggi": { "nx": "60", "ny": "120", "label": "경기" },
+  "gangwon": { "nx": "73", "ny": "134", "label": "강원" },
+  "chungbuk": { "nx": "69", "ny": "107", "label": "충북" },
+  "chungnam": { "nx": "68", "ny": "100", "label": "충남" },
+  "jeonbuk": { "nx": "63", "ny": "89", "label": "전북" },
+  "jeonnam": { "nx": "51", "ny": "67", "label": "전남" },
+  "gyeongbuk": { "nx": "89", "ny": "91", "label": "경북" },
+  "gyeongnam": { "nx": "91", "ny": "77", "label": "경남" },
+  "jeju": { "nx": "52", "ny": "38", "label": "제주" }
+}

--- a/services/cronJobs.js
+++ b/services/cronJobs.js
@@ -97,15 +97,10 @@ async function saveTodayWeather(db) {
   }
 }
 
+const cityCoords = require('../data/cityCoords.json');
+
 async function saveCityTemperatures(db) {
-  const cities = {
-    seoul: { nx: '60', ny: '127' },
-    busan: { nx: '98', ny: '76' },
-    daegu: { nx: '89', ny: '90' },
-    incheon: { nx: '55', ny: '124' },
-    gwangju: { nx: '58', ny: '74' },
-    daejeon: { nx: '67', ny: '100' },
-  };
+  const cities = cityCoords;
 
   const { baseDate, baseTime } = getDefaultBaseDateTime();
   const isoTime = `${baseDate.slice(0, 4)}-${baseDate.slice(4, 6)}-${baseDate.slice(6, 8)}T${baseTime.slice(0, 2)}:00`;


### PR DESCRIPTION
## Summary
- store coordinates for 17 Korean cities in `data/cityCoords.json`
- use new city list when saving hourly city temperatures
- share city list with dashboard API
- display labels from shared city list in CityTempChart

## Testing
- `npm ci` *(fails: registry access blocked)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6868c2c3e67883298df9c23ef095c47d