### PR TITLE
Fix ad history aggregation

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,6 +216,7 @@ Daily advertising costs from the `coupangAdd` collection can be aggregated into
 and upserts one document per day with `{ date: 'YYYYMMDD', cost: <number> }`.
 
 ```bash
+# run from the project root so dotenv can load the environment variables
 node scripts/update_ad_history.js
 ```
 

--- a/scripts/update_ad_history.js
+++ b/scripts/update_ad_history.js
@@ -17,7 +17,8 @@ async function updateAdHistory() {
         {
           $group: {
             _id: '$날짜',
-            cost: { $sum: '$광고비' },
+            // ensure cost is numeric before summing
+            cost: { $sum: { $toDouble: '$광고비' } },
           },
         },
         {


### PR DESCRIPTION
## Summary
- ensure the ad cost is converted to a number when aggregating
- document running the ad history script from project root

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6868c41a6e0c832992e90859f70779fb