### PR TITLE
Add run history logging for ad cost updater

### DIFF
--- a/scripts/update_ad_history.js
+++ b/scripts/update_ad_history.js
@@ -36,13 +36,19 @@ async function updateAdHistory() {
       ])
       .toArray();
 
-    for (const row of rows) {
-      await db.collection('adHistory').updateOne(
-        { date: row.date },
-        { $set: { cost: row.cost, updatedAt: new Date() } },
-        { upsert: true },
-      );
-    }
+  for (const row of rows) {
+    await db.collection('adHistory').updateOne(
+      { date: row.date },
+      { $set: { cost: row.cost, updatedAt: new Date() } },
+      { upsert: true },
+    );
+  }
+
+  // 기록용 로그 컬렉션에 실행 내역 저장
+  await db.collection('update_ad_history').insertOne({
+    runAt: new Date(),
+    rows: rows.length,
+  });
 
     console.log(`\u2705 Updated adHistory with ${rows.length} documents`);
   } catch (err) {

--- a/services/cronJobs.js
+++ b/services/cronJobs.js
@@ -152,6 +152,12 @@ async function saveDailyAdCost(db) {
       { upsert: true },
     );
   }
+
+  // 실행 내역 기록
+  await db.collection('update_ad_history').insertOne({
+    runAt: new Date(),
+    rows: rows.length,
+  });
 }
 
 function startCronJobs(db) {


### PR DESCRIPTION
## Summary
- track when daily ad cost aggregation is executed
- log run metadata from cron and helper script

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6868c5a94dc88329ae720ddc3a623a5d