### PR TITLE
Add adHistory update API

### DIFF
--- a/client/src/pages/AdHistory.js
+++ b/client/src/pages/AdHistory.js
@@ -58,7 +58,8 @@ function AdHistory() {
   };
 
   const fetchDateSummary = async () => {
-    const res = await fetch('/api/coupang-add/summary/date', {
+    const res = await fetch('/api/ad-history/update', {
+      method: 'POST',
       credentials: 'include',
     });
     if (res.ok) {

--- a/controllers/adHistoryController.js
+++ b/controllers/adHistoryController.js
@@ -1,5 +1,6 @@
 const { ObjectId } = require('mongodb');
 const asyncHandler = require('../middlewares/asyncHandler');
+const { saveDailyAdCost } = require('../services/cronJobs');
 
 // 광고 내역 목록 조회
 exports.list = asyncHandler(async (req, res) => {
@@ -64,4 +65,16 @@ exports.remove = asyncHandler(async (req, res) => {
   if (result.deletedCount === 0)
     return res.status(404).json({ message: 'Not found' });
   res.json({ success: true });
+});
+
+// coupangAdd 컬렉션을 기반으로 광고비 합산 후 adHistory 갱신
+exports.updateFromCoupangAdd = asyncHandler(async (req, res) => {
+  const db = req.app.locals.db;
+  await saveDailyAdCost(db);
+  const rows = await db
+    .collection('adHistory')
+    .find()
+    .sort({ date: 1 })
+    .toArray();
+  res.json(rows);
 });

--- a/routes/api/adHistory.js
+++ b/routes/api/adHistory.js
@@ -4,6 +4,7 @@ const ctrl = require('../../controllers/adHistoryController');
 
 router.get('/', ctrl.list);
 router.post('/', ctrl.create);
+router.post('/update', ctrl.updateFromCoupangAdd);
 router.get('/:id', ctrl.detail);
 router.put('/:id', ctrl.update);
 router.delete('/:id', ctrl.remove);

--- a/tests/adHistoryUpdate.test.js
+++ b/tests/adHistoryUpdate.test.js
@@ -1,0 +1,51 @@
+jest.setTimeout(60000);
+
+const mockCoupangAdd = {
+  aggregate: jest.fn(() => ({ toArray: jest.fn().mockResolvedValue([{ date: '20240601', cost: 100 }]) })),
+};
+const mockAdHistory = {
+  updateOne: jest.fn().mockResolvedValue(),
+  find: jest.fn().mockReturnThis(),
+  sort: jest.fn().mockReturnThis(),
+  toArray: jest.fn().mockResolvedValue([{ date: '20240601', cost: 100 }]),
+};
+
+jest.mock('../config/db', () => {
+  const mockDb = {
+    collection: jest.fn((name) => {
+      if (name === 'coupangAdd') return mockCoupangAdd;
+      if (name === 'adHistory') return mockAdHistory;
+      return {};
+    }),
+  };
+  const mockConnect = jest.fn().mockResolvedValue(mockDb);
+  mockConnect.then = (fn) => fn(mockDb);
+  return { connectDB: mockConnect, closeDB: jest.fn().mockResolvedValue() };
+});
+
+const request = require('supertest');
+const { initApp } = require('../server');
+const { closeDB } = require('../config/db');
+
+let app;
+
+beforeAll(async () => {
+  process.env.NODE_ENV = 'test';
+  process.env.MONGO_URI = 'mongodb://127.0.0.1:27017/testdb';
+  process.env.DB_NAME = 'testdb';
+  process.env.SESSION_SECRET = 'testsecret';
+
+  app = await initApp();
+});
+
+afterAll(async () => {
+  await closeDB();
+});
+
+test('POST /api/ad-history/update aggregates data and returns list', async () => {
+  const res = await request(app).post('/api/ad-history/update');
+  expect(res.statusCode).toBe(200);
+  expect(res.body).toEqual([{ date: '20240601', cost: 100 }]);
+  expect(app.locals.db.collection).toHaveBeenCalledWith('adHistory');
+  expect(mockAdHistory.updateOne).toHaveBeenCalled();
+});


### PR DESCRIPTION
## Summary
- compute daily ad cost and persist to adHistory via new controller function
- expose POST `/api/ad-history/update`
- update front-end to use the new endpoint
- add regression test for the update API

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6868c86f2bd0832991ca16009e856950