### PR TITLE
Enable ad cost chart

### DIFF
--- a/client/src/pages/CoupangStock.js
+++ b/client/src/pages/CoupangStock.js
@@ -3,6 +3,7 @@ import './CoupangStock.css';
 import { useQueryClient } from '../react-query-lite';
 import useDebounce from '../hooks/useDebounce';
 import useCoupangStocks from '../hooks/useCoupangStocks';
+import DailyAdCostChart from '../components/DailyAdCostChart';
 
 const BRANDS = ['트라이', 'BYC', '제임스딘'];
 
@@ -37,7 +38,10 @@ function CoupangStock() {
   }, [data]);
 
   const loadAdSummary = async () => {
-    const res = await fetch('/api/coupang-add/summary/date', { credentials: 'include' });
+    const res = await fetch('/api/ad-history/update', {
+      method: 'POST',
+      credentials: 'include',
+    });
     if (res.ok) {
       const data = await res.json();
       setAdSummary(data);
@@ -256,6 +260,7 @@ function CoupangStock() {
       {adSummary.length > 0 && (
         <div className="mt-4">
           <h3>쿠팡 광고비 내역</h3>
+          <DailyAdCostChart />
           <table className="table table-bordered text-center mt-2">
             <thead>
               <tr>


### PR DESCRIPTION
## Summary
- update Coupang stock page to show daily ad cost chart
- fetch daily ad cost data from `/api/ad-history/update`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6868cb441ed88329b9148f3e930c8e87