### PR TITLE
Improve AdHistory chart

### DIFF
--- a/client/src/components/DailyAdCostChart.jsx
+++ b/client/src/components/DailyAdCostChart.jsx
@@ -74,10 +74,15 @@ function DailyAdCostChart() {
       },
     },
     plugins: {
+      tooltip: {
+        callbacks: {
+          label: (ctx) => ctx.parsed.y.toLocaleString(),
+        },
+      },
       datalabels: {
         anchor: 'end',
         align: 'end',
-        formatter: (v) => v.toLocaleString(),
+        formatter: (v) => Math.ceil(v / 10000).toLocaleString(),
       },
     },
   };


### PR DESCRIPTION
## Summary
- show ad cost values on hover
- round chart labels to the nearest ten-thousand

## Testing
- `npx jest` *(fails: npm registry blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6868d6c3444883298989faa18c72e883