### PR TITLE
Add analytics chart with bootstrap navbar

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -21,6 +21,7 @@ import Help from './pages/Help';
 import AdminRoutes from './routes/AdminRoutes';
 import Placeholder from './pages/Placeholder';
 import AdHistory from './pages/AdHistory';
+import Analytics from './pages/Analytics';
 
 function App() {
   return (
@@ -34,10 +35,11 @@ function App() {
         <Route element={<DashboardLayout />}>
           <Route path="/dashboard" element={<Dashboard />} />
           <Route path="/board" element={<Board />} />
-          <Route path="/board/:id" element={<PostDetail />} />
-          <Route path="/:shop/board" element={<Board />} />
-          <Route path="/:shop/board/:id" element={<PostDetail />} />
-          <Route path="/sales-amount" element={<SalesAmount />} />
+        <Route path="/board/:id" element={<PostDetail />} />
+        <Route path="/:shop/board" element={<Board />} />
+        <Route path="/:shop/board/:id" element={<PostDetail />} />
+        <Route path="/sales-amount" element={<SalesAmount />} />
+        <Route path="/analytics" element={<Analytics />} />
         <Route path="/sales-volume" element={<SalesVolume />} />
         <Route path="/admin/*" element={<AdminRoutes />} />
         <Route path="/stock" element={<Stock />} />

--- a/client/src/components/Header.css
+++ b/client/src/components/Header.css
@@ -1,37 +1,4 @@
-.app-header {
-  background: #fff;
-  padding: 0.5rem 1rem;
-  display: flex;
-  align-items: center;
-  border-bottom: 1px solid #dee2e6;
-  position: fixed;
-  top: 0;
-  left: 0;
-  right: 0;
-  height: 3rem;
-  z-index: 1000;
-}
-.app-header .menu-btn {
-  font-size: 1.25rem;
-  border: none;
-  background: transparent;
-}
-
-.brand-link {
-  text-decoration: none;
-  color: #333;
-}
-
-.user-info {
-  margin-left: auto;
-  display: flex;
-  align-items: center;
-}
-
-.weather-info {
-  margin-left: 1rem;
-  font-size: 0.9rem;
-}
+/* header styles are now provided by Bootstrap */
 
 .weather-select {
   min-width: 5rem;

--- a/client/src/components/Header.js
+++ b/client/src/components/Header.js
@@ -115,73 +115,82 @@ function Header({ onToggleSidebar }) {
   };
 
   return (
-    <header className="app-header shadow-sm">
-      <button type="button" className="btn menu-btn" onClick={onToggleSidebar}>
-        ☰
-      </button>
-      <Link to="/dashboard" className="ms-2 fw-bold brand-link">
-        내의미
-      </Link>
-      {weather && (
-        <div className="weather-info ms-3 d-flex align-items-center gap-2">
-          <span>
-            {weather.temperature ?? "-"}℃ {skyMap[weather.sky] ?? weather.sky ?? "-"}
-          </span>
-          <select
-            className="form-select form-select-sm weather-select"
-            value={location ? location.label : ""}
-            onChange={(e) => {
-              const loc = locations.find((l) => l.label === e.target.value);
-              if (loc) setLocation(loc);
-            }}
-          >
-            {locations.map((l) => (
-              <option key={l.label} value={l.label}>
-                {l.label}
-              </option>
-            ))}
-          </select>
-        </div>
-      )}
-      <div className="user-info ms-auto">
-        <Link to="/weather" className="me-3">
-          날씨
+    <nav className="navbar navbar-expand-lg navbar-light bg-white fixed-top shadow-sm">
+      <div className="container-fluid">
+        <button type="button" className="btn btn-link me-2 text-decoration-none" onClick={onToggleSidebar}>
+          ☰
+        </button>
+        <Link to="/dashboard" className="navbar-brand fw-bold">
+          내의미
         </Link>
-        {user ? (
-          <>
-            <Link to="/profile" className="me-3">
-              {user.name || user.username}
-            </Link>
-            {timeLeft !== null && (
-              <span className="me-3 text-muted">
-                {String(Math.floor(timeLeft / 3600000)).padStart(2, "0")}:
-                {String(Math.floor((timeLeft % 3600000) / 60000)).padStart(2, "0")}:
-                {String(Math.floor((timeLeft % 60000) / 1000)).padStart(2, "0")}
+        <button className="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#topNavbar">
+          <span className="navbar-toggler-icon" />
+        </button>
+        <div className="collapse navbar-collapse" id="topNavbar">
+          {weather && (
+            <div className="d-flex align-items-center ms-3 gap-2">
+              <span>
+                {weather.temperature ?? '-'}℃ {skyMap[weather.sky] ?? weather.sky ?? '-'}
               </span>
+              <select
+                className="form-select form-select-sm weather-select"
+                value={location ? location.label : ''}
+                onChange={(e) => {
+                  const loc = locations.find((l) => l.label === e.target.value);
+                  if (loc) setLocation(loc);
+                }}
+              >
+                {locations.map((l) => (
+                  <option key={l.label} value={l.label}>
+                    {l.label}
+                  </option>
+                ))}
+              </select>
+            </div>
+          )}
+          <ul className="navbar-nav ms-auto align-items-lg-center">
+            <li className="nav-item">
+              <Link to="/weather" className="nav-link">날씨</Link>
+            </li>
+            {user ? (
+              <>
+                <li className="nav-item">
+                  <Link to="/profile" className="nav-link">
+                    {user.name || user.username}
+                  </Link>
+                </li>
+                {timeLeft !== null && (
+                  <li className="nav-item text-muted mx-2">
+                    {String(Math.floor(timeLeft / 3600000)).padStart(2, '0')}:
+                    {String(Math.floor((timeLeft % 3600000) / 60000)).padStart(2, '0')}:
+                    {String(Math.floor((timeLeft % 60000) / 1000)).padStart(2, '0')}
+                  </li>
+                )}
+                <li className="nav-item">
+                  <button type="button" className="btn btn-link nav-link" onClick={handleExtend}>
+                    시간연장
+                  </button>
+                </li>
+                <li className="nav-item">
+                  <button type="button" className="btn btn-link nav-link" onClick={handleLogout}>
+                    로그아웃
+                  </button>
+                </li>
+              </>
+            ) : (
+              <>
+                <li className="nav-item">
+                  <Link to="/login" className="nav-link">로그인</Link>
+                </li>
+                <li className="nav-item">
+                  <Link to="/register" className="nav-link">회원가입</Link>
+                </li>
+              </>
             )}
-            <button
-              type="button"
-              className="btn btn-link me-2"
-              onClick={handleExtend}
-            >
-              시간연장
-            </button>
-            <button type="button" className="btn btn-link" onClick={handleLogout}>
-              로그아웃
-            </button>
-          </>
-        ) : (
-          <>
-            <Link to="/login" className="me-3">
-              로그인
-            </Link>
-            <Link to="/register" className="me-3">
-              회원가입
-            </Link>
-          </>
-        )}
+          </ul>
+        </div>
       </div>
-    </header>
+    </nav>
   );
 }
 

--- a/client/src/components/SalesAdSummaryChart.jsx
+++ b/client/src/components/SalesAdSummaryChart.jsx
@@ -1,0 +1,64 @@
+import React from 'react';
+import { Bar } from 'react-chartjs-2';
+import {
+  Chart as ChartJS,
+  CategoryScale,
+  LinearScale,
+  BarElement,
+  Tooltip,
+  Legend,
+} from 'chart.js';
+import ChartDataLabels from 'chartjs-plugin-datalabels';
+
+ChartJS.register(
+  CategoryScale,
+  LinearScale,
+  BarElement,
+  Tooltip,
+  Legend,
+  ChartDataLabels,
+);
+
+function SalesAdSummaryChart({ data }) {
+  const chartData = {
+    labels: data.map((d) => d.date),
+    datasets: [
+      {
+        label: '매출',
+        data: data.map((d) => d.sales),
+        backgroundColor: 'rgba(153,102,255,0.6)',
+        yAxisID: 'y',
+      },
+      {
+        label: '광고비',
+        data: data.map((d) => d.adCost),
+        backgroundColor: 'rgba(75,192,192,0.6)',
+        yAxisID: 'y1',
+      },
+    ],
+  };
+
+  const options = {
+    responsive: true,
+    maintainAspectRatio: false,
+    scales: {
+      y: { beginAtZero: true },
+      y1: { position: 'right', grid: { drawOnChartArea: false } },
+    },
+    plugins: {
+      datalabels: {
+        anchor: 'end',
+        align: 'end',
+        formatter: (v) => v.toLocaleString(),
+      },
+    },
+  };
+
+  return (
+    <div style={{ height: '300px' }}>
+      <Bar options={options} data={chartData} />
+    </div>
+  );
+}
+
+export default SalesAdSummaryChart;

--- a/client/src/index.js
+++ b/client/src/index.js
@@ -5,6 +5,7 @@ import {
   QueryClientProvider,
 } from './react-query-lite';
 import './index.css';
+import 'bootstrap/dist/css/bootstrap.min.css';
 import App from './App';
 import reportWebVitals from './reportWebVitals';
 

--- a/client/src/pages/Analytics.js
+++ b/client/src/pages/Analytics.js
@@ -1,0 +1,86 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import SalesAdSummaryChart from '../components/SalesAdSummaryChart';
+
+function Analytics() {
+  const [data, setData] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+  const [sortField, setSortField] = useState('date');
+  const [sortDir, setSortDir] = useState('asc');
+
+  useEffect(() => {
+    fetch('/api/dashboard/sales-ad-summary', { credentials: 'include' })
+      .then((res) => (res.ok ? res.json() : Promise.reject()))
+      .then((d) => setData(d))
+      .catch(() => setError('데이터를 불러오지 못했습니다.'))
+      .finally(() => setLoading(false));
+  }, []);
+
+  const changeSort = (field) => {
+    if (sortField === field) {
+      setSortDir((d) => (d === 'asc' ? 'desc' : 'asc'));
+    } else {
+      setSortField(field);
+      setSortDir('asc');
+    }
+  };
+
+  const sorted = useMemo(() => {
+    return [...data].sort((a, b) => {
+      const aVal = a[sortField];
+      const bVal = b[sortField];
+      if (aVal < bVal) return sortDir === 'asc' ? -1 : 1;
+      if (aVal > bVal) return sortDir === 'asc' ? 1 : -1;
+      return 0;
+    });
+  }, [data, sortField, sortDir]);
+
+  return (
+    <div className="container">
+      <h2>매출 및 광고비 요약</h2>
+      <SalesAdSummaryChart data={sorted} />
+      {loading && <p>Loading…</p>}
+      {error && !loading && <p role="alert">{error}</p>}
+      {!loading && !error && (
+        <table className="table table-bordered text-center mt-4">
+          <thead>
+            <tr>
+              <th
+                className="text-nowrap"
+                role="button"
+                onClick={() => changeSort('date')}
+              >
+                날짜 {sortField === 'date' && (sortDir === 'asc' ? '▲' : '▼')}
+              </th>
+              <th
+                className="text-nowrap"
+                role="button"
+                onClick={() => changeSort('sales')}
+              >
+                매출 {sortField === 'sales' && (sortDir === 'asc' ? '▲' : '▼')}
+              </th>
+              <th
+                className="text-nowrap"
+                role="button"
+                onClick={() => changeSort('adCost')}
+              >
+                광고비 {sortField === 'adCost' && (sortDir === 'asc' ? '▲' : '▼')}
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            {sorted.map((row) => (
+              <tr key={row.date}>
+                <td className="text-nowrap">{row.date}</td>
+                <td>{row.sales.toLocaleString()}</td>
+                <td>{row.adCost.toLocaleString()}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+    </div>
+  );
+}
+
+export default Analytics;

--- a/routes/api/dashboard.js
+++ b/routes/api/dashboard.js
@@ -3,6 +3,7 @@ const router = express.Router();
 const ctrl = require('../../controllers/dashboardController');
 
 router.get('/ad-cost-daily', ctrl.getDailyAdCost);
+router.get('/sales-ad-summary', ctrl.getDailySalesAdSummary);
 
 router.get('/city-temp', ctrl.getCityTempHistory);
 router.post('/city-temp', ctrl.saveCityTemp);


### PR DESCRIPTION
## Summary
- add SalesAdSummaryChart component and Analytics page
- make navbar responsive with Bootstrap
- expose `/api/dashboard/sales-ad-summary` for aggregated sales/ads data
- include Bootstrap styles in client

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6868d73b2df48329a555da3c23c787c0