### PR TITLE
Fix unused variable in CoupangStock

### DIFF
--- a/client/src/pages/CoupangStock.js
+++ b/client/src/pages/CoupangStock.js
@@ -221,6 +221,7 @@ function CoupangStock() {
           ))}
         </tbody>
       </table>
+      {isFetching && <div className="text-center py-2">로딩 중...</div>}
       {totalPages > 1 && (
       <nav className="d-flex justify-content-center my-3">
         <ul className="pagination">


### PR DESCRIPTION
## Summary
- show loading text while fetching Coupang stock data

## Testing
- `npm run lint`
- `npm test` *(fails: jest not found)*
- `cd client && npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6868da0745e083298555b9134a3ce2f6