### PR TITLE
Fix ESLint prop-type warnings

### DIFF
--- a/client/src/components/SalesAdSummaryChart.jsx
+++ b/client/src/components/SalesAdSummaryChart.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import { Bar } from 'react-chartjs-2';
 import {
   Chart as ChartJS,
@@ -62,3 +63,13 @@ function SalesAdSummaryChart({ data }) {
 }
 
 export default SalesAdSummaryChart;
+
+SalesAdSummaryChart.propTypes = {
+  data: PropTypes.arrayOf(
+    PropTypes.shape({
+      date: PropTypes.string.isRequired,
+      sales: PropTypes.number.isRequired,
+      adCost: PropTypes.number.isRequired,
+    }),
+  ).isRequired,
+};

--- a/client/src/react-query-lite.js
+++ b/client/src/react-query-lite.js
@@ -1,4 +1,5 @@
 import React, { createContext, useContext, useState, useEffect } from 'react';
+import PropTypes from 'prop-types';
 
 class QueryClient {
   constructor() {
@@ -50,6 +51,11 @@ function QueryClientProvider({ client, children }) {
     <QueryClientContext.Provider value={client}>{children}</QueryClientContext.Provider>
   );
 }
+
+QueryClientProvider.propTypes = {
+  client: PropTypes.instanceOf(QueryClient).isRequired,
+  children: PropTypes.node.isRequired,
+};
 
 function useQueryClient() {
   return useContext(QueryClientContext);


### PR DESCRIPTION
## Summary
- add PropTypes to `SalesAdSummaryChart`
- add PropTypes to `QueryClientProvider`

## Testing
- `npm run lint`
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6869c93e1ab883298f80bc8620b7ea57