### PR TITLE
Adjust default weather fetch time

### DIFF
--- a/controllers/dashboardController.js
+++ b/controllers/dashboardController.js
@@ -3,18 +3,9 @@ const { fetchDaily } = require('./weatherController');
 const cityCoords = require('../data/cityCoords.json');
 
 function getDefaultBaseDateTime() {
-  const now = new Date();
-  let baseDateObj = new Date(now);
-  let hour = now.getHours();
-  if (now.getMinutes() < 40) {
-    hour -= 1;
-    if (hour < 0) {
-      hour = 23;
-      baseDateObj = new Date(now.getTime() - 86400000);
-    }
-  }
-  const baseDate = baseDateObj.toISOString().slice(0, 10).replace(/-/g, '');
-  const baseTime = `${String(hour).padStart(2, '0')}00`;
+  const now = new Date(Date.now() - 60 * 60 * 1000); // 1 hour earlier
+  const baseDate = now.toISOString().slice(0, 10).replace(/-/g, '');
+  const baseTime = `${String(now.getHours()).padStart(2, '0')}00`;
   return { baseDate, baseTime };
 }
 

--- a/controllers/weatherController.js
+++ b/controllers/weatherController.js
@@ -6,18 +6,9 @@ const xlsx = require("xlsx");
 const asyncHandler = require("../middlewares/asyncHandler");
 
 function getDefaultBaseDateTime() {
-  const now = new Date();
-  let baseDateObj = new Date(now);
-  let hour = now.getHours();
-  if (now.getMinutes() < 40) {
-    hour -= 1;
-    if (hour < 0) {
-      hour = 23;
-      baseDateObj = new Date(now.getTime() - 86400000);
-    }
-  }
-  const baseDate = baseDateObj.toISOString().slice(0, 10).replace(/-/g, "");
-  const baseTime = `${String(hour).padStart(2, "0")}00`;
+  const now = new Date(Date.now() - 60 * 60 * 1000); // 1 hour earlier
+  const baseDate = now.toISOString().slice(0, 10).replace(/-/g, "");
+  const baseTime = `${String(now.getHours()).padStart(2, "0")}00`;
   return { baseDate, baseTime };
 }
 

--- a/services/cronJobs.js
+++ b/services/cronJobs.js
@@ -2,18 +2,9 @@ const { coupangRequest } = require('../lib/coupangApiClient');
 const { fetchDaily } = require('../controllers/weatherController');
 
 function getDefaultBaseDateTime() {
-  const now = new Date();
-  let baseDateObj = new Date(now);
-  let hour = now.getHours();
-  if (now.getMinutes() < 40) {
-    hour -= 1;
-    if (hour < 0) {
-      hour = 23;
-      baseDateObj = new Date(now.getTime() - 86400000);
-    }
-  }
-  const baseDate = baseDateObj.toISOString().slice(0, 10).replace(/-/g, '');
-  const baseTime = `${String(hour).padStart(2, '0')}00`;
+  const now = new Date(Date.now() - 60 * 60 * 1000); // 1 hour earlier
+  const baseDate = now.toISOString().slice(0, 10).replace(/-/g, '');
+  const baseTime = `${String(now.getHours()).padStart(2, '0')}00`;
   return { baseDate, baseTime };
 }
 


### PR DESCRIPTION
## Summary
- shift default weather queries to fetch data from one hour earlier

## Testing
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6869cc08b6a48329a135fed0be164b94