### PR TITLE
Add stock data parsing and grouping

### DIFF
--- a/client/src/pages/Stock.css
+++ b/client/src/pages/Stock.css
@@ -48,6 +48,7 @@
 
 .stock-table th {
   background-color: #ffffff;
+  white-space: nowrap;
 }
 
 .stock-table tbody tr {
@@ -60,6 +61,10 @@
 
 .stock-table th[role='button'] {
   cursor: pointer;
+}
+
+.stock-table td:first-child {
+  white-space: nowrap;
 }
 
 

--- a/client/src/pages/Stock.js
+++ b/client/src/pages/Stock.js
@@ -10,10 +10,13 @@ const columns = [
   { key: 'allocation', label: '할당' },
 ];
 
-const columnIndex = columns.reduce((acc, col, idx) => {
-  acc[col.key] = idx + 1;
-  return acc;
-}, {});
+const columnIndex = columns.reduce(
+  (acc, col, idx) => {
+    acc[col.key] = idx + 1;
+    return acc;
+  },
+  { seq: 0 },
+);
 
 function Stock() {
   const [searchItemCode, setSearchItemCode] = useState('');
@@ -198,7 +201,10 @@ function Stock() {
           <table className="table table-bordered shadow-sm rounded bg-white align-middle text-center stock-table">
             <thead className="table-light">
               <tr>
-                <th># 순번</th>
+                <th onClick={() => changeSort('seq')} role="button" className="no-wrap">
+                  # 순번{' '}
+                  {sortCol === 'seq' && (sortDir === 'asc' ? '▲' : '▼')}
+                </th>
                 {columns.map((col) => (
                   <th
                     key={col.key}


### PR DESCRIPTION
## Summary
- map item code/name/color and group matching rows by size and allocation
- return grouped results from stock API
- make index column sortable and keep header text on a single line

## Testing
- `npm run lint`
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6869d11410dc83299c2a36a6dd51bc9d