### PR TITLE
Fix undefined fields in AdHistory

### DIFF
--- a/client/src/pages/AdHistory.js
+++ b/client/src/pages/AdHistory.js
@@ -183,8 +183,8 @@ function AdHistory() {
   const sortedDateSummary = useMemo(() => {
     const arr = [...dateSummary];
     arr.sort((a, b) => {
-      const av = a.날짜;
-      const bv = b.날짜;
+      const av = a.date;
+      const bv = b.date;
       if (av < bv) return dateSortDir === 'asc' ? -1 : 1;
       if (av > bv) return dateSortDir === 'asc' ? 1 : -1;
       return 0;
@@ -355,9 +355,9 @@ function AdHistory() {
             </thead>
             <tbody>
               {sortedDateSummary.map((row) => (
-                <tr key={row.날짜}>
-                  <td>{row.날짜}</td>
-                  <td>{row.광고비.toLocaleString()}</td>
+                <tr key={row.date}>
+                  <td>{row.date}</td>
+                  <td>{Number(row.cost || 0).toLocaleString()}</td>
                 </tr>
               ))}
             </tbody>


### PR DESCRIPTION
## Summary
- handle date summary fields returned by API

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6869d18bd1b48329bc210d0cc8bc9a54