### PR TITLE
Add inbound request list

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -7,6 +7,7 @@ import Stock from './pages/Stock';
 import Coupang from './pages/Coupang';
 import CoupangAdd from './pages/CoupangAdd';
 import CoupangStock from './pages/CoupangStock';
+import CoupangInboundRequest from './pages/CoupangInboundRequest';
 import Login from './pages/Login';
 import Register from './pages/Register';
 import RegisterSuccess from './pages/RegisterSuccess';
@@ -45,10 +46,12 @@ function App() {
         <Route path="/stock" element={<Stock />} />
         <Route path="/coupang" element={<Coupang />} />
         <Route path="/coupang/stock" element={<CoupangStock />} />
+        <Route path="/coupang/inbound-request" element={<CoupangInboundRequest />} />
         <Route path="/coupang-add" element={<CoupangAdd />} />
         <Route path="/ad-history" element={<AdHistory />} />
         <Route path="/:shop/ad-history" element={<AdHistory />} />
         <Route path="/weather" element={<Weather />} />
+        <Route path="/:shop/inbound-request" element={<CoupangInboundRequest />} />
         <Route path="/:shop/:section" element={<Placeholder />} />
         </Route>
       </Routes>

--- a/client/src/hooks/useCoupangStocks.js
+++ b/client/src/hooks/useCoupangStocks.js
@@ -2,7 +2,7 @@ import { useQuery } from '../react-query-lite';
 
 const pageSize = 50;
 
-async function fetchCoupangStocks({ page, keyword, brand, sort, order }) {
+async function fetchCoupangStocks({ page, keyword, brand, sort, order, shortage }) {
   const params = new URLSearchParams({
     page: String(page),
     limit: String(pageSize),
@@ -10,6 +10,7 @@ async function fetchCoupangStocks({ page, keyword, brand, sort, order }) {
     brand,
     sort,
     order,
+    shortage: shortage ? '1' : undefined,
   });
   const res = await fetch(`/api/coupang?${params.toString()}`, {
     credentials: 'include',

--- a/client/src/pages/CoupangInboundRequest.js
+++ b/client/src/pages/CoupangInboundRequest.js
@@ -1,0 +1,128 @@
+import { useState, useEffect } from 'react';
+import useDebounce from '../hooks/useDebounce';
+import useCoupangStocks from '../hooks/useCoupangStocks';
+import './CoupangStock.css';
+
+function CoupangInboundRequest() {
+  const pageSize = 50;
+  const [total, setTotal] = useState(0);
+  const [page, setPage] = useState(1);
+  const [threshold, setThreshold] = useState(0);
+  const [sortCol, setSortCol] = useState('Sales in the last 30 days');
+  const [sortDir, setSortDir] = useState('desc');
+  const debouncedThreshold = useDebounce(threshold, 300);
+
+  const { data, isFetching } = useCoupangStocks({
+    page,
+    sort: sortCol,
+    order: sortDir,
+    shortage: true,
+  });
+
+  useEffect(() => {
+    if (data) setTotal(data.total || 0);
+  }, [data]);
+
+  const totalPages = Math.ceil(total / pageSize) || 1;
+
+  const changeSort = (col) => {
+    if (sortCol === col) {
+      setSortDir((d) => (d === 'asc' ? 'desc' : 'asc'));
+    } else {
+      setSortCol(col);
+      setSortDir('asc');
+    }
+    setPage(1);
+  };
+
+  return (
+    <div className="container">
+      <h2>입고 요청</h2>
+      <div className="d-flex gap-2 align-items-end mb-3">
+        <div>
+          <label htmlFor="threshold" className="form-label mb-0 me-1">
+            재고 임계값
+          </label>
+          <input
+            id="threshold"
+            type="number"
+            className="form-control d-inline-block"
+            style={{ width: '6rem' }}
+            value={threshold}
+            onChange={(e) => setThreshold(e.target.value)}
+          />
+        </div>
+      </div>
+      <table className="table table-bordered text-center auto-width coupang-stock-table">
+        <thead>
+          <tr>
+            <th onClick={() => changeSort('Option ID')} role="button">
+              옵션ID {sortCol === 'Option ID' && (sortDir === 'asc' ? '▲' : '▼')}
+            </th>
+            <th onClick={() => changeSort('Product name')} role="button">
+              상품명 {sortCol === 'Product name' && (sortDir === 'asc' ? '▲' : '▼')}
+            </th>
+            <th onClick={() => changeSort('Option name')} role="button">
+              옵션명 {sortCol === 'Option name' && (sortDir === 'asc' ? '▲' : '▼')}
+            </th>
+            <th onClick={() => changeSort('Offer condition')} role="button">
+              상품상태 {sortCol === 'Offer condition' && (sortDir === 'asc' ? '▲' : '▼')}
+            </th>
+            <th onClick={() => changeSort('Orderable quantity (real-time)')} role="button">
+              재고량 {sortCol === 'Orderable quantity (real-time)' && (sortDir === 'asc' ? '▲' : '▼')}
+            </th>
+            <th onClick={() => changeSort('Shortage quantity')} role="button">
+              부족재고량 {sortCol === 'Shortage quantity' && (sortDir === 'asc' ? '▲' : '▼')}
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          {(data?.data || []).map((row, idx) => {
+            const shortage = Number(row['Shortage quantity'] || 0);
+            return (
+              <tr key={idx} className={shortage > debouncedThreshold ? 'table-danger' : ''}>
+                <td>{row['Option ID']}</td>
+                <td className="text-start">{row['Product name']}</td>
+                <td className="text-start">{row['Option name']}</td>
+                <td>{row['Offer condition']}</td>
+                <td>{Number(row['Orderable quantity (real-time)'] || 0).toLocaleString()}</td>
+                <td>{shortage.toLocaleString()}</td>
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
+      {isFetching && <div className="text-center py-2">로딩 중...</div>}
+      {totalPages > 1 && (
+        <nav className="d-flex justify-content-center my-3">
+          <ul className="pagination">
+            <li className={`page-item ${page === 1 ? 'disabled' : ''}`}>
+              <button className="page-link" type="button" onClick={() => setPage((p) => Math.max(1, p - 1))}>
+                이전
+              </button>
+            </li>
+            {(() => {
+              const groupSize = 10;
+              const start = Math.floor((page - 1) / groupSize) * groupSize + 1;
+              const end = Math.min(start + groupSize - 1, totalPages);
+              return Array.from({ length: end - start + 1 }, (_, i) => start + i).map((p) => (
+                <li key={p} className={`page-item ${p === page ? 'active' : ''}`}>
+                  <button type="button" className="page-link" onClick={() => setPage(p)}>
+                    {p}
+                  </button>
+                </li>
+              ));
+            })()}
+            <li className={`page-item ${page === totalPages ? 'disabled' : ''}`}>
+              <button className="page-link" type="button" onClick={() => setPage((p) => Math.min(totalPages, p + 1))}>
+                다음
+              </button>
+            </li>
+          </ul>
+        </nav>
+      )}
+    </div>
+  );
+}
+
+export default CoupangInboundRequest;

--- a/routes/api/coupangApi.js
+++ b/routes/api/coupangApi.js
@@ -33,6 +33,7 @@ router.get("/", async (req, res) => {
       ? req.query.sort
       : "Product name";
     const sortOrder = req.query.order === "desc" ? -1 : 1;
+    const shortageOnly = req.query.shortage === "1";
 
     const conditions = [];
     if (keyword) {
@@ -50,6 +51,7 @@ router.get("/", async (req, res) => {
     }
 
     const query = conditions.length ? { $and: conditions } : {};
+    if (shortageOnly) query["Shortage quantity"] = { $gt: 0 };
 
     const [rows, total] = await Promise.all([
       db

--- a/routes/web/coupang.js
+++ b/routes/web/coupang.js
@@ -100,6 +100,13 @@ router.get("/sales-amount", (req, res) => {
   res.sendFile(reactIndex);
 });
 
+// React page for /coupang/inbound-request
+router.get("/inbound-request", (req, res) => {
+  const path = require("path");
+  const reactIndex = path.join(__dirname, "..", "..", "client", "public", "index.html");
+  res.sendFile(reactIndex);
+});
+
 // ✅ 엑셀 업로드
 router.post("/upload", upload.single("excelFile"), async (req, res) => {
   const db = req.app.locals.db;


### PR DESCRIPTION
## Summary
- show React client for inbound request
- allow API to filter shortage only
- extend hook to send shortage param
- add inbound request route and React page

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6869d2ad387483298d53235970d30771