### PR TITLE
Add detail modal for Coupang items

### DIFF
--- a/client/src/components/CoupangDetailModal.jsx
+++ b/client/src/components/CoupangDetailModal.jsx
@@ -1,0 +1,53 @@
+import React from 'react';
+
+function CoupangDetailModal({ data, onClose }) {
+  if (!data) return null;
+  const { item, options } = data;
+  return (
+    <>
+      <div className="modal fade show d-block" tabIndex="-1" role="dialog">
+        <div className="modal-dialog modal-lg" role="document">
+          <div className="modal-content">
+            <div className="modal-header">
+              <h5 className="modal-title">{item['Product name']}</h5>
+              <button type="button" className="btn-close" onClick={onClose} />
+            </div>
+            <div className="modal-body">
+              <p>
+                <strong>옵션ID:</strong> {item['Option ID']}
+              </p>
+              <p>
+                <strong>최근 30일 판매금액:</strong>{' '}
+                {item['Sales amount on the last 30 days']}
+              </p>
+              <p>
+                <strong>최근 30일 판매량:</strong>{' '}
+                {item['Sales in the last 30 days']}
+              </p>
+              <h6 className="mt-3">옵션 목록</h6>
+              <ul className="list-group">
+                {options.map((o) => (
+                  <li
+                    key={o['Option ID']}
+                    className="list-group-item d-flex justify-content-between"
+                  >
+                    <span>{o['Option name']}</span>
+                    <span>{o['Orderable quantity (real-time)']}</span>
+                  </li>
+                ))}
+              </ul>
+            </div>
+            <div className="modal-footer">
+              <button type="button" className="btn btn-secondary" onClick={onClose}>
+                닫기
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div className="modal-backdrop fade show" />
+    </>
+  );
+}
+
+export default CoupangDetailModal;

--- a/client/src/pages/CoupangStock.js
+++ b/client/src/pages/CoupangStock.js
@@ -3,6 +3,7 @@ import './CoupangStock.css';
 import { useQueryClient } from '../react-query-lite';
 import useDebounce from '../hooks/useDebounce';
 import useCoupangStocks from '../hooks/useCoupangStocks';
+import CoupangDetailModal from '../components/CoupangDetailModal';
 
 const BRANDS = ['트라이', 'BYC', '제임스딘'];
 
@@ -15,6 +16,7 @@ function CoupangStock() {
   const [sortCol, setSortCol] = useState('Product name');
   const [sortDir, setSortDir] = useState('asc');
   const [uploadProgress, setUploadProgress] = useState(0);
+  const [detailData, setDetailData] = useState(null);
   const fileRef = useRef(null);
   const queryClient = useQueryClient();
   const totalPages = Math.ceil(total / pageSize) || 1;
@@ -93,6 +95,16 @@ function CoupangStock() {
       setSortDir('asc');
     }
     setPage(1);
+  };
+
+  const handleRowClick = async (optionId) => {
+    const res = await fetch(`/api/coupang/detail/${optionId}`, {
+      credentials: 'include',
+    });
+    if (res.ok) {
+      const detail = await res.json();
+      setDetailData(detail);
+    }
   };
 
 
@@ -192,7 +204,7 @@ function CoupangStock() {
         </thead>
         <tbody>
           {(data?.data || []).map((row, idx) => (
-            <tr key={idx}>
+            <tr key={idx} onClick={() => handleRowClick(row['Option ID'])} style={{ cursor: 'pointer' }}>
               <td>{row['Option ID']}</td>
               <td className="text-start">{row['Product name']}</td>
               <td className="text-start">{row['Option name']}</td>
@@ -242,6 +254,7 @@ function CoupangStock() {
         </ul>
       </nav>
       )}
+      <CoupangDetailModal data={detailData} onClose={() => setDetailData(null)} />
     </div>
   );
 }

--- a/routes/api/coupangApi.js
+++ b/routes/api/coupangApi.js
@@ -97,6 +97,35 @@ router.post("/upload", upload.single("excelFile"), async (req, res) => {
   }
 });
 
+// 상세 데이터 조회 API
+router.get("/detail/:optionId", async (req, res) => {
+  const db = req.app.locals.db;
+  const { optionId } = req.params;
+  try {
+    const item = await db
+      .collection("coupang")
+      .findOne({ "Option ID": optionId });
+    if (!item) return res.status(404).json({ message: "Not found" });
+
+    const options = await db
+      .collection("coupang")
+      .find({ "Product name": item["Product name"] })
+      .toArray();
+
+    const sales = await db
+      .collection("coupangSales")
+      .find({ productName: item["Product name"] })
+      .sort({ startDate: -1 })
+      .limit(5)
+      .toArray();
+
+    res.json({ item, options, sales });
+  } catch (err) {
+    console.error("GET /api/coupang/detail 오류:", err);
+    res.status(500).json({ status: "error", message: "조회 실패" });
+  }
+});
+
 router.delete("/", async (req, res) => {
   const db = req.app.locals.db;
   try {

--- a/tests/coupangDetailApi.test.js
+++ b/tests/coupangDetailApi.test.js
@@ -38,14 +38,18 @@ afterAll(async () => {
 
 describe('GET /api/coupang/detail/:id', () => {
   it('returns detail data when item exists', async () => {
+    mockCollection.findOne.mockResolvedValueOnce(null); // logo lookup
     mockCollection.findOne.mockResolvedValueOnce({
       'Option ID': '123',
       'Product name': 'Prod',
     });
-    mockCollection.toArray.mockResolvedValueOnce([
-      { 'Option ID': '123' },
-      { 'Option ID': '456' },
-    ]);
+    mockCollection.toArray
+      .mockResolvedValueOnce([]) // banner lookup
+      .mockResolvedValueOnce([
+        { 'Option ID': '123' },
+        { 'Option ID': '456' },
+      ])
+      .mockResolvedValueOnce([]); // sales lookup
     const res = await request(app).get('/api/coupang/detail/123');
     expect(res.statusCode).toBe(200);
     expect(res.body.item['Option ID']).toBe('123');

--- a/tests/coupangDetailApi.test.js
+++ b/tests/coupangDetailApi.test.js
@@ -1,0 +1,60 @@
+jest.setTimeout(60000);
+
+const mockCollection = {
+  bulkWrite: jest.fn().mockResolvedValue(),
+  deleteMany: jest.fn().mockResolvedValue(),
+  find: jest.fn().mockReturnThis(),
+  sort: jest.fn().mockReturnThis(),
+  limit: jest.fn().mockReturnThis(),
+  toArray: jest.fn().mockResolvedValue([]),
+  findOne: jest.fn().mockResolvedValue(null),
+};
+
+jest.mock('../config/db', () => {
+  const mockDb = { collection: jest.fn(() => mockCollection) };
+  const mockConnect = jest.fn().mockResolvedValue(mockDb);
+  mockConnect.then = (fn) => fn(mockDb);
+  return { connectDB: mockConnect, closeDB: jest.fn().mockResolvedValue() };
+});
+
+const request = require('supertest');
+const { initApp } = require('../server');
+const { closeDB } = require('../config/db');
+
+let app;
+
+beforeAll(async () => {
+  process.env.NODE_ENV = 'test';
+  process.env.MONGO_URI = 'mongodb://127.0.0.1:27017/testdb';
+  process.env.DB_NAME = 'testdb';
+  process.env.SESSION_SECRET = 'testsecret';
+
+  app = await initApp();
+});
+
+afterAll(async () => {
+  await closeDB();
+});
+
+describe('GET /api/coupang/detail/:id', () => {
+  it('returns detail data when item exists', async () => {
+    mockCollection.findOne.mockResolvedValueOnce({
+      'Option ID': '123',
+      'Product name': 'Prod',
+    });
+    mockCollection.toArray.mockResolvedValueOnce([
+      { 'Option ID': '123' },
+      { 'Option ID': '456' },
+    ]);
+    const res = await request(app).get('/api/coupang/detail/123');
+    expect(res.statusCode).toBe(200);
+    expect(res.body.item['Option ID']).toBe('123');
+    expect(Array.isArray(res.body.options)).toBe(true);
+  });
+
+  it('returns 404 when item not found', async () => {
+    mockCollection.findOne.mockResolvedValueOnce(null);
+    const res = await request(app).get('/api/coupang/detail/999');
+    expect(res.statusCode).toBe(404);
+  });
+});


### PR DESCRIPTION
## Summary
- add API endpoint to fetch detailed Coupang item info
- create `CoupangDetailModal` React component
- show modal in Coupang stock page on row click
- add Jest test for new API

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6869d3e14708832996ef9db231aa09af