### PR TITLE
Implement stock table Excel export

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -11,7 +11,9 @@
     "web-vitals": "^2.1.4",
     "chart.js": "^4.4.1",
     "react-chartjs-2": "^5.2.0",
-    "chartjs-plugin-datalabels": "^2.2.0"
+    "chartjs-plugin-datalabels": "^2.2.0",
+    "xlsx": "^0.18.5",
+    "file-saver": "^2.0.5"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/client/src/pages/Stock.js
+++ b/client/src/pages/Stock.js
@@ -1,5 +1,58 @@
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useEffect, useRef, useState, useMemo } from 'react';
+import { utils, write, book_new, book_append_sheet } from 'xlsx';
+import { saveAs } from 'file-saver';
 import './Stock.css';
+
+const transformData = (rows) => {
+  const itemCodeMapper = { TMDROM6: 'TMDROMA', TMDROM7: 'TMDROMB' };
+  const itemNameMapper = {
+    'OM)TRY즈로즈#06': 'OM)TRY즈로즈#0A',
+    'OM)TRY즈로즈#07': 'OM)TRY즈로즈#0B',
+  };
+  const colorMapper = { GA: '회색', UD: '네이비', BK: '검정', AD: '진회색' };
+
+  const groupedData = {};
+  rows.forEach((row) => {
+    const 품번 = itemCodeMapper[row.item_code] || row.item_code;
+    const 품명 = itemNameMapper[row.item_name] || row.item_name;
+    const 색상 = colorMapper[row.color?.substring(0, 2)] || row.color;
+    const key = `${품번}-${품명}-${색상}-${row.size}-${row.allocation}`;
+    if (groupedData[key]) {
+      groupedData[key].수량 += Number(row.qty);
+    } else {
+      groupedData[key] = {
+        순번: Object.keys(groupedData).length + 1,
+        품번,
+        품명,
+        색상,
+        사이즈: row.size,
+        수량: Number(row.qty),
+        할당: row.allocation,
+      };
+    }
+  });
+  return Object.values(groupedData);
+};
+
+const exportToExcel = (data) => {
+  const wsData = [
+    ['순번', '품번', '품명', '색상', '사이즈', '수량', '할당'],
+    ...data.map((d) => [d.순번, d.품번, d.품명, d.색상, d.사이즈, d.수량, d.할당]),
+  ];
+  const ws = utils.aoa_to_sheet(wsData);
+  const colWidths = wsData[0].map((_, idx) =>
+    Math.max(...wsData.map((row) => String(row[idx]).length)) + 2,
+  );
+  ws['!cols'] = colWidths.map((w) => ({ wch: w }));
+  wsData[0].forEach((_, i) => {
+    const cell = utils.encode_cell({ r: 0, c: i });
+    if (ws[cell]) ws[cell].s = { font: { bold: true } };
+  });
+  const wb = utils.book_new();
+  utils.book_append_sheet(wb, ws, 'Sheet1');
+  const wbout = write(wb, { bookType: 'xlsx', type: 'array' });
+  saveAs(new Blob([wbout], { type: 'application/octet-stream' }), 'inventory.xlsx');
+};
 
 const columns = [
   { key: 'item_code', label: '품번' },
@@ -21,7 +74,6 @@ const columnIndex = columns.reduce(
 function Stock() {
   const [searchItemCode, setSearchItemCode] = useState('');
   const [searchItemName, setSearchItemName] = useState('');
-  const [searchFullName, setSearchFullName] = useState('');
   const [searchColor, setSearchColor] = useState('');
   const [searchSize, setSearchSize] = useState('');
   const excelFormRef = useRef(null);
@@ -34,6 +86,8 @@ function Stock() {
   const [loading, setLoading] = useState(false);
   const [message, setMessage] = useState(null);
   const [messageType, setMessageType] = useState('');
+
+  const transformedRows = useMemo(() => transformData(rows), [rows]);
 
   const fetchData = async () => {
     setLoading(true);
@@ -75,7 +129,6 @@ function Stock() {
   const handleRefresh = () => {
     setSearchItemCode('');
     setSearchItemName('');
-    setSearchFullName('');
     setSearchColor('');
     setSearchSize('');
     setPage(0);
@@ -102,17 +155,6 @@ function Stock() {
 
   const totalPages = Math.ceil(total / pageSize);
 
-  const parseProductName = (name) => {
-    const parts = name.trim().split(/\s+/);
-    if (parts.length >= 3) {
-      return {
-        code: parts[0],
-        color: parts[parts.length - 1],
-        item: parts.slice(1, -1).join(' '),
-      };
-    }
-    return { code: '', item: '', color: '' };
-  };
 
   const changeSort = (col) => {
     if (sortCol === col) {
@@ -149,6 +191,13 @@ function Stock() {
           <button type="submit" className="btn btn-success btn-upload">업로드</button>
         </form>
         <button onClick={handleRefresh} className="btn btn-danger btn-reset">초기화</button>
+        <button
+          type="button"
+          className="btn btn-outline-success"
+          onClick={() => exportToExcel(transformedRows)}
+        >
+          엑셀 다운로드
+        </button>
       </div>
 
 
@@ -171,28 +220,17 @@ function Stock() {
         </div>
         <div className="col-md-3">
           <label htmlFor="itemName" className="form-label">상품명</label>
-          <div className="input-group">
-            <input
-              type="text"
-              id="itemName"
-              className="form-control"
-              placeholder="전체 상품명 입력"
-              value={searchFullName}
-              onChange={(e) => setSearchFullName(e.target.value)}
-            />
-            <button
-              type="button"
-              className="btn btn-outline-secondary"
-              onClick={() => {
-                const { code, item, color } = parseProductName(searchFullName);
-                setSearchItemCode(code);
-                setSearchItemName(item);
-                setSearchColor(color);
-              }}
-            >
-              파싱
-            </button>
-          </div>
+          <input
+            type="text"
+            id="itemName"
+            className="form-control"
+            placeholder="상품명 입력"
+            value={searchItemName}
+            onChange={(e) => {
+              setSearchItemName(e.target.value);
+              setPage(0);
+            }}
+          />
         </div>
         <div className="col-md-3">
           <label htmlFor="color" className="form-label">
@@ -260,12 +298,15 @@ function Stock() {
               </tr>
             </thead>
             <tbody>
-              {rows.map((r, idx) => (
-                <tr key={r._id}>
-                  <td>{page * pageSize + idx + 1}</td>
-                  {columns.map((col) => (
-                    <td key={col.key}>{r[col.key]}</td>
-                  ))}
+              {transformedRows.map((r, idx) => (
+                <tr key={idx}>
+                  <td>{r.순번}</td>
+                  <td>{r.품번}</td>
+                  <td>{r.품명}</td>
+                  <td>{r.색상}</td>
+                  <td>{r.사이즈}</td>
+                  <td>{r.수량}</td>
+                  <td>{r.할당}</td>
                 </tr>
               ))}
             </tbody>


### PR DESCRIPTION
## Summary
- add client-side data transform logic
- support Excel export for stock data
- remove parsing search and keep one-line search form
- include `xlsx` and `file-saver` dependencies

## Testing
- `npm test` *(fails: jest not found)*
- `npm install` in client *(fails: 403 Forbidden due to network)*

------
https://chatgpt.com/codex/tasks/task_e_6869d9cd2d5c83299046c555ba8a7e99